### PR TITLE
Add runtimeconfig to windows payloads in nuget package

### DIFF
--- a/nuget/NugetPackager.ps1
+++ b/nuget/NugetPackager.ps1
@@ -45,6 +45,7 @@ CopyPreserveRelativePath $packageXml $runtimeDir
 
 CopyPreserveRelativePath ./tap.exe  $runtimeDir
 CopyPreserveRelativePath ./tap.dll $runtimeDir
+CopyPreserveRelativePath ./tap.runtimeconfig.json $runtimeDir
 
 $git2dll = Get-ChildItem -File -Recurse *git2-*.dll | Resolve-Path -Relative | Select-Object -First 1
 CopyPreserveRelativePath $git2dll $runtimeDir
@@ -59,6 +60,7 @@ CopyPreserveRelativePath $packageXml $runtimeDir
 
 CopyPreserveRelativePath ./tap.exe  $runtimeDir
 CopyPreserveRelativePath ./tap.dll $runtimeDir
+CopyPreserveRelativePath ./tap.runtimeconfig.json $runtimeDir
 
 $git2dll = Get-ChildItem -File -Recurse *git2-*.dll | Resolve-Path -Relative | Select-Object -First 1
 CopyPreserveRelativePath $git2dll $runtimeDir


### PR DESCRIPTION
This fixes an issue preventing tap.exe from running on windows when using the nuget package.