### PR TITLE
298 Add Result Listener In TestPlanRun: Fix + Unit Tests

### DIFF
--- a/Engine.UnitTests/PlanRunMonitorTests.cs
+++ b/Engine.UnitTests/PlanRunMonitorTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using NUnit.Framework;
+using OpenTap.Engine.UnitTests.TestTestSteps;
+
+namespace OpenTap.Engine.UnitTests
+{
+    [TestFixture]
+    public class PlanRunMonitorTests
+    {
+        [Browsable(false)]
+        public class TestTestPlanRunMonitor : ComponentSettings<TestTestPlanRunMonitor>, ITestPlanRunMonitor
+        {
+            public bool IsEnabled { get; set; }
+            public IResultListener ListenerToAdd { get; set; }
+            public bool Entered { get; set; }
+            public bool Exited { get; set; }
+            public bool ThrowOnEnter { get; set; }
+
+            public void EnterTestPlanRun(TestPlanRun plan)
+            {
+                if (!IsEnabled) return;
+                Entered = true;
+                if (ThrowOnEnter)
+                    throw new Exception("Intended exception");
+                if (ListenerToAdd != null)
+                    plan.AddResultListener(ListenerToAdd);
+            }
+
+            public void ExitTestPlanRun(TestPlanRun plan)
+            {
+                if (!IsEnabled) return;
+                Exited = true;
+                if (ListenerToAdd != null)
+                    plan.RemoveResultListener(ListenerToAdd);
+            }
+        }
+
+        [Test]
+        public void TestAddResultListenerInPlanRunMonitor()
+        {
+            // Verify that a result listener can be added by an ITestPlanRunMonitor.
+            var plan = new TestPlan();
+            plan.ChildTestSteps.Add(new SineResultsStep());
+            using (Session.Create(SessionOptions.OverlayComponentSettings))
+            {
+                var listener = new PlanRunCollectorListener {CollectResults = true};
+                TestTestPlanRunMonitor.Current.IsEnabled = true;
+                TestTestPlanRunMonitor.Current.ListenerToAdd = listener;
+                var executed = plan.Execute();
+                Assert.IsFalse(executed.ResultListeners.Contains(listener));
+                Assert.IsTrue(listener.WasOpened);
+                Assert.IsFalse(listener.IsConnected);
+                Assert.IsTrue(listener.Results.Any());
+                Assert.IsFalse(ResultSettings.Current.Any());
+            }
+        }
+
+        [Test]
+        public void PlanRunMonitorGeneralTest()
+        {
+            var plan = new TestPlan();
+            plan.ChildTestSteps.Add(new SineResultsStep());
+            using (Session.Create(SessionOptions.OverlayComponentSettings))
+            {
+                // Verify that run monitor is both entered and exited.
+                TestTestPlanRunMonitor.Current.IsEnabled = true;
+                plan.Execute();
+                Assert.IsTrue(TestTestPlanRunMonitor.Current.Entered);
+                Assert.IsTrue(TestTestPlanRunMonitor.Current.Exited);
+            }
+
+            using (Session.Create(SessionOptions.OverlayComponentSettings))
+            {
+                // Verify that run monitor is both entered and exited, even if the plan failed to start.
+                TestTestPlanRunMonitor.Current.IsEnabled = true;
+                TestTestPlanRunMonitor.Current.ThrowOnEnter = true;
+                var run = plan.Execute();
+                Assert.IsTrue(run.FailedToStart);
+                Assert.IsTrue(TestTestPlanRunMonitor.Current.Entered);
+                Assert.IsTrue(TestTestPlanRunMonitor.Current.Exited);
+            }
+            
+            // verify that the overlaid session works.
+            Assert.IsFalse(TestTestPlanRunMonitor.Current.ThrowOnEnter);
+        }
+        
+        [Test]
+        public void PlanRunMonitorOpenTestTest()
+        {
+            var plan = new TestPlan();
+            plan.ChildTestSteps.Add(new SineResultsStep());
+            using (Session.Create(SessionOptions.OverlayComponentSettings))
+            {
+                // Verify that run monitor is both entered and exited.
+                TestTestPlanRunMonitor.Current.IsEnabled = true;
+                var listener = new PlanRunCollectorListener {CollectResults = true};
+                TestTestPlanRunMonitor.Current.ListenerToAdd = listener;
+                plan.Open();
+                var executed = plan.Execute();
+                var listener2 = new PlanRunCollectorListener {CollectResults = true};
+                TestTestPlanRunMonitor.Current.ListenerToAdd = listener2;
+                var executed2 = plan.Execute();
+                Assert.IsFalse(executed.ResultListeners.Contains(listener));
+                Assert.IsFalse(executed2.ResultListeners.Contains(listener2));
+                Assert.IsFalse(executed2.ResultListeners.Contains(listener));
+                Assert.IsTrue(listener.WasOpened);
+                Assert.IsTrue(listener.IsConnected);
+                Assert.IsTrue(listener.Results.Any());
+                Assert.IsTrue(listener2.Results.Any());
+                Assert.IsTrue(listener2.IsConnected);
+                Assert.IsFalse(ResultSettings.Current.Any());
+                Assert.IsTrue(TestTestPlanRunMonitor.Current.Entered);
+                Assert.IsTrue(TestTestPlanRunMonitor.Current.Exited);
+                plan.Close();
+                Assert.IsFalse(listener.IsConnected);
+            }
+
+        }
+    }
+}

