### PR TITLE
TapPackage Serializer Bug Fix

### DIFF
--- a/Package/PackageSource/IPackageSource.cs
+++ b/Package/PackageSource/IPackageSource.cs
@@ -27,6 +27,8 @@ namespace OpenTap.Package
         /// The file path of the .TapPackage the package definition is loaded from.
         /// </summary>
         public string PackageFilePath { get; set; }
+
+        public override string ToString() => PackageFilePath;
     }
 
     /// <summary>
@@ -38,6 +40,7 @@ namespace OpenTap.Package
         /// The repository the package is sourced.
         /// </summary>
         string RepositoryUrl { get; set; }
+        
     }
 
     /// <summary>
@@ -53,6 +56,9 @@ namespace OpenTap.Package
         /// The repository the package is sourced.
         /// </summary>
         public string RepositoryUrl { get; set; }
+        
+        
+        public override string ToString() => RepositoryUrl;
     }
 
     /// <summary>

--- a/Package/TestPlanPackageDependency.cs
+++ b/Package/TestPlanPackageDependency.cs
@@ -96,7 +96,7 @@ namespace OpenTap.Package
             {
                 if (package.Name == null)
                 {
-                    Log.Error("Package name is null. {0}", package.Location);
+                    Log.Error("Package name is null. {0}", package.PackageSource);
                     continue;
                 }
 


### PR DESCRIPTION
Originally filed September 17 2021 by Rolf Madsen on [GitLab](https://gitlab.com/OpenTAP/opentap/-/merge_requests/976)

- Tried to fix a possible issue, but was not able to reproduce the problem.. Something related to PackageDef.Name == null.