### PR TITLE
actually run install action during build

### DIFF
--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -55,18 +55,22 @@
     <Delete Files="@(PackagePayloadFilesToClean)" />
   </Target>
 
+  <PropertyGroup>
+    <PackageName>$(ProjectName).TapPackage</PackageName>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(CreateOpenTapPackage)' != 'false' And
+                        '$(OutDir)' != '' And Exists('$(OutDir)') And
+                        '$(OpenTapPackageDefinitionPath)' != '' And
+                        Exists('$(OpenTapPackageDefinitionPath)')">    
+    <CreateCommands Include=".\tap package create &quot;$(ProjectDir)\$(OpenTapPackageDefinitionPath)&quot; -o $(PackageName)"/>
+    <CreateCommands Include=".\tap package install $(PackageName)" Condition="'$(InstallCreatedOpenTapPackage)' == 'true'"/>
+  </ItemGroup>
+
   <Target Name="CreateOpenTapPackage"
-          Condition="'$(CreateOpenTapPackage)' != 'false' And
-                     '$(OutDir)' != '' And
-                     Exists('$(OutDir)') And
-                     '$(OpenTapPackageDefinitionPath)' != '' And
-                     Exists('$(OpenTapPackageDefinitionPath)')"
+          Condition="'@(CreateCommands)' != ''"
           AfterTargets="Build">
-    <Exec Command=".\tap package create &quot;$(ProjectDir)\$(OpenTapPackageDefinitionPath)&quot;"
-          Condition="'$(InstallCreatedOpenTapPackage)' != 'true'"
-          WorkingDirectory="$(OutDir)" LogStandardErrorAsError="$(IsWindows)" />
-    <Exec Command=".\tap package create &quot;$(ProjectDir)\$(OpenTapPackageDefinitionPath)&quot; --install"
-          Condition="'$(InstallCreatedOpenTapPackage)' == 'true'"
+    <Exec Command="%(CreateCommands.Identity)"
           WorkingDirectory="$(OutDir)" LogStandardErrorAsError="$(IsWindows)" />
   </Target>
 


### PR DESCRIPTION
Originally filed June 09 2021 by Alexander Nørskov Larsen on [GitLab](https://gitlab.com/OpenTAP/opentap/-/merge_requests/905)

Run ./tap package install during msbuild instead of using the fake install from csproj

You can test this by downloading the NuGet package from this pipeline and building the project linked in the issue with that OpenTAP nuget package. Verify that it works by running "tap package verify ClassLibrary1" from the output folder

Closes #72