--- a/Engine.UnitTests/ResultListeners/PlanRunCollectorListener.cs
+++ b/Engine.UnitTests/ResultListeners/PlanRunCollectorListener.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Xml.Serialization;
+
+namespace OpenTap.Engine.UnitTests
+{
+    [DisplayName("Test\\Test Plan Collector")]
+    [System.ComponentModel.Description("Gathers Test Plans and Test Steps into lists for manipulation in code.")]
+    public class PlanRunCollectorListener : ResultListener
+    {
+        [XmlIgnore]
+        public List<TestPlanRun> PlanRuns = new List<TestPlanRun>();
+        [XmlIgnore]
+        public List<TestStepRun> StepRuns = new List<TestStepRun>();
+
+        public string LogString;
+
+        public override void OnTestPlanRunStart(TestPlanRun planRun)
+        {
+            base.OnTestPlanRunStart(planRun);
+            Results.Clear();
+        }
+
+        public override void OnTestPlanRunCompleted(TestPlanRun planRun, System.IO.Stream logStream)
+        {
+            PlanRuns.Add(planRun);
+            LogString = new System.IO.StreamReader(logStream).ReadToEnd();
+        }
+
+        public override void OnTestStepRunStart(TestStepRun stepRun)
+        {
+            base.OnTestStepRunStart(stepRun);
+        }
+
+        public override void OnTestStepRunCompleted(TestStepRun stepRun)
+        {
+            StepRuns.Add(stepRun);
+        }
+        
+        public PlanRunCollectorListener()
+        {
+            Name = "Collector";
+        }
+        public bool WasOpened { get; private set; }
+        
+        public override void Open()
+        {
+            base.Open();
+            WasOpened = true;
+        }
+
+        public bool CollectResults = false;
+
+        public class CollectedResult
+        {
+            public Guid StepRunId;
+            public ResultTable Result;
+
+            public override string ToString() => $"Collected Result, {Result.Rows} rows, {Result.Columns.Length} columns.";
+        }
+
+        public List<CollectedResult> Results = new List<CollectedResult>();
+
+        public override void OnResultPublished(Guid stepRunId, ResultTable result)
+        {
+            if (CollectResults)
+            {
+                Results.Add(new CollectedResult { StepRunId = stepRunId, Result = result });
+            }
+            base.OnResultPublished(stepRunId, result);
+
+        }
+    }
+}

--- a/Engine.UnitTests/TestPlanCompositeRunTests.cs
+++ b/Engine.UnitTests/TestPlanCompositeRunTests.cs
@@ -4,15 +4,11 @@
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Threading;
-using System.Xml.Serialization;
 using OpenTap.EngineUnitTestUtils;
