### PR TITLE
Fix: Newtonsoft dll not shipped on Linux

### DIFF
--- a/opentap_linux64.package.xml
+++ b/opentap_linux64.package.xml
@@ -50,6 +50,7 @@
     <File Path="Dependencies/System.Linq.4.1.2.0/LICENSE.txt"                       SourcePath="dotnet_library_license.txt"/>
     <File Path="Dependencies/DotNet.Glob.3.0.1.0/LICENSE.txt"                       SourcePath="Dotnet.Glob.License.txt"  />
     <File Path="Dependencies/Newtonsoft.Json.12.0.0.0/LICENSE.txt"                  SourcePath="newtonsoft_mit_license.txt" />
+    <File Path="Dependencies/Newtonsoft.Json.12.0.0.0/Newtonsoft.Json.dll"          SourcePath="Newtonsoft.Json.dll" />
   </Files>
   <PackageActionExtensions>
     <ActionStep ActionName="install" ExeFile="chmod" Arguments="+x tap"  />


### PR DESCRIPTION
This is a temporary fix which manually adds the dll. We should investigate why the dll needs to be manually added and find a proper solution.