### PR TITLE
Enhance TypeData logic to construct types with default constructors

### DIFF
--- a/Engine.UnitTests/TestCreateInstance.cs
+++ b/Engine.UnitTests/TestCreateInstance.cs
@@ -1,0 +1,88 @@
+using System;
+using NUnit.Framework;
+
+namespace OpenTap.UnitTests
+{
+    public class ParameterlessConstructor
+    {
+    }
+    public class ConstructorWithDefaultValues
+    {
+        public ConstructorWithDefaultValues(int a = 1)
+        {
+            // This should be instantiated with the default value
+            Assert.AreEqual(1, a);
+        }
+    }
+    public class ConstructorWithSomeDefaultValues
+    {
+        public ConstructorWithSomeDefaultValues(string s, int a = 1)
+        {
+            // This should not be possible to instantiate
+            Assert.Fail();
+        }
+    }
+
+    public class ConstructorWithoutDefaultValues
+    {
+        public ConstructorWithoutDefaultValues(int a)
+        {
+            // This should not be possible to instantiate
+            Assert.Fail();
+        }
+    }
+
+    public class MultipleValidConstructors
+    {
+        public MultipleValidConstructors()
+        {
+
+        }
+
+        public MultipleValidConstructors(string s = "123")
+        {
+            // We should resolve the parameterless constructor first
+            Assert.Fail();
+        }
+    }
+
+    public class ConstructorWithNullAsDefault
+    {
+        public ConstructorWithNullAsDefault(ConstructorWithNullAsDefault a = null)
+        {
+            // We should be able to construct this type with 'null' as the argument
+            Assert.IsNull(a);
+        }
+    }
+
+
+    [TestFixture]
+    public class TestCreateInstance
+    {
+        [Test]
+        public void TestCreateInstanceScenarios()
+        {
+            void testConstructor<T>(bool expected)
+            {
+                var td = TypeData.FromType(typeof(T));
+                if (expected)
+                {
+                    Assert.IsTrue(td.CanCreateInstance);
+                    Assert.NotNull(td.CreateInstance());
+                }
+                else
+                {
+                    Assert.IsFalse(td.CanCreateInstance);
+                    Assert.Throws<MissingMethodException>(() => td.CreateInstance());
+                }
+            }
+
+            testConstructor<ParameterlessConstructor>(true);
+            testConstructor<ConstructorWithDefaultValues>(true);
+            testConstructor<MultipleValidConstructors>(true);
+            testConstructor<ConstructorWithNullAsDefault>(true);
+            testConstructor<ConstructorWithSomeDefaultValues>(false);
+            testConstructor<ConstructorWithoutDefaultValues>(false);
+        }
+    }
+}

--- a/Engine/Reflection/ReflectionDataExtensions.cs
+++ b/Engine/Reflection/ReflectionDataExtensions.cs
@@ -18,7 +18,16 @@ namespace OpenTap
         /// </summary>
         public static object CreateInstance(this ITypeData type)
         {
-            return type.CreateInstance(Array.Empty<object>());
+            var ctor = type.AsTypeData().GetPreferredConstructor();
+            if (ctor == null)
+            {
+                // This could be an ITypeData implementation which does not represent a dotnet type
+                // Try to invoke its virtual constructor anyway
+                return type.CreateInstance(Array.Empty<object>());
+            }
+
+            var args = ctor.GetParameters().Select(p => p.DefaultValue).ToArray();
+            return type.CreateInstance(args);
         }
 
         /// <summary> returns true if 'type' is a descendant of 'basetype'. </summary>


### PR DESCRIPTION
This adds a check to the assembly reader so it will no longer consider private constructors when determining if an instance can be created from a typedata.

It also expands the type creation logic a bit so we now check if there is a constructor that has all default values. This should make the system a bit less restrictive to use, as you would previously have to create an empty constructor which called the other constructor with default values.

This is not a breaking change because we still prefer constructors with fewer parameters, so it should only affect types which did not previously have an applicable constructor.

Closes #302 
Closes #304