### PR TITLE
348-package-show-usability

### DIFF
--- a/Package/PackageActions/Show.cs
+++ b/Package/PackageActions/Show.cs
@@ -100,22 +100,6 @@ namespace OpenTap.Package
         private List<IPackageRepository> repositories = new List<IPackageRepository>();
 
         private VersionSpecifier versionSpec { get; set; }
-        public PackageShowAction()
-        {
-            Architecture = ArchitectureHelper.GuessBaseArchitecture;
-            switch (Environment.OSVersion.Platform)
-            {
-                case PlatformID.MacOSX:
-                    OS = "MacOS";
-                    break;
-                case PlatformID.Unix:
-                    OS = "Linux";
-                    break;
-                default:
-                    OS = "Windows";
-                    break;
-            }
-        }
 
         private void DisableHttpRepositories()
         {
@@ -211,6 +195,13 @@ namespace OpenTap.Package
             if (string.IsNullOrWhiteSpace(package.Version.PreRelease))
                 packageVersions = packageVersions.Where(p => string.IsNullOrWhiteSpace(p.Version.PreRelease));
 
+            if (Architecture != CpuArchitecture.Unspecified)
+                packageVersions = packageVersions.Where(p => ArchitectureHelper.CompatibleWith(Architecture, p.Architecture));
+
+            if (!string.IsNullOrWhiteSpace(OS))
+                packageVersions = packageVersions.Where(p => p.OS.Contains(OS));
+
+
             GetPackageInfo(package, packageVersions.ToList(), targetInstallation);
 
             return (int)ExitCodes.Success;
@@ -246,7 +237,12 @@ namespace OpenTap.Package
                 AddWritePair("Newest Version in Repository", $"{latestVersion}");
 
             AddWritePair("Compatible Architectures", string.Join(Environment.NewLine, similarReleases.Select(x => x.Architecture).Distinct()));
-            AddWritePair("Compatible Platforms", string.Join(Environment.NewLine, similarReleases.Select(x => x.OS).Distinct()));
+
+            var platforms = similarReleases
+                .SelectMany(x => x.OS.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+
+            AddWritePair("Compatible Platforms", string.Join(Environment.NewLine, platforms));
 
             if (packageInstalled == false)
             {


### PR DESCRIPTION
Filter 'similar packages' by OS and architecture if specified. Improve parsing of OS field in packages

Closes #348 
Closes #346
Closes #109