### PR TITLE
178 Repeat Until Pass (v2): Fix

### DIFF
--- a/BasicSteps/RepeatStep.cs
+++ b/BasicSteps/RepeatStep.cs
@@ -40,6 +40,10 @@ namespace OpenTap.Plugins.BasicSteps
         
         [Display("Retry", Order:3, Description: "Clear the verdict and try again if break conditions were reached for child steps.")]
         public bool Retry { get; set; }
+        
+        [EnabledIf("Action", RepeatStepAction.While, RepeatStepAction.Until, HideIfDisabled = true)]
+        [Display("Clear Verdict", Order:3, Description: "Clear the verdict before each loop iteration. This can be useful for 'repeat until pass' scenarios.")]
+        public bool ClearVerdict { get; set; }
 
         public Enabled<uint> maxCount = new Enabled<uint> { Value = 3, IsEnabled = false };
 
@@ -86,6 +90,8 @@ namespace OpenTap.Plugins.BasicSteps
         Verdict iterate()
         {
             TapThread.Current.AbortToken.ThrowIfCancellationRequested();
+            if (ClearVerdict)
+                Verdict = Verdict.NotSet;
             if (Retry && Verdict == Verdict.Error) // previous break conditions were reached
                 Verdict = Verdict.NotSet; 
             this.iteration += 1;

--- a/Engine.UnitTests/BasicStepsTest.cs
+++ b/Engine.UnitTests/BasicStepsTest.cs
@@ -80,6 +80,28 @@ namespace OpenTap.UnitTests
             }
         }
         
+        [Test]
+        public void RepeatUntilPass2()
+        {
+            var step = new PassThirdTime();
+            var rpt = new RepeatStep
+            {
+                Action =  RepeatStep.RepeatStepAction.Until,
+                TargetStep = step,
+                TargetVerdict = Verdict.Pass,
+                ClearVerdict = true,
+                MaxCount = new Enabled<uint>{IsEnabled = true, Value = 5}
+            };
+            rpt.ChildTestSteps.Add(step);
+            var plan = new TestPlan();
+            plan.ChildTestSteps.Add(rpt);
+            
+            var run = plan.Execute();
+
+            Assert.AreEqual(Verdict.Pass, run.Verdict);
+            Assert.AreEqual(3, step.Iterations);
+        }
+        
         
         // These two cases are technically equivalent.
         [Test]

--- a/Engine.UnitTests/TestTestSteps/RunTimeStep.cs
+++ b/Engine.UnitTests/TestTestSteps/RunTimeStep.cs
@@ -1,10 +1,23 @@
+using System;
+
 namespace OpenTap.Engine.UnitTests.TestTestSteps
 {
     [Display("Run Times Count", "A test step that counts how many time it has been run during a single test plan run.", "Tests")]
     public class RunTimeStep : TestStep
     {
         [Output] public int RunCount { get; set; }
-        public override void PrePlanRun() => RunCount = 0;
-        public override void Run() => RunCount += 1;
+        public ITestStep RestartMarker { get; set; }
+
+        Guid lastRestartMarker;
+        public override void Run()
+        {
+            var nowMarker = RestartMarker.StepRun?.Id ?? RestartMarker?.Id ?? Guid.Empty;
+            if (nowMarker != lastRestartMarker)
+            {
+                RunCount = 0;
+                lastRestartMarker = nowMarker;
+            }
+            RunCount += 1;
+        }
     }
 }

--- a/tests/RepeatOutputCompare.TapPlan
+++ b/tests/RepeatOutputCompare.TapPlan
@@ -16,11 +16,11 @@
       <ChildTestSteps>
         <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.RunTimeStep" Version="0.0.0" Id="b01de716-29f4-4f89-9bce-2696e5664075">
           <RunCount Parameter="Parameters \ RunCount" Scope="44ed0f8d-d06f-4f21-886c-58bfb0f87e2b">3</RunCount>
+          <RestartMarker>44ed0f8d-d06f-4f21-886c-58bfb0f87e2b</RestartMarker>
           <Enabled>true</Enabled>
           <Name>RunTimeStep</Name>
           <ChildTestSteps />
           <BreakConditions>Inherit</BreakConditions>
-          <OpenTap.Description />
         </TestStep>
       </ChildTestSteps>
       <BreakConditions>Inherit</BreakConditions>
@@ -33,13 +33,12 @@
       <Name>CompareIntStep</Name>
       <ChildTestSteps />
       <BreakConditions>Inherit</BreakConditions>
