### PR TITLE
274 Deserialize Warning Improvement

### DIFF
--- a/Engine.UnitTests/TestPlanDependencyTest.cs
+++ b/Engine.UnitTests/TestPlanDependencyTest.cs
@@ -197,7 +197,7 @@ namespace OpenTap.UnitTests
                 Assert.AreEqual(3, errors.Length, "Expected 3 errors.");
                 Assert.IsTrue(errors.Any(e =>
                     e.Contains(
-                        $"Package '{TestPackageName}' is required to load the test plan, but it is not installed.")));
+                        $"Package '{TestPackageName}' is required to load, but it is not installed.")));
                 Assert.IsTrue(errors.Any(e =>
                     e.Contains(
                         $"File '{ReferencedFile}' from package '{TestPackageName}' is required by the test plan, but it could not be found.")));

--- a/Package/TestPlanPackageDependency.cs
+++ b/Package/TestPlanPackageDependency.cs
@@ -120,7 +120,7 @@ namespace OpenTap.Package
                     }
                     else
                     {
-                        errors.Add($"Package '{packageName}' is required to load the test plan, but it is not installed.");
+                        errors.Add($"Package '{packageName}' is required to load, but it is not installed.");
                     }
 
                     if (UsePlatformInteraction)


### PR DESCRIPTION
Improved the message by not writing Test Plan, since anything could in theory be deserialized and hopefully the user knows based on the other log messages