### PR TITLE
209-parallelDeadlock

### DIFF
--- a/Engine.UnitTests/InputTest.cs
+++ b/Engine.UnitTests/InputTest.cs
@@ -139,6 +139,28 @@ namespace OpenTap.Engine.UnitTests
             }
         }
 
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(10)]
+        public void ParallelIfVerdictDeadlock(int n)
+        {
+            var plan = new TestPlan();
+            ParallelStep parallelStep = new ParallelStep();
+            plan.Steps.Add(parallelStep);
+            for (int i = 1; i < n; i++)
+            {
+                var step = new ParallelStep();
+                parallelStep.ChildTestSteps.Add(step);
+                parallelStep = step;
+            }
+            var ifVerdictStep = new IfStep();
+            parallelStep.ChildTestSteps.Add(ifVerdictStep);
+            ifVerdictStep.InputVerdict.Step = parallelStep;
+            ifVerdictStep.InputVerdict.Property = TypeData.GetTypeData(parallelStep).GetMember(nameof(parallelStep.Verdict));
+            
+            Assert.AreEqual(plan.Execute().Verdict, Verdict.Error);
+        }
+
         [Test]
         public void RepeatVerdictTest()
         {

--- a/Engine/InputOutputRelation.cs
+++ b/Engine/InputOutputRelation.cs
@@ -189,7 +189,7 @@ namespace OpenTap
             {
                 TestStepRun run = ResolveStepRun(step);  
                 if (run != null)
-                    run.WaitForOutput(avail);
+                    run.WaitForOutput(avail, step);
             }
 
             return outputMember.GetValue(outputObject);

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -844,6 +844,7 @@ namespace OpenTap
                 step.Verdict = newVerdict;
         }
 
+        /// <summary> This is the currently executing test step or null, used to detect deadlock when a step is waiting for its parent. </summary>
         [ThreadStatic]
         internal static ITestStep currentlyExecutingTestStep = null;
 

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -844,6 +844,9 @@ namespace OpenTap
                 step.Verdict = newVerdict;
         }
 
+        [ThreadStatic]
+        internal static ITestStep currentlyExecutingTestStep = null;
+
         internal static TestStepRun DoRun(this ITestStep Step, TestPlanRun planRun, TestRun parentRun, IEnumerable<ResultParameter> attachedParameters = null)
         {
             {
@@ -868,6 +871,8 @@ namespace OpenTap
                 TestStepPath = Step.GetStepPath(),
             };
 
+            var previouslyExecutingTestStep = currentlyExecutingTestStep;
+            currentlyExecutingTestStep = Step;
             var stepPath = stepRun.TestStepPath;
             //Raise an event prior to starting the actual run of the TestStep. 
             Step.OfferBreak(stepRun, true);
@@ -905,6 +910,7 @@ namespace OpenTap
                     finally
                     {
                         planRun.AddTestStepStateUpdate(stepRun.TestStepId, stepRun, StepState.Deferred);
+                        currentlyExecutingTestStep = previouslyExecutingTestStep;
                     }
                 }
                 finally

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -349,12 +349,14 @@ namespace OpenTap
                 case OutputAvailability.BeforeRun: 
                     return;
                 case OutputAvailability.AfterDefer:
-                    if ((StepThread == currentThread && runDone.Wait(0) == false) || IsStepChildOf(currentStep, waitingFor))
+                    if ((StepThread == currentThread && runDone.Wait(0) == false) ||
+                        (currentStep != null && IsStepChildOf(currentStep, waitingFor)))
                         throw new Exception("Deadlock detected");
                     deferDone.Wait(TapThread.Current.AbortToken);
                     break; 
                 case OutputAvailability.AfterRun:
-                    if ((StepThread == currentThread && runDone.Wait(0) == false) || IsStepChildOf(currentStep, waitingFor))
+                    if ((StepThread == currentThread && runDone.Wait(0) == false) ||
+                        (currentStep != null && IsStepChildOf(currentStep, waitingFor)))
                         throw new Exception("Deadlock detected");
                     runDone.Wait(TapThread.Current.AbortToken);
                     break;


### PR DESCRIPTION
Added deadlock detection for when a childstep is waiting for one of its parent steps.
Added unit tests with 1,2 and 10 levels of parallel nesting.

Closes #209