### PR TITLE
Update target framework to match Developer's System

### DIFF
--- a/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
+++ b/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
@@ -6,7 +6,7 @@
     <!-- If your plugin is Windows only and you use Windows specific API's, feel free to change "netstandard2.0" below to "net462" and everything will work as when you are debugging. In this case, remember to change "OS" in package.xml to only "windows" -->
     <!-- If your plugin should be cross platform but does not build in release mode, please verify that all API's you used are available. You might need references or nuget packages for API's that are available in NET framework, but not in NetStandard -->
     <OpenTapPackageDefinitionPath>package.xml</OpenTapPackageDefinitionPath>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This removes some warnings when building the SDK Examples projects that have started occurring after we changed the target framework in KS8400 from net462 to net472.

Closes #398 