### PR TITLE
314 Change casing of UserID dir

### DIFF
--- a/Package.UnitTests/PackageManagerTests.cs
+++ b/Package.UnitTests/PackageManagerTests.cs
@@ -61,7 +61,7 @@ namespace OpenTap.Package.UnitTests
         [Test]
         public void TestUserId()
         {
-            var idPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTAP", "OpenTapGeneratedId");
+            var idPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTap", "OpenTapGeneratedId");
             string orgId = null;
             if (File.Exists(idPath))
                 orgId = File.ReadAllText(idPath);

--- a/Package/Repositories/HttpPackageRepository.cs
+++ b/Package/Repositories/HttpPackageRepository.cs
@@ -96,7 +96,7 @@ namespace OpenTap.Package
         Action<string, long, long> IPackageDownloadProgress.OnProgressUpdate { get; set; }
         internal static string GetUserId()
         {
-            var idPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTAP", "OpenTapGeneratedId");
+            var idPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTap", "OpenTapGeneratedId");
             string id = default(Guid).ToString(); // 00000000-0000-0000-0000-000000000000
 
             try

--- a/docker/Linux/Dockerfile
+++ b/docker/Linux/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod -R +w /opt/tap
 RUN chmod +x /opt/tap/tap
 ENV PATH="/opt/tap:${PATH}"
 ENV TAP_PATH="/opt/tap"
-RUN mkdir -p /root/.local/share/OpenTAP
+RUN mkdir -p /root/.local/share/OpenTap
 RUN echo 11111111-1111-1111-1111-111111111111 > /root/.local/share/OpenTap/OpenTapGeneratedId
 
 # Test TAP

--- a/docker/Linux/Dockerfile
+++ b/docker/Linux/Dockerfile
@@ -23,7 +23,7 @@ RUN chmod +x /opt/tap/tap
 ENV PATH="/opt/tap:${PATH}"
 ENV TAP_PATH="/opt/tap"
 RUN mkdir -p /root/.local/share/OpenTAP
-RUN echo 11111111-1111-1111-1111-111111111111 > /root/.local/share/OpenTAP/OpenTapGeneratedId
+RUN echo 11111111-1111-1111-1111-111111111111 > /root/.local/share/OpenTap/OpenTapGeneratedId
 
 # Test TAP
 RUN tap -h

--- a/docker/Windows/Dockerfile
+++ b/docker/Windows/Dockerfile
@@ -7,4 +7,4 @@ COPY OpenTAP.exe .
 RUN cmd /C "OpenTAP.exe /quiet /VERYSILENT"
 RUN cmd /C "setx PATH '%PATH%C:\Program Files\OpenTAP;'"
 RUN mkdir C:\Users\ContainerAdministrator\AppData\Local\OpenTAP
-RUN echo 11111111-1111-1111-1111-111111111111 > C:\Users\ContainerAdministrator\AppData\Local\OpenTAP\OpenTapGeneratedId
+RUN echo 11111111-1111-1111-1111-111111111111 > C:\Users\ContainerAdministrator\AppData\Local\OpenTap\OpenTapGeneratedId


### PR DESCRIPTION
This moves the 'OpenTapGeneratedId' into the same folder as the user-wide package cache on Linux, so the behavior is the same as on Windows.

This will cause Linux installations to get a new UserID, but this is not a huge issue. Runners and dockers get new images constantly, so this will make no difference.

The issue never existed on Windows because paths are not case sensitive. 

Closes #314 