### PR TITLE
i502-PackageCreateOutDirectory

### DIFF
--- a/Package/PackageActions/Create.cs
+++ b/Package/PackageActions/Create.cs
@@ -159,16 +159,15 @@ namespace OpenTap.Package
                     {
                         var path = outputPath;
 
-                        if (String.IsNullOrEmpty(path))
+                        if (String.IsNullOrEmpty(path) || path.EndsWith(Path.DirectorySeparatorChar.ToString()) || path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
                         {
-                            path = GetRealFilePathFromName(pkg.Name, pkg.Version.ToString(), DefaultEnding);
                             // Package names support path separators now -- avoid writing the newly created package into a nested folder and
                             // replace the path separators with dots instead
-                            path = path.Replace('/', '.');
+                            var name = pkg.Name.Replace(Path.DirectorySeparatorChar, '.').Replace(Path.AltDirectorySeparatorChar, '.');
+                            path = Path.Combine(path, GetRealFilePathFromName(name, pkg.Version.ToString(), DefaultEnding));
                         }
 
                         Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)));
-
                         ProgramHelper.FileCopy(tmpFile, path);
                         log.Info("OpenTAP plugin package '{0}' containing '{1}' successfully created.", path, pkg.Name);
                     }

--- a/tests/package-create-error.TapPlan
+++ b/tests/package-create-error.TapPlan
@@ -9,8 +9,7 @@
       <BreakConditions>Inherit</BreakConditions>
     </TestStep>
     <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.WriteFileStep" Version="0.0.0" Id="45f82fc0-8acf-41b2-8472-2c1b9db25f32">
-        <String>
-            &lt;Project Sdk="Microsoft.NET.Sdk"&gt;
+      <String>&lt;Project Sdk="Microsoft.NET.Sdk"&gt;
                 &lt;PropertyGroup&gt;
                     &lt;TargetFrameworkIdentifier&gt;&lt;/TargetFrameworkIdentifier&gt;
                     &lt;TargetFrameworkVersion&gt;&lt;/TargetFrameworkVersion&gt;
@@ -24,8 +23,7 @@
                     &lt;PackageReference Include="SSH.NET" Version="2020.0.0"/&gt;
                     &lt;OpenTapPackageReference Include="SSH" Version="0.3.0-beta.8" Repository="packages.opentap.io" /&gt;
                 &lt;/ItemGroup&gt;
-           &lt;/Project&gt;
-        </String>
+           &lt;/Project&gt;</String>
       <File>../../NewProj/NewProj.csproj</File>
       <Enabled>true</Enabled>
       <Name>Write {File}</Name>
@@ -157,7 +155,7 @@
       <ChildTestSteps>
         <TestStep type="OpenTap.Plugins.BasicSteps.ProcessStep" Version="9.4.0-Development" Id="f63f9625-b293-4240-b75d-29183ae2b290">
           <Application>tap</Application>
-          <Arguments>package create ../../package.xml</Arguments>
+          <Arguments>package create ../../package.xml --out ../</Arguments>
           <WorkingDirectory>../../NewProj/bin/Debug</WorkingDirectory>
           <WaitForEnd>true</WaitForEnd>
           <Timeout>0</Timeout>
@@ -211,4 +209,9 @@
     </TestStep>
   </Steps>
   <BreakConditions>Inherit</BreakConditions>
+  <OpenTap.Description />
+  <Package.Dependencies>
+    <Package Name="OpenTAP" Version="^9.18.0-alpha.7.2+aa5cfdec.502-PackageCreateOutDirectory" />
+    <Package Name="FakePackageReferencingFile" Version="^3.4.5" />
+  </Package.Dependencies>
 </TestPlan>

--- a/tests/package-create-error.TapPlan
+++ b/tests/package-create-error.TapPlan
@@ -148,6 +148,41 @@
       <ChildTestSteps />
       <BreakConditions>Inherit</BreakConditions>
     </TestStep>
+    <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.ExpectStep" Version="0.0.0" Id="e00535ae-8152-4ee1-ab61-f14ed3f4d12d">
+      <ExpectedVerdict>Pass</ExpectedVerdict>
+      <Enabled>true</Enabled>
+      <Name>Expect {ExpectedVerdict}</Name>
+      <ChildTestSteps>
+        <TestStep type="OpenTap.Plugins.BasicSteps.ProcessStep" Version="9.4.0-Development" Id="68e9af36-4263-4370-bf79-d5671ac8bf5e">
+          <Application>tap</Application>
+          <Arguments>package create ../../package.xml</Arguments>
+          <WorkingDirectory>../../NewProj/bin/Debug</WorkingDirectory>
+          <WaitForEnd>true</WaitForEnd>
+          <Timeout>0</Timeout>
+          <AddToLog>true</AddToLog>
+          <LogHeader />
+          <CheckExitCode>true</CheckExitCode>
+          <RegularExpressionPattern>
+            <Value>(.*)</Value>
+            <IsEnabled>false</IsEnabled>
+          </RegularExpressionPattern>
+          <VerdictOnMatch>Error</VerdictOnMatch>
+          <VerdictOnNoMatch>NotSet</VerdictOnNoMatch>
+          <ResultRegularExpressionPattern>
+            <Value>(.*)</Value>
+            <IsEnabled>false</IsEnabled>
+          </ResultRegularExpressionPattern>
+          <ResultName>Regex Result</ResultName>
+          <Behavior>GroupsAsDimensions</Behavior>
+          <DimensionTitles></DimensionTitles>
+          <Enabled>true</Enabled>
+          <Name>Run: {Application} {Command Line Arguments}</Name>
+          <ChildTestSteps />
+          <BreakConditions>Inherit</BreakConditions>
+        </TestStep>
+      </ChildTestSteps>
+      <BreakConditions>Inherit</BreakConditions>
+    </TestStep>
     <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.ExpectStep" Version="0.0.0" Id="83f384d0-fbef-4fcb-8024-282e2304b1c0">
       <ExpectedVerdict>Pass</ExpectedVerdict>
       <Enabled>true</Enabled>
@@ -209,9 +244,4 @@
     </TestStep>
   </Steps>
   <BreakConditions>Inherit</BreakConditions>
-  <OpenTap.Description />
-  <Package.Dependencies>
-    <Package Name="OpenTAP" Version="^9.18.0-alpha.7.2+aa5cfdec.502-PackageCreateOutDirectory" />
-    <Package Name="FakePackageReferencingFile" Version="^3.4.5" />
-  </Package.Dependencies>
 </TestPlan>


### PR DESCRIPTION
Allows specifying an out directory by trailing the --out parameter of package create with a '/' or '\\' depending on the platform.
This will then create a package in the specified folder with the default package name.
Fixing issue #502 
## Testing
Modified a testplan step to include an out parameter with a directory.