### PR TITLE
Win: Revert tap.exe to .net 462

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           #Copy-Item .\bin\Release\runtimes\win-x64\native\git2-b7bad55.dll .\bin\Release
-          dotnet vstest bin/Release/OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed"
+          dotnet vstest bin/Release/OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" /Platform:x64
       - uses: actions/upload-artifact@v2
         with:
           name: win-testresults
@@ -639,8 +639,9 @@ jobs:
           # package.xml, tap.dll, and tap.runtimeconfig.json of an installation should always come from 
           # one of the Runtime directories. Delete it from the payload directory.
           Remove-Item ./nuget/build/payload/Packages/OpenTAP/package.xml
-          Remove-Item ./nuget/build/payload/tap.dll
-          Remove-Item ./nuget/build/payload/tap.runtimeconfig.json
+          # these files only exists when building for net6.0.
+          #Remove-Item ./nuget/build/payload/tap.dll
+          #Remove-Item ./nuget/build/payload/tap.runtimeconfig.json
 
           Move-Item ./bin/Release/OpenTap.Package.xml ./nuget/build/payload
           Move-Item ./bin/Release/OpenTap.xml ./nuget/build/payload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Restore
         #if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          dotnet restore
+          dotnet restore /p:Platform=${{ matrix.Architecture }}
       - name: Build
         run: |
           dotnet build --no-restore -c Release /p:Platform=${{ matrix.Architecture }}
@@ -286,7 +286,7 @@ jobs:
       - name: Test
         run: |
           $ErrorActionPreference = "Stop"
-          Copy-Item .\bin\Release\runtimes\win-x64\native\git2-b7bad55.dll .\bin\Release
+          #Copy-Item .\bin\Release\runtimes\win-x64\native\git2-b7bad55.dll .\bin\Release
           dotnet vstest bin/Release/OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed"
       - uses: actions/upload-artifact@v2
         with:
@@ -413,7 +413,8 @@ jobs:
           $env:Platform = "Windows"
           $env:Architecture =  "${{ matrix.Architecture }}"
           cd bin/Release-x64
-          cp .\runtimes\win-x64\native\git2-b7bad55.dll .
+          # this is only needed for .net6 
+          #cp .\runtimes\win-x64\native\git2-b7bad55.dll .
           .\tap.exe package install -f ../../sign.TapPackage
           echo "${{ secrets.SIGN_SERVER_CERT }}" > $env:TAP_SIGN_CERT
           $version=$(./tap sdk gitversion)
@@ -532,7 +533,7 @@ jobs:
           $env:Platform = "Windows"
           cd bin/Release
           Remove-Item -Recurse -Force ./Packages
-          cp .\runtimes\win-x64\native\git2-b7bad55.dll .
+          #cp .\runtimes\win-x64\native\git2-b7bad55.dll .
           .\tap.exe package create ../../package.xml --install -v -c
           Copy-Item "../../sdk/Examples" "Packages/SDK/Examples" -Recurse
           Copy-Item "../../Package/PackageSchema.xsd" "Packages/SDK/PackageSchema.xsd"
@@ -624,7 +625,7 @@ jobs:
           path: .
       - name: Package
         run: |
-          cp bin\Release\runtimes\win-x64\native\git2-b7bad55.dll bin\Release
+          #cp bin\Release\runtimes\win-x64\native\git2-b7bad55.dll bin\Release
           ./bin/Release/tap sdk gitversion --replace ./nuget/OpenTAP.nuspec --fields 4
           New-Item -Force ./nuget/build/payload -ItemType Directory | Out-Null
           # Expand-Archive will only extract .zip extensions    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,12 +287,13 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           #Copy-Item .\bin\Release\runtimes\win-x64\native\git2-b7bad55.dll .\bin\Release
-          dotnet vstest /framework:.NETFramework,Version=v4.62 /Platform:x64 bin/Release/OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" 
+          cd bin/Release
+          dotnet vstest /framework:.NETFramework,Version=v4.62 /Platform:x64 OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" 
       - uses: actions/upload-artifact@v2
         with:
           name: win-testresults
           path: |
