### PR TITLE
Make gitlab CI aware of nuget cache folder

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,7 @@ Build-x86:
   image: mcr.microsoft.com/dotnet/framework/sdk:4.7.2
   tags: [ docker, windows ]
   variables:
-      NUGET_PACKAGES: $CI_PROJECT_DIR/.nuget
+      NUGET_PACKAGES: "%CI_PROJECT_DIR%/.nuget"
   cache:
     paths:
       - .nuget
@@ -116,7 +116,7 @@ Build-x64:
   image: mcr.microsoft.com/dotnet/framework/sdk:4.7.2
   tags: [ docker, windows ]
   variables:
-      NUGET_PACKAGES: $CI_PROJECT_DIR/.nuget
+      NUGET_PACKAGES: "%CI_PROJECT_DIR%/.nuget"
   cache:
     paths:
       - .nuget
@@ -136,7 +136,7 @@ WarningTest:
   image: mcr.microsoft.com/dotnet/framework/sdk:4.7.2
   tags: [ docker, windows ]
   variables:
-      NUGET_PACKAGES: $CI_PROJECT_DIR/.nuget
+      NUGET_PACKAGES: "%CI_PROJECT_DIR%/.nuget"
   cache:
     paths:
       - .nuget


### PR DESCRIPTION
Originally filed October 15 2020 by Asger Iversen on [GitLab](https://gitlab.com/OpenTAP/opentap/-/merge_requests/643)