-      <OpenTap.Description />
       <TestStep.Inputs>
         <InputOutputMember id="44ed0f8d-d06f-4f21-886c-58bfb0f87e2b" member="Parameters \ RunCount" target-member="InputValue"></InputOutputMember>
       </TestStep.Inputs>
     </TestStep>
   </Steps>
   <BreakConditions>Inherit</BreakConditions>
-  <OpenTap.Description> Verifies that the input/output system works as well as parameterizations and repeat loop. </OpenTap.Description>
+  <OpenTap.Description>Verifies that the input/output system works as well as parameterizations and repeat loop.</OpenTap.Description>
   <Parameters_x0020__x005C__x0020_ExpectedValue>3</Parameters_x0020__x005C__x0020_ExpectedValue>
 </TestPlan>

--- a/tests/regression.TapPlan
+++ b/tests/regression.TapPlan
@@ -1,105 +1,119 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TestPlan type="OpenTap.TestPlan" Locked="false">
   <Steps>
-    <TestStep type="OpenTap.Plugins.BasicSteps.ParallelStep" Version="9.4.0-Development" Id="d032668a-7a5e-4300-b927-a8ff0b6f91fd">
+    <TestStep type="OpenTap.Plugins.BasicSteps.RepeatStep" Version="9.4.0-Development" Id="3e122a5a-3943-4147-ab3f-5379b9ba64f7">
+      <Action>Until</Action>
+      <TargetStep>3e122a5a-3943-4147-ab3f-5379b9ba64f7</TargetStep>
+      <TargetVerdict>Pass</TargetVerdict>
+      <Count>3</Count>
+      <Retry>false</Retry>
+      <ClearVerdict>true</ClearVerdict>
+      <MaxCount>
+        <Value>3</Value>
+        <IsEnabled>true</IsEnabled>
+      </MaxCount>
       <Enabled>true</Enabled>
-      <Name>Parallel</Name>
+      <Name>Repeat</Name>
       <ChildTestSteps>
-        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="1e18241d-7317-4cf0-9d1e-e6b920256386">
-          <Filepath>../../tests/show-tags.TapPlan</Filepath>
-          <StepMapping />
+        <TestStep type="OpenTap.Plugins.BasicSteps.SequenceStep" Version="9.4.0-Development" Id="d032668a-7a5e-4300-b927-a8ff0b6f91fd">
           <Enabled>true</Enabled>
-          <Name>Test Plan: {Referenced Plan}</Name>
-          <BreakConditions>Inherit</BreakConditions>
-        </TestStep>
-        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="f05ae695-da0b-47c1-9562-32a89c3c424c">
-          <Filepath>../../tests/package-create-error.TapPlan</Filepath>
-          <StepMapping />
-          <Enabled>true</Enabled>
-          <Name>Test Plan: {Referenced Plan}</Name>
-          <BreakConditions>Inherit</BreakConditions>
-        </TestStep>
-        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="321543e3-31fc-4923-ae06-674cc13bc232">
-          <Filepath>../../tests/ILGitVersionBug.TapPlan</Filepath>
-          <StepMapping>
-            <GuidMapping>
-              <Guid1>3a8e33d7-d7f9-4d58-868b-c38acbf0c15e</Guid1>
-              <Guid2>e8c42535-b680-4922-9251-a0b3805d2e76</Guid2>
-            </GuidMapping>
-            <GuidMapping>
-              <Guid1>45f82fc0-8acf-41b2-8472-2c1b9db25f32</Guid1>
-              <Guid2>32ccc3e7-e8aa-4e34-93ff-3244e0ae6f8d</Guid2>
-            </GuidMapping>
-            <GuidMapping>
-              <Guid1>fc4259db-b8d5-4790-a940-5de27bfb515d</Guid1>
-              <Guid2>c39f9346-77e0-474c-9cbc-1663c5f586cf</Guid2>
-            </GuidMapping>
-            <GuidMapping>
-              <Guid1>87ef4ac9-541e-4add-8c40-7303cdccda87</Guid1>
-              <Guid2>95b1b48f-2bef-4320-bb05-1237cb9f5738</Guid2>
-            </GuidMapping>
-            <GuidMapping>
-              <Guid1>03572f31-123d-40de-b737-74c714b8cd31</Guid1>
-              <Guid2>6541135f-3800-4c45-b85f-0adfc457f075</Guid2>
-            </GuidMapping>
-            <GuidMapping>
-              <Guid1>ef81482d-125b-4f3f-a1d5-eaf212d302fe</Guid1>
-              <Guid2>c6ea9599-17d0-4574-9252-88f08c755664</Guid2>
-            </GuidMapping>
-          </StepMapping>
-          <Enabled>true</Enabled>
-          <Name>Test Plan: {Referenced Plan}</Name>
-          <BreakConditions>Inherit</BreakConditions>
-        </TestStep>
-        <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.RunOnOs" Version="0.0.0" Id="a1a83800-0036-49ad-a461-d2aa1daac281">
-          <OperatingSystem>Windows</OperatingSystem>
-          <Enabled>true</Enabled>
-          <Name>Run On {OperatingSystem}</Name>
+          <Name>Sequence</Name>
           <ChildTestSteps>
