### PR TITLE
Read SCPI Block with termination character included in the last char.

### DIFF
--- a/Engine/ScpiInstrument.cs
+++ b/Engine/ScpiInstrument.cs
@@ -599,11 +599,21 @@ namespace OpenTap
                     string lengthFieldText = LockRetry(() => ReadString(lengthFieldLength));
                     int length = int.Parse(lengthFieldText);
                     TerminationCharacterEnabled = false;
-                    string text = LockRetry(() => ReadString(length)) + TerminationCharacter;
+                    string text = LockRetry(() => ReadString(length));
+                    if (text.LastOrDefault() == TerminationCharacter)
+                    {
+                        // Do nothing, this is a hack to fix an issue with instruments including the termination
+                        // character as the last character in the block.
+                    }else
+                    {
+                        text += TerminationCharacter;
+                        // Read the terminating character to get it off the output buffer
+                        LockRetry(() => ReadString());    
+                    }
+                    
                     TerminationCharacterEnabled = true;
 
-                    // Read the terminating character to get it of the output buffer
-                    LockRetry(() => ReadString());
+                    
 
                     return text;
                 }


### PR DESCRIPTION
A hack was introduced to fix issues with instruments that includes the termination character in the bytes read from a IEEE Block.
In this case we should not wait for the last termination character as that has already been sent and doing so will cause in a timeout exception in the best case.