### PR TITLE
330 Cleanup in the SDK Examples project files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,11 +138,12 @@ jobs:
       - name: Stamp Version
         run: |
           $AssemblyVersion = "`"${{needs.GetVersion.outputs.ShortVersion}}.0`""
+          $AssemblyFileVersion = "`"${{needs.GetVersion.outputs.ShortVersion}}`""
           $GitVersion = "`"${{needs.GetVersion.outputs.GitVersion}}`""
           Push-Location ./tap/Properties
           $AssemblyInfoFile = (Get-Content AssemblyInfo.cs.Template)
           $AssemblyInfoFile = ($AssemblyInfoFile) -replace '"AssemblyVersion"', $AssemblyVersion
-          $AssemblyInfoFile = ($AssemblyInfoFile) -replace '"AssemblyFileVersion"', $AssemblyVersion
+          $AssemblyInfoFile = ($AssemblyInfoFile) -replace '"AssemblyFileVersion"', $AssemblyFileVersion
           $AssemblyInfoFile = ($AssemblyInfoFile) -replace '"AssemblyInformationalVersion"', $GitVersion
           $AssemblyInfoFile | Set-Content AssemblyInfo.cs
           cat AssemblyInfo.cs

--- a/sdk/Examples/Directory.Build.props
+++ b/sdk/Examples/Directory.Build.props
@@ -9,7 +9,7 @@
 	<PropertyGroup>
 		<!-- This variable is only defined so we can compile locally without replacing GitVersion. 
 		     It will be removed in the build script. -->
-		<GitVersion>9.16.1</GitVersion>
+		<GitVersion>9.17.0</GitVersion>
 	</PropertyGroup>	
 	<PropertyGroup>
 		<!-- Ensure that all projects in this solution use the same version of OpenTAP -->		
@@ -20,6 +20,7 @@
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<OutputPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</OutputPath>
+        <PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
 	
 	<!-- To support building on linux, it is needed to disable some things, like installing Developers System. -->
@@ -30,11 +31,6 @@
 	<PropertyGroup Condition="'$(OS)'=='Windows_NT'">
 		<IsLinux>False</IsLinux>
 		<IsWindows>True</IsWindows>
-	</PropertyGroup>
-	
-	<!-- We are setting TargetFramework in debug configuration, otherwise Visual Studio tries to attach a .NET Core debugger. That will not work, because the program we open is a .NET Framework executable -->
-	<PropertyGroup Condition="'$(OS)'=='Windows_NT' AND '$(Configuration)'=='Debug'">
-		<TargetFramework>net462</TargetFramework>
 	</PropertyGroup>
 
   <ItemGroup>

--- a/sdk/Examples/ExamplePlugin/ExamplePlugin.csproj
+++ b/sdk/Examples/ExamplePlugin/ExamplePlugin.csproj
@@ -10,30 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsWindows)'=='True'">
-    <!-- Developer's System is needed to debug in 'Editor' 
-         Normally you can get that in your debug folder with just:
-           <AdditionalOpenTapPackage Include="Developer's System"/>
-         or 
-           <AdditionalOpenTapPackage Include="Developer's System CE"/>
-         Here we do some optimizations that leverages an existing OpenTAP installation in OutputPath
-    -->
-    <CachedOpenTapPackages Include="$(OutputPath)\PackageCache\Developer*" />
-
-    <!-- Editor, included dependency: WPF Controls -->
-    <AdditionalOpenTapPackage Include="Editor" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="Editor" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <!-- Results Viewer, included dependency: CSV -->
-    <AdditionalOpenTapPackage Include="Results Viewer" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="Results Viewer" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <!-- Timing Analyzer -->
-    <AdditionalOpenTapPackage Include="Timing Analyzer" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="Timing Analyzer" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <!-- SQLite and PostgreSQL -->
-    <AdditionalOpenTapPackage Include="SQLite and PostgreSQL" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="SQLite and PostgreSQL" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-
-    <AdditionalOpenTapPackage Include="Developer's System CE" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor') == false" />
-    <AdditionalOpenTapPackage Include="Developer's System CE" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor') == false" />
+	  <AdditionalOpenTapPackage Include="Developer's System CE" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
+++ b/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
@@ -14,35 +14,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsWindows)'=='True'">
-    <!-- Developer's System is needed to debug in 'Editor' 
-         Normally you can get that in your debug folder with just:
-           <AdditionalOpenTapPackage Include="Developer's System"/>
-         or 
-           <AdditionalOpenTapPackage Include="Developer's System CE"/>
-         Here we do some optimizations that leverages an existing OpenTAP installation in OutputPath
-    -->
-    <CachedOpenTapPackages Include="$(OutputPath)\PackageCache\Developer*" />
-    
-    <!-- Editor, included dependency: WPF Controls -->
-    <AdditionalOpenTapPackage Include="Editor" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="Editor" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <!-- Results Viewer, included dependency: CSV -->
-    <AdditionalOpenTapPackage Include="Results Viewer" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="Results Viewer" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <!-- Timing Analyzer -->
-    <AdditionalOpenTapPackage Include="Timing Analyzer" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="Timing Analyzer" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <!-- SQLite and PostgreSQL -->
-    <AdditionalOpenTapPackage Include="SQLite and PostgreSQL" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="SQLite and PostgreSQL" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-
-    <AdditionalOpenTapPackage Include="Developer's System CE" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor') == false" />
-    <AdditionalOpenTapPackage Include="Developer's System CE" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor') == false" />
+	<AdditionalOpenTapPackage Include="Developer's System CE" />
+	<OpenTapPackageReference Include="WPF Controls" />
   </ItemGroup>
 
   <ItemGroup>
-    <OpenTapPackageReference Include="WPF Controls" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != ''" />
-    <OpenTapPackageReference Include="WPF Controls" Condition="@(CachedOpenTapPackages) == ''" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Windows.Forms" />

--- a/sdk/Examples/PluginDevelopment/PluginDevelopment.csproj
+++ b/sdk/Examples/PluginDevelopment/PluginDevelopment.csproj
@@ -9,32 +9,9 @@
     <AssemblyName>OpenTap.Plugins.PluginDevelopment</AssemblyName>
     <RootNamespace>OpenTap.Plugins.PluginDevelopment</RootNamespace>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(IsWindows)'=='True'">
-    <!-- Developer's System is needed to debug in 'Editor' 
-         Normally you can get that in your debug folder with just:
-           <AdditionalOpenTapPackage Include="Developer's System"/>
-         or 
-           <AdditionalOpenTapPackage Include="Developer's System CE"/>
-         Here we do some optimizations that leverages an existing OpenTAP installation in OutputPath
-    -->
-    <CachedOpenTapPackages Include="$(OutputPath)\PackageCache\Developer*" />
-
-    <!-- Editor, included dependency: WPF Controls -->
-    <AdditionalOpenTapPackage Include="Editor" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="Editor" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <!-- Results Viewer, included dependency: CSV -->
-    <AdditionalOpenTapPackage Include="Results Viewer" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="Results Viewer" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <!-- Timing Analyzer -->
-    <AdditionalOpenTapPackage Include="Timing Analyzer" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="Timing Analyzer" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <!-- SQLite and PostgreSQL -->
-    <AdditionalOpenTapPackage Include="SQLite and PostgreSQL" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor')" />
-    <AdditionalOpenTapPackage Include="SQLite and PostgreSQL" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor')" />
-
-    <AdditionalOpenTapPackage Include="Developer's System CE" Repository="$(OutputPath)\PackageCache" Version="Any" Condition="@(CachedOpenTapPackages) != '' AND Exists('$(OutputPath)\Packages\Editor') == false" />
-    <AdditionalOpenTapPackage Include="Developer's System CE" Condition="@(CachedOpenTapPackages) == '' AND Exists('$(OutputPath)\Packages\Editor') == false" />
+	<AdditionalOpenTapPackage Include="Developer's System CE" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove a lot of caching logic which is now builtin in OpenTAP and the
nuget package.

Set PlatformTarget=x64 to avoid copying incorrect payload files

The build will still fail until Editor CE 9.17.x is released because it tries to create WPF controls in a .NET 6 process

Closes #330 