### PR TITLE
Available values re-read issue

### DIFF
--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -249,12 +249,16 @@ namespace OpenTap.UnitTests
             
             a.Write();
             a.Read();
+            
+            // if we take the first element here, then previously updates would be lost after the first read. 
+            // - at least if reading from the point of view of an available values proxy.
             newelem = col.AnnotatedElements.FirstOrDefault();
             newelem.GetMember("State").Get<IStringValueAnnotation>().Value = "true";
             a.Write();
             a.Read();
             var selected = newelem.GetMember("SelectedInt").Get<IAvailableValuesAnnotationProxy>().SelectedValue; 
             var vals = newelem.GetMember("SelectedInt").Get<IAvailableValuesAnnotationProxy>().AvailableValues;
+            // verify that the available values corresponds to NestedObject.State = true;
             Assert.IsTrue(vals.Select(x => x.Source).SequenceEqual(obj.List2[0].Avail.Cast<object>()));
         }
 

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -1782,18 +1782,16 @@ namespace OpenTap
                     if (invalidated || (annotatedElements == null && Elements != null))
                     {
                         invalidated = false;
-                        List<AnnotationCollection> annotations = new List<AnnotationCollection>();
-                        foreach (var elem in Elements)
+                        if (annotatedElements != null && Elements.Cast<object>()
+                                .SequenceEqual(annotatedElements.Select(x => x.Source)))
                         {
-                            annotations.Add(fac.AnnotateSub(null, elem));
-                        }
-
-                        if (annotatedElements != null && annotations.Select(x => x.Source)
-                            .SequenceEqual(
-                                annotatedElements?.Select(x => x.Source)))
-                        {
+                            // The values has not changed. Don't create a new list of annotation, just re-use the old.
                             return annotatedElements;
                         }
+                        List<AnnotationCollection> annotations = new List<AnnotationCollection>();
+                        foreach (var elem in Elements)
+                            annotations.Add(fac.AnnotateSub(null, elem));
+                        
                         annotatedElements = annotations;
                     }
 


### PR DESCRIPTION


Closes  #378

A test has been added which verifies the issue, to test with the Editor UI, use a class like this:

Create a AvailableValuesAttributeExample2, add elements to the list and try configuring the values. 

Note that when Selected Value changes, the available values for Selected Value 2 does not change (which it should).


```cs
    public class AvailableValuesAttributeExample2 : TestStep
    {
        public AvailableValuesAttributeExample2()
        {
            ListOfObjects = new List<SomeListOfObjects>();
        }

        public class SomeListOfObjects : ValidatingObject
        {
            [Display("Available Values", "An editable list of values.")]
            public List<string> ListOfAvailableValues { get; private set; }

            [XmlIgnore]
            public IEnumerable<string> ListOfAvailableValues2
            {
                get
                {
                    switch (_selectedValue)
                    {
                        case "One":
                            return new[] { "A", "B", "C" };
                        case "Two":
                            return new[] { "D", "E", "F" };
                        case "Three":
                            return new[] { "G", "H", "I" };
                    }

                    return Array.Empty<string>();
                }
            }

            private string _selectedValue;

            [Display("Selected Value", "Shows the use of available values attribute.", Order: 10.1)]
            [AvailableValues(nameof(ListOfAvailableValues))]
            public string SelectedValue
            {
                get => _selectedValue;
                set => _selectedValue = value;
            }

            [Display("Selected Value 2", "Shows the use of available values attribute.", Order: 10.2)]
            [AvailableValues(nameof(ListOfAvailableValues2))]
            public string SelectedValue2 { get; set; }

            public SomeListOfObjects()
            {
                ListOfAvailableValues = new List<string> { "One", "Two", "Three" };
                SelectedValue = string.Empty;
            }
        }

        [Display("ListOfObjects", Order: 10.9)]
        public List<SomeListOfObjects> ListOfObjects { get; set; }


        public override void Run()
        {
            // Do nothing
        }
    }
```