### PR TITLE
103 EmptyLicenseRequired string: fix

### DIFF
--- a/Package.UnitTests/PackageDefSerializationTest.cs
+++ b/Package.UnitTests/PackageDefSerializationTest.cs
@@ -1,0 +1,16 @@
+﻿using NUnit.Framework;
+
+namespace OpenTap.Package.UnitTests
+{
+    [TestFixture]
+    public class PackageDefSerializationTest
+    {
+        [Test]
+        public void PackageFileLicenseRequiredTest()
+        {
+            var pf = new PackageDef {LicenseRequired = ""};
+            var str = new TapSerializer().SerializeToString(pf);
+            Assert.IsFalse(str.Contains("LicenseRequired=\"\""));
+        }
+    }
+}

--- a/Package/CreatePackage/Package.cs
+++ b/Package/CreatePackage/Package.cs
@@ -685,7 +685,7 @@ namespace OpenTap.Package
                 // Concat license required from all files. But only if the property has not manually been set.
                 if (string.IsNullOrEmpty(pkg.LicenseRequired))
                 {
-                    var licenses = pkg.Files.Select(f => f.LicenseRequired).Where(l => l != null).ToList();
+                    var licenses = pkg.Files.Select(f => f.LicenseRequired).Where(l => string.IsNullOrWhiteSpace(l) == false).ToList();
                     pkg.LicenseRequired = string.Join(", ", licenses.Distinct().Select(l => LicenseBase.FormatFriendly(l, false)).ToList());
                 }
                 

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -138,8 +138,8 @@ namespace OpenTap.Package
         /// License required by the plugin file.
         /// </summary>
         [XmlAttribute("LicenseRequired")]
-        [DefaultValue(null)]
-        public string LicenseRequired { get; set; }
+        [DefaultValue("")]
+        public string LicenseRequired { get; set; } = "";
 
         /// <summary>
         /// Creates a new instance of PackageFile.
@@ -367,8 +367,8 @@ namespace OpenTap.Package
         /// Bundle packages (<see cref="Class"/> is 'bundle') can use this property to show licenses that are required by the bundle dependencies. 
         /// </summary>
         [XmlAttribute]
-        [DefaultValue(null)]
-        public string LicenseRequired { get; set; }
+        [DefaultValue("")]
+        public string LicenseRequired { get; set; } = "";
 
         /// <summary>
         /// The package class, this can be either 'package', 'bundle' or 'solution'.


### PR DESCRIPTION
Fixed the issue by setting the default value of LicenseRequired to "" instead of null. It was always being set to "" by package create, but generally was inconsistently used.

Added a unit test to verify the behavior.