### PR TITLE
Added CNAME file to public folder that gets committed to the pages repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,6 @@ jobs:
         working-directory: doc
       - name: Copy API
         run: cp -r API public/api
-      - name: Add CNAME
-        run: echo doc.opentap.io > ./public/CNAME
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
         working-directory: doc
       - name: Copy API
         run: cp -r API public/api
+      - name: Add CNAME
+        run: echo doc.opentap.io > ./public/CNAME
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: startsWith(github.ref, 'refs/tags/v')

--- a/doc/.vuepress/public/CNAME
+++ b/doc/.vuepress/public/CNAME
@@ -1,0 +1,1 @@
+doc.opentap.io


### PR DESCRIPTION
Github pages can be configured to use a custom domain (get a cert for that domain):

![image](https://user-images.githubusercontent.com/20689829/157346730-6ce0ac9d-1798-49e5-a5c1-6a67ec5848c1.png)

However, that setting just results a commit adding a CNAME file to the root of the git repo. Next time the CI pipeline publishes the pages, this file gets overwritten (see [here](https://github.com/opentap/opentap.github.io/commit/60cf887937615db27f47dfea8027aa7eb22d5e57#diff-76b26edb75578663ca0fd6515ec7880ca04046bdbab298938981c9f0bd3907dd)).

Instead of using that setting in the opentap/opentap.github.io repo, manually create the CNAME file in this repo, before committing.