-using OpenTap;
 
 namespace OpenTap.Engine.UnitTests
 {
@@ -385,71 +381,5 @@ namespace OpenTap.Engine.UnitTests
 
 
         #endregion
-    }
-
-    [DisplayName("Test\\Test Plan Collector")]
-    [System.ComponentModel.Description("Gathers Test Plans and Test Steps into lists for manipulation in code.")]
-    public class PlanRunCollectorListener : ResultListener
-    {
-        [XmlIgnore]
-        public List<TestPlanRun> PlanRuns = new List<TestPlanRun>();
-        [XmlIgnore]
-        public List<TestStepRun> StepRuns = new List<TestStepRun>();
-
-        public string LogString;
-
-        public override void OnTestPlanRunStart(TestPlanRun planRun)
-        {
-            base.OnTestPlanRunStart(planRun);
-            Results.Clear();
-        }
-
-        public override void OnTestPlanRunCompleted(TestPlanRun planRun, System.IO.Stream logStream)
-        {
-            PlanRuns.Add(planRun);
-            LogString = new System.IO.StreamReader(logStream).ReadToEnd();
-        }
-
-        public override void OnTestStepRunStart(TestStepRun stepRun)
-        {
-            base.OnTestStepRunStart(stepRun);
-        }
-
-        public override void OnTestStepRunCompleted(TestStepRun stepRun)
-        {
-            StepRuns.Add(stepRun);
-        }
-        
-        public PlanRunCollectorListener()
-        {
-            Name = "Collector";
-        }
-        public bool WasOpened { get; private set; }
-        
-        public override void Open()
-        {
-            base.Open();
-            WasOpened = true;
-        }
-
-        public bool CollectResults = false;
-
-        public class CollectedResult
-        {
-            public Guid StepRunId;
-            public ResultTable Result;
-        }
-
-        public List<CollectedResult> Results = new List<CollectedResult>();
-
-        public override void OnResultPublished(Guid stepRunId, ResultTable result)
-        {
-            if (CollectResults)
-            {
-                Results.Add(new CollectedResult { StepRunId = stepRunId, Result = result });
-            }
-            base.OnResultPublished(stepRunId, result);
-
-        }
     }
 }

--- a/Engine.UnitTests/TestPlanTest.cs
+++ b/Engine.UnitTests/TestPlanTest.cs
@@ -403,6 +403,7 @@ namespace OpenTap.Engine.UnitTests
         [Test]
         public void MissingInstReferencesIntoResultListener()
         {
+            InstrumentSettings.Current.Clear();
             PlanRunCollectorListener pl = new PlanRunCollectorListener();
             TestPlan testPlan = new TestPlan();
             ScpiTestStep step = new ScpiTestStep();
@@ -2553,6 +2554,5 @@ namespace OpenTap.Engine.UnitTests
             
         }
     }
-
 }
 

--- a/Engine.UnitTests/TestTestSteps/SineResultsStep.cs
+++ b/Engine.UnitTests/TestTestSteps/SineResultsStep.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace OpenTap.Engine.UnitTests.TestTestSteps
+{
+    [Display("Sine Results", "Generates a sine wave of results.", "Tests")]
+    public class SineResultsStep : TestStep
+    {
+        public double Periods { get; set; } = 1;
+        public int Samples { get; set; } = 1024;
+        public override void Run()
+        {
+            for (int i = 0; i < Samples; i++)
+            {
+                var phase = i * (Periods / Samples);
+                Results.Publish("Sine", new {Phase = phase, Amplitude = Math.Sin(phase)});
+            }
+        }
+    }
+}

--- a/Engine.UnitTests/TestTestSteps/WriteFileStep.cs
+++ b/Engine.UnitTests/TestTestSteps/WriteFileStep.cs
@@ -1,8 +1,5 @@
-
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text.RegularExpressions;
@@ -213,5 +210,4 @@ namespace OpenTap.Engine.UnitTests.TestTestSteps
             UpgradeVerdict(Verdict.Fail);
         }
     }
-    
 }

--- a/Engine/ITestPlanRunMonitor.cs
+++ b/Engine/ITestPlanRunMonitor.cs
@@ -31,9 +31,9 @@ namespace OpenTap
         /// <returns></returns>
         public static ITestPlanRunMonitor[] GetCurrent()
         {
-            return PluginManager.GetPlugins<ComponentSettings>()
-                .Where(settings => settings.DescendsTo(typeof(ITestPlanRunMonitor)))
-                .Select(ComponentSettings.GetCurrent).OfType<ITestPlanRunMonitor>()
+            return TypeData.GetDerivedTypes<ITestPlanRunMonitor>()
+                .Select(ComponentSettings.GetCurrent)
+                .OfType<ITestPlanRunMonitor>()
                 .ToArray();
         }
     }

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -544,16 +544,14 @@ namespace OpenTap
 
             if (currentExecutionState != null)
             {
+                currentExecutionState.ResultListenersSealed = false;
                 // load result listeners that are _not_ used in the previous runs.
                 // otherwise they wont get opened later.
                 foreach (var rl in resultListeners)
                 {
-                    if (!currentExecutionState.ResultListeners.Contains(rl))
-                        currentExecutionState.ResultListeners.Add(rl);
+                    currentExecutionState.AddResultListener(rl);
                 }
             }
