### PR TITLE
508-externalParameterDeserializeError

### DIFF
--- a/Engine.UnitTests/SerializerTest.cs
+++ b/Engine.UnitTests/SerializerTest.cs
@@ -1669,6 +1669,7 @@ namespace OpenTap.Engine.UnitTests
 
             public override void Run()
             {
+                throw new NotImplementedException();
             }
         }
 
@@ -1689,11 +1690,10 @@ namespace OpenTap.Engine.UnitTests
             using (var ms = new MemoryStream())
             {
                 plan.Save(ms);
-                ms.Seek(0, SeekOrigin.Begin);
+                ms.Position = 0;
                 plan = TestPlan.Load(ms, "test.tapplan", false, serializer);
             }
             Assert.IsTrue(serializer.Errors.Any() == fail);
-            plan.Execute();
         }
 
         [Test]
@@ -2447,10 +2447,18 @@ namespace OpenTap.Engine.UnitTests
         [Test]
         public void NullInstrumentTest()
         {
-             object outValue = new ObjectCloner(null).Clone(true, null, TypeData.FromType(typeof(ScpiInstrument)));
-             Assert.IsNull(outValue);
+            object outValue = new ObjectCloner(null).Clone(true, null, TypeData.FromType(typeof(ScpiInstrument)));
+            Assert.IsNull(outValue);
         }
-        
+
+        [Test]
+        public void NullValueTypeTest()
+        {
+            Assert.Throws<InvalidCastException>(() => new ObjectCloner("asd").Clone(true, 1, TypeData.FromType(typeof(int))));
+            Assert.Throws<InvalidCastException>(() => new ObjectCloner("").Clone(true, 1, TypeData.FromType(typeof(int))));
+            Assert.DoesNotThrow(() => new ObjectCloner("123").Clone(true, 1, TypeData.FromType(typeof(int))));
+        }
+
         public class InPlaceProperty : ValidatingObject
         {
             int x;

--- a/Engine.UnitTests/TypeDataTest.cs
+++ b/Engine.UnitTests/TypeDataTest.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenTap.UnitTests
+{
+    public class TypeDataTest
+    {
+        public class IntObject
+        {
+            public int SomeInt { get; set; }
+        }
+
+        [Test]
+        public void SettingPropertyToInvalidType()
+        {
+            var obj = new IntObject();
+            var typeData = TypeData.GetTypeData(obj);
+            var memberData = typeData.GetMember(nameof(IntObject.SomeInt));
+            Assert.DoesNotThrow(() => memberData.SetValue(obj, 123));
+            // PropertyInfo.SetValue(xx, null) does not throw an exception for value types.
+            // https://docs.microsoft.com/de-de/dotnet/api/system.reflection.propertyinfo.setvalue
+            Assert.DoesNotThrow(() => memberData.SetValue(obj, null));
+        }
+    }
+}

--- a/Engine/ObjectCloner.cs
+++ b/Engine/ObjectCloner.cs
@@ -81,15 +81,21 @@ namespace OpenTap
                     clone = null;
                     return false;
                 }
+            }else if(skipIfPossible && typeOfValue.DescendsTo(targetType))
+            {
+                clone = value;
+                return true;
             }
-
             clone = value;
             return false;
         }
 
         public object Clone(bool skipIfPossible, object context, ITypeData targetType)
         {
-            TryClone(context, targetType, skipIfPossible, out var clone);
+            if (TryClone(context, targetType, skipIfPossible, out var clone) == false)
+            {
+                throw new InvalidCastException($"Failed cloning {value} as {targetType.Name}.");
+            }
             return clone;
         }
     }

--- a/OpenTAP.sln
+++ b/OpenTAP.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30413.136
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32414.318
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{B2B5AFDA-56F7-49AA-8615-4640581242A3}"
 	ProjectSection(SolutionItems) = preProject
@@ -17,6 +17,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tap.Engine", "Engine\Tap.Engine.csproj", "{1856EE05-7D06-4805-A9D6-1DAD2DD3034E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tap.Engine.UnitTests", "Engine.UnitTests\Tap.Engine.UnitTests.csproj", "{4FC25C4A-F7ED-4329-B1FD-624E67DA09AA}"
+	ProjectSection(ProjectDependencies) = postProject
+		{C2C29219-4ED1-4197-85BB-BBD96286686F} = {C2C29219-4ED1-4197-85BB-BBD96286686F}
+		{1EB4D48C-5719-483D-82DE-017F6B1634E6} = {1EB4D48C-5719-483D-82DE-017F6B1634E6}
+	EndProjectSection
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Tap.Shared", "Shared\Tap.Shared.shproj", "{11C58BD2-45E5-4A19-AE43-073B689FDB43}"
 EndProject
@@ -32,7 +36,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTap.Sdk.MSBuild", "sdk\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTap.Sdk.New", "sdk\OpenTap.Sdk.New\OpenTap.Sdk.New.csproj", "{02302CA3-FD57-477D-B469-08EEDFAC9827}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tap.Upgrader", "Tap.Upgrader\Tap.Upgrader.csproj", "{AB89A17A-29D0-4264-9D38-B9E5A8E8906B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tap.Upgrader", "Tap.Upgrader\Tap.Upgrader.csproj", "{AB89A17A-29D0-4264-9D38-B9E5A8E8906B}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution


### PR DESCRIPTION
Added test to prove the issue
Added other tests to TypeData, aswell as ObjectCloner.Clone
ObjectCloner.Clone has been updated to throw an InvalidCastException if TryClone returns false.
ObjectCloner.TryClone has been fixed so it can skip serialization and still succeed the cloning if the value is assignable to the targetType.