### PR TITLE
If dependencyGraph does not specify an architecture, use the architec…

### DIFF
--- a/Package/DependencyResolver.cs
+++ b/Package/DependencyResolver.cs
@@ -154,8 +154,10 @@ namespace OpenTap.Package
             CpuArchitecture arch;
             if (archs.Count != 1)
             {
-                if (openTapPackage?.Architecture != null && openTapPackage.Architecture != CpuArchitecture.Unspecified)
+                if (openTapPackage?.Architecture != null && openTapPackage.Architecture != CpuArchitecture.Unspecified && openTapPackage.Architecture != CpuArchitecture.AnyCPU)
                     arch = openTapPackage.Architecture;
+                else if (InstalledPackages.ContainsKey("OpenTAP"))
+                    arch = InstalledPackages["OpenTAP"].Architecture;
                 else
                     arch = ArchitectureHelper.GuessBaseArchitecture;
             }


### PR DESCRIPTION
…ture of the installed OpenTAP package.

This fixes a bugs like this one: https://github.com/opentap/opentap/pull/410#issuecomment-1059005816