### PR TITLE
Create lock directory if it is missing.

### DIFF
--- a/Package/PackageActions/LockingPackageAction.cs
+++ b/Package/PackageActions/LockingPackageAction.cs
@@ -94,7 +94,9 @@ namespace OpenTap.Package
                 FileSystemHelper.EnsureDirectory(Target);
             }
 
-            using var fileLock = FileLock.Create(Path.Combine(Target, ".lock"));
+            var lockfile = Path.Combine(Target, ".lock");
+            FileSystemHelper.EnsureDirectory(lockfile);
+            using var fileLock = FileLock.Create(lockfile);
             bool useLocking = Unlocked == false;
             if (useLocking && !fileLock.WaitOne(0))
             {

--- a/Package/PackageInstallHelpers/FileLocks.cs
+++ b/Package/PackageInstallHelpers/FileLocks.cs
@@ -19,7 +19,6 @@ namespace OpenTap.Package.PackageInstallHelpers
     {
         public static IFileLock Create(string file)
         {
-            FileSystemHelper.EnsureDirectory(file);
             if (OperatingSystem.Current == OperatingSystem.Windows) return new Win32FileLock(file);
             if (OperatingSystem.Current == OperatingSystem.MacOS) return new MacOSFileLock(file);
             return new PosixFileLock(file);

--- a/Package/PackageInstallHelpers/FileLocks.cs
+++ b/Package/PackageInstallHelpers/FileLocks.cs
@@ -19,6 +19,7 @@ namespace OpenTap.Package.PackageInstallHelpers
     {
         public static IFileLock Create(string file)
         {
+            FileSystemHelper.EnsureDirectory(file);
             if (OperatingSystem.Current == OperatingSystem.Windows) return new Win32FileLock(file);
             if (OperatingSystem.Current == OperatingSystem.MacOS) return new MacOSFileLock(file);
             return new PosixFileLock(file);


### PR DESCRIPTION
flock would throw an exception if the directory containing the lock file was missing.

Closes #528 