### PR TITLE
Add null check for resultListeners parameter

### DIFF
--- a/Engine/TestPlanRun.cs
+++ b/Engine/TestPlanRun.cs
@@ -454,10 +454,13 @@ namespace OpenTap
             Parameters.IncludeMetadataFromObject(plan);
 
             this.Verdict = Verdict.NotSet; // set Parameters before setting Verdict.
-            
-            foreach (var res in resultListeners)
+
+            if (resultListeners !=  null)
             {
-                AddResultListener(res);
+                foreach (var res in resultListeners)
+                {
+                    AddResultListener(res);
+                }
             }
 
             StartTime = startTime;


### PR DESCRIPTION
This null check was there in 9.16.4, but was removed in 9.17.

Closes #434 