-            TestResult.xml
+            bin/Release/TestResult.xml
 
   TestWindowsPlan:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           #Copy-Item .\bin\Release\runtimes\win-x64\native\git2-b7bad55.dll .\bin\Release
-          dotnet vstest bin/Release/OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" /Platform:x64
+          dotnet vstest /framework:.NETFramework,Version=v4.62 /Platform:x64 bin/Release/OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" 
       - uses: actions/upload-artifact@v2
         with:
           name: win-testresults

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,6 +121,7 @@ QuickTest: # Quick test to fail as early as possible.
     # We need to build twice because 'gitversion' requires tap..
     # Netcore apps require that the 32-bit runtime is used to run a 32-bit app (though targetting that runtime is not a problem)
     # There is no 32-bit windows server .NET6 docker image. Target x64 first to get access to gitversion.
+    - dotnet restore /p:Platform=x64
     - dotnet build -c Release /p:Platform=x64
     - cp bin\Release\runtimes\win-x64\native\git2-4aecb64.dll bin\Release
     - $AssemblyVersion = "`"$(bin/Release/tap sdk gitversion --fields 3).0`""
@@ -139,7 +140,7 @@ QuickTest: # Quick test to fail as early as possible.
     # Now we actually build for the target architecture.
     - dotnet build -c Release /p:Platform=$Architecture
     - dotnet build tap/tap.csproj -c Release /p:Platform=$Architecture
-    - get-content ./bin/Release/tap.runtimeconfig.json
+    #- get-content ./bin/Release/tap.runtimeconfig.json
     - Remove-Item -recurse "bin\Release\Packages"
   artifacts:
     expire_in: 1 week
@@ -479,8 +480,9 @@ Package-NuGet:
     # package.xml, tap.dll, and tap.runtimeconfig.json of an installation should always come from 
     # one of the Runtime directories. Delete it from the payload directory.
     - Remove-Item ./nuget/build/payload/Packages/OpenTAP/package.xml
-    - Remove-Item ./nuget/build/payload/tap.dll
-    - Remove-Item ./nuget/build/payload/tap.runtimeconfig.json
+    ## .net 462: These are not included.
+    #- Remove-Item ./nuget/build/payload/tap.dll
+    #- Remove-Item ./nuget/build/payload/tap.runtimeconfig.json
     
     - Move-Item ./bin/Release/OpenTap.Package.xml ./nuget/build/payload
     - Move-Item ./bin/Release/OpenTap.xml ./nuget/build/payload

--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 9.17.3
+version = 9.17.4
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,17 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <IsDebug>false</IsDebug>
+    <OpenTapAppTargetFramework>net6.0</OpenTapAppTargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworkIdentifier></TargetFrameworkIdentifier>
+    <TargetFrameworkVersion></TargetFrameworkVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OS)' != 'Unix'">
+    <!-- .net462 revert: on windows we build -->   
+    <OpenTapAppTargetFramework>net462</OpenTapAppTargetFramework>
+  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <IsDebug>true</IsDebug>
   </PropertyGroup>
@@ -26,12 +35,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <TargetFrameworkIdentifier></TargetFrameworkIdentifier>
-    <TargetFrameworkVersion></TargetFrameworkVersion>
   </PropertyGroup>
 
   <Target Name="RemoveSatelliteAssemblies" AfterTargets="ResolveAssemblyReferences">

--- a/Engine.UnitTests/SerializerTest.cs
+++ b/Engine.UnitTests/SerializerTest.cs
@@ -2573,7 +2573,7 @@ namespace OpenTap.Engine.UnitTests
             var str = ser.SerializeToString(x);
             Assert.IsFalse(ser.XmlErrors.Any());
             var str2 = @"<?xml version=""1.0"" encoding=""utf-8""?>
-                <EnabledOfEnabledOfEnabledOfInt32 type=""OpenTap.Enabled`1[[OpenTap.Enabled`1[[OpenTap.Enabled`1[[System.Int32, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], OpenTap, Version=9.4.0.0, Culture=neutral, PublicKeyToken=null]], OpenTap, Version=9.4.0.0, Culture=neutral, PublicKeyToken=null]]"">
+                <EnabledOfEnabledOfEnabledOfInt32 type=""OpenTap.Enabled`1[[OpenTap.Enabled`1[[OpenTap.Enabled`1[[System.Int32]], OpenTap, Version=9.4.0.0, Culture=neutral, PublicKeyToken=null]], OpenTap, Version=9.4.0.0, Culture=neutral, PublicKeyToken=null]]"">
                 <Value>
                 <Value>
                 <Value>abc</Value>

--- a/Engine.UnitTests/Tap.Engine.UnitTests.csproj
+++ b/Engine.UnitTests/Tap.Engine.UnitTests.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Engine.UnitTests/Tap.Engine.UnitTests.csproj
+++ b/Engine.UnitTests/Tap.Engine.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>OpenTap.UnitTests</AssemblyName>
     <RootNamespace>OpenTap.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(OpenTapAppTargetFramework)</TargetFramework>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   

--- a/Engine.UnitTests/TestPlanRunnerTests.cs
+++ b/Engine.UnitTests/TestPlanRunnerTests.cs
@@ -135,7 +135,7 @@ namespace OpenTap.Engine.UnitTests
             }
             catch(ArgumentNullException ex)
             {
-                Assert.AreEqual($"Value cannot be null. (Parameter 'plan')", ex.Message);
+                Assert.IsTrue(ex.Message.Contains("Value cannot be null") && ex.Message.Contains("Parameter") && ex.Message.Contains("plan"));
                 argumentNullExceptionCaught = true;
             }
             

--- a/Package.UnitTests/PackageDefTests.cs
+++ b/Package.UnitTests/PackageDefTests.cs
@@ -249,7 +249,7 @@ namespace OpenTap.Package.UnitTests
                     File.Delete(outputFilename);
             }
         }
-
+#if NET6_0
         [Test]
         public void CreatePackageVersioningMono()
         {
@@ -274,7 +274,7 @@ namespace OpenTap.Package.UnitTests
             Assert.AreEqual("0.1.2", FileVersionInfo.GetVersionInfo(tmpFile).ProductVersion, "GetVersionInfo().ProductVersion");
             Assert.AreEqual("0.1.2", FileSystemHelper.GetAssemblyVersion(tmpFile), "FileSystemHelper.GetAssemblyVersion");
         }
-
+#endif
         [Test]
         public void CreatePackageDepVersions()
         {

--- a/Package.UnitTests/PdbFixupTest.cs
+++ b/Package.UnitTests/PdbFixupTest.cs
@@ -17,9 +17,6 @@ namespace OpenTap.Package.UnitTests
             var xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
 <Package Name=""TestPackage""   Version=""1.0.0"" OS=""{OperatingSystem.Current}"" Architecture=""x64"">
     <Files>
-         <File Path=""tap.dll"">
-            <SetAssemblyInfo Attributes=""Version"" />
-        </File>
         <File Path=""OpenTap.dll"">
             <SetAssemblyInfo Attributes=""Version"" />
         </File>
@@ -44,7 +41,7 @@ namespace OpenTap.Package.UnitTests
             var outFile = Path.GetTempFileName();
             
             var files = new string[]
-                { "tap", "OpenTap.Package", "OpenTap.Plugins.BasicSteps", "OpenTap.Cli" };
+                { "OpenTap.Package", "OpenTap.Plugins.BasicSteps", "OpenTap.Cli" };
 
             var create = new PackageCreateAction()
             {

--- a/Package.UnitTests/Tap.Package.UnitTests.csproj
+++ b/Package.UnitTests/Tap.Package.UnitTests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Package.UnitTests/Tap.Package.UnitTests.csproj
+++ b/Package.UnitTests/Tap.Package.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>    
     <AssemblyName>OpenTap.Package.UnitTests</AssemblyName>
     <RootNamespace>OpenTap.Package.UnitTests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(OpenTapAppTargetFramework)</TargetFramework>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
   

--- a/Tap.Upgrader/Program.cs
+++ b/Tap.Upgrader/Program.cs
@@ -119,8 +119,9 @@ namespace Tap.Upgrader
             new UpgradePair("../../tap.exe.new", "../../tap.exe", true),
             // this file is part of the payload for OpenTAP 9.17 and later
             new UpgradePair("tap.exe.new", "../../tap.exe", false),
-            // this file is written when installing any version of OpenTAP with OpenTAP 9.17 or later
-            new UpgradePair("../../tap.dll.new", "../../tap.dll", true),
+            // .net462 no tap.dll exists.
+            //// this file is written when installing any version of OpenTAP with OpenTAP 9.17 or later
+            //new UpgradePair("../../tap.dll.new", "../../tap.dll", true),
         };
 
         static Dictionary<string, string> parseArgs(string[] args)

--- a/nuget/NugetPackager.ps1
+++ b/nuget/NugetPackager.ps1
@@ -44,8 +44,9 @@ $packageXml = Get-ChildItem -File -Recurse package.xml | Resolve-Path -Relative 
 CopyPreserveRelativePath $packageXml $runtimeDir
 
 CopyPreserveRelativePath ./tap.exe  $runtimeDir
-CopyPreserveRelativePath ./tap.dll $runtimeDir
-CopyPreserveRelativePath ./tap.runtimeconfig.json $runtimeDir
+# .net462 revert:
+#CopyPreserveRelativePath ./tap.dll $runtimeDir
+#CopyPreserveRelativePath ./tap.runtimeconfig.json $runtimeDir
 
 $git2dll = Get-ChildItem -File -Recurse *git2-*.dll.x86 | Resolve-Path -Relative | Select-Object -First 1
 CopyPreserveRelativePath $git2dll $runtimeDir
@@ -59,8 +60,9 @@ $packageXml = Get-ChildItem -File -Recurse package.xml | Resolve-Path -Relative 
 CopyPreserveRelativePath $packageXml $runtimeDir
 
 CopyPreserveRelativePath ./tap.exe  $runtimeDir
-CopyPreserveRelativePath ./tap.dll $runtimeDir
-CopyPreserveRelativePath ./tap.runtimeconfig.json $runtimeDir
+# .net462 revert:
+#CopyPreserveRelativePath ./tap.dll $runtimeDir
+#CopyPreserveRelativePath ./tap.runtimeconfig.json $runtimeDir
 
 $git2dll = Get-ChildItem -File -Recurse *git2-*.dll.x64 | Resolve-Path -Relative | Select-Object -First 1
 CopyPreserveRelativePath $git2dll $runtimeDir

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,8 @@
     <Owner>OpenTAP</Owner>
     <!-- Common files  -->
     <Files Condition="$(Debug) == false">
-        <File Path="tap.runtimeconfig.json"/>
-        <File Path="tap.dll">
+        <File  Condition="$(Platform) != Windows" Path="tap.runtimeconfig.json"/>
+        <File Condition="$(Platform) != Windows" Path="tap.dll">
             <SetAssemblyInfo Attributes="Version" />
             <Sign Certificate="Keysight Technologies, Inc" Condition="$(Sign)==true"/>
         </File>
@@ -41,9 +41,9 @@
     </Files>
     <!-- For debug builds. Includes debugging symbols and puts all the DLLs in the OpenTAP root directory.  -->
     <Files Condition="$(Debug) == true">
-        <File Path="tap.runtimeconfig.json"/>
-        <File Path="tap.dll"/>
-        <File Path="tap.pdb"/>
+        <File Condition="$(Platform) != Windows" Path="tap.runtimeconfig.json"/>
+        <File Condition="$(Platform) != Windows" Path="tap.dll"/>
+        <File Path="tap.pdb"/>  
         <File Path="OpenTap.dll"/>
         <File Path="OpenTap.pdb"/>
         <File Path="OpenTap.Package.dll"/>

--- a/tap/tap.csproj
+++ b/tap/tap.csproj
@@ -5,7 +5,7 @@
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
     <ApplicationIcon>../Installer/Assets/opentap.ico</ApplicationIcon>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(OpenTapAppTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
for builds targeting windows we now build for .net 462.

This avoids some incompatibility issues we encountered as we migrated to .net 6.0

Closes #472