-
-            var currentListeners = currentExecutionState != null ? currentExecutionState.ResultListeners : resultListeners;
 
             TestPlanRun execStage;
             bool continuedExecutionState = false;
@@ -590,7 +588,7 @@ namespace OpenTap
             {
                 execStage.FailedToStart = true; // Set it here in case OpenInternal throws an exception. Could happen if a step is missing an instrument
 
-                OpenInternal(execStage, continuedExecutionState, currentListeners.Cast<IResource>().ToList(), allEnabledSteps);
+                OpenInternal(execStage, continuedExecutionState, allEnabledSteps);
                     
                 execStage.WaitForSerialization();
                 execStage.ResourceManager.BeginStep(execStage, this, TestPlanExecutionStage.Execute, TapThread.Current.AbortToken);
@@ -711,7 +709,7 @@ namespace OpenTap
                 Stopwatch timer = Stopwatch.StartNew();
                 currentExecutionState = new TestPlanRun(this, listeners.ToList(), DateTime.Now, Stopwatch.GetTimestamp(), true);
                 currentExecutionState.Start();
-                OpenInternal(currentExecutionState, false, listeners.Cast<IResource>().ToList(), allSteps);
+                OpenInternal(currentExecutionState, false, allSteps);
                 try
                 {
                     currentExecutionState.ResourceManager.WaitUntilAllResourcesOpened(TapThread.Current.AbortToken);
@@ -740,7 +738,7 @@ namespace OpenTap
             }
         }
         
-        private void OpenInternal(TestPlanRun run, bool isOpen, List<IResource> resources, List<ITestStep> steps)
+        private void OpenInternal(TestPlanRun run, bool isOpen, List<ITestStep> steps)
         {
             monitors = TestPlanRunMonitors.GetCurrent();
             try
@@ -752,8 +750,8 @@ namespace OpenTap
             finally   // We need to make sure OpenAllAsync is always called (even when CheckResources throws an exception). 
             {         // Otherwise we risk that e.g. ResourceManager.WaitUntilAllResourcesOpened() will hang forever.
                 run.ResourceManager.EnabledSteps = steps;
-                run.ResourceManager.StaticResources = resources;
-
+                run.ResourceManager.StaticResources = run.ResultListeners.ToArray();
+                run.ResultListenersSealed = true;
                 if (!isOpen)
                     run.ResourceManager.BeginStep(run, this, TestPlanExecutionStage.Open, TapThread.Current.AbortToken);
             }

--- a/Package/Image/ImageSpecifier.cs
+++ b/Package/Image/ImageSpecifier.cs
@@ -33,7 +33,7 @@ namespace OpenTap.Package
         /// Resolve the desired packages from the specified repositories. This will check if the packages are available, compatible and can successfully be deployed as an OpenTAP installation
         /// </summary>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>An <see cref="ImageIdentifier"/></returns>
+        /// <exception cref="ImageResolveException">The exception thrown if the image could not be resolved</exception>
         public ImageIdentifier Resolve(CancellationToken cancellationToken)
         {
             List<IPackageRepository> repositories = Repositories.Select(PackageRepositoryHelpers.DetermineRepositoryType).ToList();
@@ -49,6 +49,13 @@ namespace OpenTap.Package
             return image;
         }
 
+        /// <summary>
+        /// Merges and resolves the packages for a number of images. May throw an exception if the packages cannot be resolved.
+        /// </summary>
+        /// <param name="images">The images to merge.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation before time. This will cause an OperationCancelledException to be thrown.</param>
+        /// <returns></returns>
+        /// <exception cref="ImageResolveException">The exception thrown if the image could not be resolved</exception>
         public static ImageIdentifier MergeAndResolve(IEnumerable<ImageSpecifier> images, CancellationToken cancellationToken)
         {
             List<IPackageRepository> repositories = images.SelectMany(s => s.Repositories).Distinct().Select(PackageRepositoryHelpers.DetermineRepositoryType).ToList();


### PR DESCRIPTION
- Added support for adding and removing ResultListeners from the test plan run. There is a very limited time window in which is is possible, namely during the time ITestPlanRunMonitor is activated. In this window it is both possible to remove (mostly for test plan exited) and add (mostly for test plan entered).

- Did a cleanup in TestPlanRun to reduce the confusion gbetween ResultListeners an resultWorkQueues.

- Added unit tests to verify the new behavior.