-            <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="e46b3aba-9711-4dc2-afcc-376f25461664">
-              <Filepath>../../tests/NoAssemblyInfo.TapPlan</Filepath>
+            <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="1e18241d-7317-4cf0-9d1e-e6b920256386">
+              <Filepath>../../tests/show-tags.TapPlan</Filepath>
+              <StepMapping />
+              <Enabled>true</Enabled>
+              <Name>Test Plan: {Referenced Plan}</Name>
+              <BreakConditions>Inherit</BreakConditions>
+            </TestStep>
+            <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="f05ae695-da0b-47c1-9562-32a89c3c424c">
+              <Filepath>../../tests/package-create-error.TapPlan</Filepath>
+              <StepMapping />
+              <Enabled>true</Enabled>
+              <Name>Test Plan: {Referenced Plan}</Name>
+              <BreakConditions>Inherit</BreakConditions>
+            </TestStep>
+            <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="321543e3-31fc-4923-ae06-674cc13bc232">
+              <Filepath>../../tests/ILGitVersionBug.TapPlan</Filepath>
               <StepMapping>
                 <GuidMapping>
                   <Guid1>3a8e33d7-d7f9-4d58-868b-c38acbf0c15e</Guid1>
-                  <Guid2>8c6d4846-30d9-4322-b152-34264b3110f9</Guid2>
+                  <Guid2>e8c42535-b680-4922-9251-a0b3805d2e76</Guid2>
                 </GuidMapping>
                 <GuidMapping>
                   <Guid1>45f82fc0-8acf-41b2-8472-2c1b9db25f32</Guid1>
-                  <Guid2>80d5b604-84dc-4f91-91bf-1298b51559fe</Guid2>
+                  <Guid2>32ccc3e7-e8aa-4e34-93ff-3244e0ae6f8d</Guid2>
+                </GuidMapping>
+                <GuidMapping>
+                  <Guid1>fc4259db-b8d5-4790-a940-5de27bfb515d</Guid1>
+                  <Guid2>c39f9346-77e0-474c-9cbc-1663c5f586cf</Guid2>
                 </GuidMapping>
                 <GuidMapping>
                   <Guid1>87ef4ac9-541e-4add-8c40-7303cdccda87</Guid1>
-                  <Guid2>f5e3089c-fb08-450d-adaa-c473a5cc4e26</Guid2>
+                  <Guid2>95b1b48f-2bef-4320-bb05-1237cb9f5738</Guid2>
                 </GuidMapping>
                 <GuidMapping>
                   <Guid1>03572f31-123d-40de-b737-74c714b8cd31</Guid1>
-                  <Guid2>5c5a4931-8882-4008-9988-8e58d8ad6fbe</Guid2>
+                  <Guid2>6541135f-3800-4c45-b85f-0adfc457f075</Guid2>
                 </GuidMapping>
                 <GuidMapping>
                   <Guid1>ef81482d-125b-4f3f-a1d5-eaf212d302fe</Guid1>
-                  <Guid2>8682b331-57c9-4ded-a59a-a644f1debc32</Guid2>
+                  <Guid2>c6ea9599-17d0-4574-9252-88f08c755664</Guid2>
                 </GuidMapping>
               </StepMapping>
               <Enabled>true</Enabled>
-              <Name>Test Plan: {Referenced Plan} (1)</Name>
+              <Name>Test Plan: {Referenced Plan}</Name>
               <BreakConditions>Inherit</BreakConditions>
             </TestStep>
