### PR TITLE
Fixed sign conditional in build script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
         run: |
           $env:Platform = "Windows"
           $env:Architecture =  "${{ matrix.Architecture }}"
-          if (!$GITHUB_REF_PROTECTED) { $env:Sign = "false" } else { $env:Sign = "true" }
+          if ($env:GITHUB_REF_PROTECTED -eq "true") { $env:Sign = "true" } else { $env:Sign = "false" }
           cd bin/Release-x64
           cp .\runtimes\win-x64\native\git2-b7bad55.dll .
           .\tap.exe package install -f sign.TapPackage
@@ -398,7 +398,7 @@ jobs:
         run: |
           $env:Platform = "Linux,MacOS"
           $env:Architecture = "x64"
-          if (!$GITHUB_REF_PROTECTED) { $env:Sign = "false" } else { $env:Sign = "true" }
+          if ($env:GITHUB_REF_PROTECTED -eq "true") { $env:Sign = "true" } else { $env:Sign = "false" }
           pushd bin\linux-x64\ 
           ../Release/tap package install -f "/repo/Sign.TapPackage"
           cp .\runtimes\win-x64\native\git2-b7bad55.dll .


### PR DESCRIPTION
Closes #233 


Build log from main that doesn't look like it is signing: https://github.com/Keysight/opentap/runs/5185158736?check_suite_focus=true

Excerpt from that log:
```
00:00:00.884 : VariableExpander : Initialized variable expander:
00:00:00.884 : VariableExpander : Debug = 'false'
00:00:00.885 : XML Expander : Expanded '$(GitVersion)' -> '9.17.0-alpha.58.3+53f3db86.211-add-tap-upgrader'
00:00:00.885 : XML Expander : Expanded '$(Architecture)' -> 'x86'
00:00:00.885 : XML Expander : Expanded '$(Platform)' -> 'Windows'
00:00:00.886 : XML Expander : Expanded '$(Debug) == false' -> 'false == false'
00:00:00.886 : Condition Evaluator : XML Line 19: Evaluated Condition="false == false" to "True"
00:00:00.886 : XML Expander : Expanded '$(Sign)==true' -> 'false==true'
00:00:00.886 : Condition Evaluator : XML Line 23: Evaluated Condition="false==true" to "False"
00:00:00.887 : XML Expander : Expanded '$(Sign)==true' -> 'false==true'
```
