### PR TITLE
449 Avoid Input to string blocking: fix

### DIFF
--- a/Engine/IStringConvertProvider.cs
+++ b/Engine/IStringConvertProvider.cs
@@ -165,7 +165,7 @@ namespace OpenTap
         static IEnumerable<IStringConvertProvider> Providers => StringConvertCacheOptimizer.GetValue();
         
         /// <summary>
-        /// Turn value to a string if an IStringConvertProvider plugin supports the value.
+        /// Turn value to a string if an IStringConvertProvider plugin supports the value. Returns null if the input value is null.
         /// </summary>
         /// <param name="value">The value to be converted to a string.</param>
         /// <param name="culture">If null, invariant culture is used.</param>

--- a/Engine/Input.cs
+++ b/Engine/Input.cs
@@ -3,7 +3,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Serialization;
@@ -166,22 +165,17 @@ namespace OpenTap
                 return (T)InputOutputRelation.GetOutput(Property, Step); 
             }
         }
-        
-        /// <summary>Constructor for the Input class.</summary>
-        public Input()
-        {
-            
-        }
 
+        T GetValueNonBlocking()
+        {
+            if (Step != null && Property?.GetValue(Step) is T v)
+                return v;
+            return default;
+        }
+        
         /// <summary> Converts the value of this instance to its equivalent string representation. </summary>
         /// <returns> The string representation of the value of this instance. </returns>
-        public override string ToString()
-        {
-            if (Step == null|| Property == null)
-                return "";
-            var value = Value == null ? "" : StringConvertProvider.GetString(Value);
-            return value ?? "";
-        }
+        public override string ToString() =>  StringConvertProvider.GetString(GetValueNonBlocking()) ?? "";
 
         /// <summary> Compares one Input to another. </summary>
         /// <param name="obj"></param>


### PR DESCRIPTION
Fixed that input.ToString could block and while this is fine for Value, we should avoid doing time consuming work inside a ToString implementation.