-          </ChildTestSteps>
-          <BreakConditions>Inherit</BreakConditions>
-        </TestStep>
-        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="e7497477-b937-460b-9d8a-fdcc8c1a8d0a">
-          <Filepath>../../tests/package-create-out-of-installation.TapPlan</Filepath>
-          <StepMapping />
-          <Enabled>true</Enabled>
-          <Name>Test Plan: {Referenced Plan}</Name>
-          <BreakConditions>Inherit</BreakConditions>
-        </TestStep>
-        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="28f79a0f-fa70-4dc8-9b31-322828869f8c">
-          <Parameters_x0020__x005C__x0020_ExpectedValue>3</Parameters_x0020__x005C__x0020_ExpectedValue>
-          <Filepath>../../tests/RepeatOutputCompare.TapPlan</Filepath>
-          <StepMapping />
-          <Enabled>true</Enabled>
-          <Name>Test Plan: {Referenced Plan}</Name>
+            <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.RunOnOs" Version="0.0.0" Id="a1a83800-0036-49ad-a461-d2aa1daac281">
+              <OperatingSystem>Windows</OperatingSystem>
+              <Enabled>true</Enabled>
+              <Name>Run On {OperatingSystem}</Name>
+              <ChildTestSteps>
+                <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="e46b3aba-9711-4dc2-afcc-376f25461664">
+                  <Filepath>../../tests/NoAssemblyInfo.TapPlan</Filepath>
+                  <StepMapping>
+                    <GuidMapping>
+                      <Guid1>3a8e33d7-d7f9-4d58-868b-c38acbf0c15e</Guid1>
+                      <Guid2>8c6d4846-30d9-4322-b152-34264b3110f9</Guid2>
+                    </GuidMapping>
+                    <GuidMapping>
+                      <Guid1>45f82fc0-8acf-41b2-8472-2c1b9db25f32</Guid1>
+                      <Guid2>80d5b604-84dc-4f91-91bf-1298b51559fe</Guid2>
+                    </GuidMapping>
+                    <GuidMapping>
+                      <Guid1>87ef4ac9-541e-4add-8c40-7303cdccda87</Guid1>
+                      <Guid2>f5e3089c-fb08-450d-adaa-c473a5cc4e26</Guid2>
+                    </GuidMapping>
+                    <GuidMapping>
+                      <Guid1>03572f31-123d-40de-b737-74c714b8cd31</Guid1>
+                      <Guid2>5c5a4931-8882-4008-9988-8e58d8ad6fbe</Guid2>
+                    </GuidMapping>
+                    <GuidMapping>
+                      <Guid1>ef81482d-125b-4f3f-a1d5-eaf212d302fe</Guid1>
+                      <Guid2>8682b331-57c9-4ded-a59a-a644f1debc32</Guid2>
+                    </GuidMapping>
+                  </StepMapping>
+                  <Enabled>true</Enabled>
+                  <Name>Test Plan: {Referenced Plan} (1)</Name>
+                  <BreakConditions>Inherit</BreakConditions>
+                </TestStep>
+              </ChildTestSteps>
+              <BreakConditions>Inherit</BreakConditions>
+            </TestStep>
+            <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="e7497477-b937-460b-9d8a-fdcc8c1a8d0a">
+              <Filepath>../../tests/package-create-out-of-installation.TapPlan</Filepath>
+              <StepMapping />
+              <Enabled>true</Enabled>
+              <Name>Test Plan: {Referenced Plan}</Name>
+              <BreakConditions>Inherit</BreakConditions>
+            </TestStep>
+            <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="28f79a0f-fa70-4dc8-9b31-322828869f8c">
+              <Parameters_x0020__x005C__x0020_ExpectedValue>3</Parameters_x0020__x005C__x0020_ExpectedValue>
+              <Filepath>../../tests/RepeatOutputCompare.TapPlan</Filepath>
+              <StepMapping />
+              <Enabled>true</Enabled>
+              <Name>Test Plan: {Referenced Plan}</Name>
           <BreakConditions>Inherit</BreakConditions>
         </TestStep>
         <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="13d39559-0c3b-407c-8ac0-7e998324567d">
@@ -107,6 +121,9 @@
           <StepMapping />
           <Enabled>true</Enabled>
           <Name>Test Plan {Referenced Plan}</Name>
+              <BreakConditions>Inherit</BreakConditions>
+            </TestStep>
+          </ChildTestSteps>
           <BreakConditions>Inherit</BreakConditions>
         </TestStep>
       </ChildTestSteps>


### PR DESCRIPTION
- Added ClearVerdict on RepeatStep. This enables clearing the verdict in each iteration.
- Added unit test to verify the behavior.

Closes #178 