### PR TITLE
113 Xml cache -> Save Component Settings

### DIFF
--- a/Engine/ComponentSettingsContext.cs
+++ b/Engine/ComponentSettingsContext.cs
@@ -47,6 +47,8 @@ namespace OpenTap
 
         public void SaveAllCurrentSettings()
         {
+            foreach (var cacheType in xmlCache.Keys.ToArray())
+                GetCurrent(cacheType);
             foreach (var comp in objectCache.GetResults().Where(x => x != null))
                 Save(comp);
         }


### PR DESCRIPTION
When the XML cache is used in component settings. Evaluate it before saving all current component settings. This ensures that the setting in question becomes saved with the right data.

Also I've added an unit test that verifies the behavior.(Courtesy of Dennis)