### PR TITLE
Fix intermittently failing version check in test

### DIFF
--- a/tests/NoAssemblyInfo.TapPlan
+++ b/tests/NoAssemblyInfo.TapPlan
@@ -16,9 +16,19 @@
       <BreakConditions>Inherit</BreakConditions>
     </TestStep>
     <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.WriteFileStep" Version="0.0.0" Id="45f82fc0-8acf-41b2-8472-2c1b9db25f32">
-      <String>
-        <Base64>PFByb2plY3QgU2RrPSJNaWNyb3NvZnQuTkVULlNkayI+DQogIDxQcm9wZXJ0eUdyb3VwPg0KICA8VGFyZ2V0RnJhbWV3b3JrSWRlbnRpZmllcj48L1RhcmdldEZyYW1ld29ya0lkZW50aWZpZXI+DQogICAgPFRhcmdldEZyYW1ld29ya1ZlcnNpb24+PC9UYXJnZXRGcmFtZXdvcmtWZXJzaW9uPg0KICAgIDxUYXJnZXRGcmFtZXdvcms+bmV0c3RhbmRhcmQyLjA8L1RhcmdldEZyYW1ld29yaz4NCiAgICA8QXBwZW5kVGFyZ2V0RnJhbWV3b3JrVG9PdXRwdXRQYXRoPmZhbHNlPC9BcHBlbmRUYXJnZXRGcmFtZXdvcmtUb091dHB1dFBhdGg+DQogICAgPENvcHlMb2NhbExvY2tGaWxlQXNzZW1ibGllcz50cnVlPC9Db3B5TG9jYWxMb2NrRmlsZUFzc2VtYmxpZXM+DQogICA8T3V0cHV0UGF0aD5iaW4vRGVidWc8L091dHB1dFBhdGg+DQogIDwvUHJvcGVydHlHcm91cD4NCiAgPEl0ZW1Hcm91cD4NCiAgICA8UGFja2FnZVJlZmVyZW5jZSBJbmNsdWRlPSJPcGVuVEFQIiBWZXJzaW9uPSI5LjkuMCIgLz4NCiAgPC9JdGVtR3JvdXA+DQo8L1Byb2plY3Q+</Base64>
-      </String>
+      <String>&lt;Project Sdk="Microsoft.NET.Sdk"&gt;
+  &lt;PropertyGroup&gt;
+  &lt;TargetFrameworkIdentifier&gt;&lt;/TargetFrameworkIdentifier&gt;
+    &lt;TargetFrameworkVersion&gt;&lt;/TargetFrameworkVersion&gt;
+    &lt;TargetFramework&gt;netstandard2.0&lt;/TargetFramework&gt;
+    &lt;AppendTargetFrameworkToOutputPath&gt;false&lt;/AppendTargetFrameworkToOutputPath&gt;
+    &lt;CopyLocalLockFileAssemblies&gt;true&lt;/CopyLocalLockFileAssemblies&gt;
+   &lt;OutputPath&gt;bin/Debug&lt;/OutputPath&gt;
+  &lt;/PropertyGroup&gt;
+  &lt;ItemGroup&gt;
+    &lt;PackageReference Include="OpenTAP" Version="9.16.4" /&gt;
+  &lt;/ItemGroup&gt;
+&lt;/Project&gt;</String>
       <File>../../NewProj3/NewProj3.csproj</File>
       <Enabled>true</Enabled>
       <Name>Write {File}</Name>


### PR DESCRIPTION
It seems the 'tap package install' step does not always actually run in the test plan, which is causing the version check to fail because the dll actually containing the version was not installed.