### PR TITLE
317 invalidate non alpha numeric chars for identifiers

### DIFF
--- a/sdk/OpenTap.Sdk.New/GeneratePlugin.cs
+++ b/sdk/OpenTap.Sdk.New/GeneratePlugin.cs
@@ -23,7 +23,7 @@ namespace OpenTap.Sdk.New
 
         public override int Execute(CancellationToken cancellationToken)
         {
-            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false))
+            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false, allowAlphaNumericOnly: true))
             {
                 return (int)ExitCodes.ArgumentError;
             }
@@ -47,7 +47,7 @@ namespace OpenTap.Sdk.New
 
         public override int Execute(CancellationToken cancellationToken)
         {
-            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false))
+            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false, allowAlphaNumericOnly: true))
             {
                 return (int)ExitCodes.ArgumentError;
             }
@@ -70,7 +70,7 @@ namespace OpenTap.Sdk.New
 
         public override int Execute(CancellationToken cancellationToken)
         {
-            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false))
+            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false, allowAlphaNumericOnly: true))
             {
                 return (int)ExitCodes.ArgumentError;
             }
@@ -93,7 +93,7 @@ namespace OpenTap.Sdk.New
 
         public override int Execute(CancellationToken cancellationToken)
         {
-            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false))
+            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false, allowAlphaNumericOnly: true))
             {
                 return (int)ExitCodes.ArgumentError;
             }
@@ -116,7 +116,7 @@ namespace OpenTap.Sdk.New
 
         public override int Execute(CancellationToken cancellationToken)
         {
-            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false))
+            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false, allowAlphaNumericOnly: true))
             {
                 return (int)ExitCodes.ArgumentError;
             }
@@ -143,7 +143,7 @@ namespace OpenTap.Sdk.New
 
         public override int Execute(CancellationToken cancellationToken)
         {
-            if (!Validate(name: Name, allowWhiteSpace: true, allowLeadingNumbers: true))
+            if (!Validate(name: Name, allowWhiteSpace: true, allowLeadingNumbers: true, allowAlphaNumericOnly: false))
             {
                 return (int)ExitCodes.ArgumentError;
             }
@@ -180,7 +180,7 @@ namespace OpenTap.Sdk.New
 
         public override int Execute(CancellationToken cancellationToken)
         {
-            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false))
+            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false, allowAlphaNumericOnly: true))
             {
                 return (int)ExitCodes.ArgumentError;
             }
@@ -203,7 +203,7 @@ namespace OpenTap.Sdk.New
 
         public override int Execute(CancellationToken cancellationToken)
         {
-            if (!Validate(name: Name, allowWhiteSpace: true, allowLeadingNumbers: true))
+            if (!Validate(name: Name, allowWhiteSpace: true, allowLeadingNumbers: true, allowAlphaNumericOnly: false))
             {
                 return (int)ExitCodes.ArgumentError;
             }

--- a/sdk/OpenTap.Sdk.New/GenerateProject.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateProject.cs
@@ -82,7 +82,7 @@ namespace OpenTap.Sdk.New
 
         public override int Execute(CancellationToken cancellationToken)
         {
-            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false))
+            if (!Validate(name: Name, allowWhiteSpace: false, allowLeadingNumbers: false, allowAlphaNumericOnly: true))
             {
                 return (int)ExitCodes.ArgumentError;
             }

--- a/sdk/OpenTap.Sdk.New/GenerateType.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateType.cs
@@ -10,13 +10,15 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.CodeDom.Compiler;
 
 namespace OpenTap.Sdk.New
 {
     public abstract class GenerateType : ICliAction
     {
-        internal bool Validate(string name, bool allowWhiteSpace, bool allowLeadingNumbers)
+        internal bool Validate(string name, bool allowWhiteSpace, bool allowLeadingNumbers, bool allowAlphaNumericOnly)
         {
+
             bool anyInvalid = false;
             var invalid = Path.GetInvalidFileNameChars();
             var sb = new StringBuilder();
@@ -35,7 +37,8 @@ namespace OpenTap.Sdk.New
                 leading = false;
 
                 // Then detect any invalid filename or C# identifier chars
-                if (invalid.Contains(ch) || (!allowWhiteSpace && char.IsWhiteSpace(ch)))
+                if (invalid.Contains(ch) || (!allowWhiteSpace && char.IsWhiteSpace(ch)) ||
+                    (allowAlphaNumericOnly && !char.IsLetterOrDigit(ch)))
                 {
                     sb.Append("^");
                     anyInvalid = true;

--- a/sdk/OpenTap.Sdk.New/GenerateType.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateType.cs
@@ -38,7 +38,7 @@ namespace OpenTap.Sdk.New
 
                 // Then detect any invalid filename or C# identifier chars
                 if (invalid.Contains(ch) || (!allowWhiteSpace && char.IsWhiteSpace(ch)) ||
-                    (allowAlphaNumericOnly && !char.IsLetterOrDigit(ch)))
+                    (allowAlphaNumericOnly && !char.IsLetterOrDigit(ch) && ch != '_'))
                 {
                     sb.Append("^");
                     anyInvalid = true;

--- a/tests/test-sdk-templates.TapPlan
+++ b/tests/test-sdk-templates.TapPlan
@@ -40,6 +40,16 @@
           <Loop>5c686743-7dcc-49e6-afb6-8e30a11212f2</Loop>
           <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project contains/path\separators</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
         </SweepRow>
+        <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+          <Enabled>true</Enabled>
+          <Loop>5c686743-7dcc-49e6-afb6-8e30a11212f2</Loop>
+          <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project non_alpha.numeric</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
+        </SweepRow>
+        <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+          <Enabled>true</Enabled>
+          <Loop>5c686743-7dcc-49e6-afb6-8e30a11212f2</Loop>
+          <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project symbols?&amp;/()=</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
+        </SweepRow>
       </SweepValues>
       <Selected>
         <KeyValuePairOfString>
@@ -57,7 +67,7 @@
           <ChildTestSteps>
             <TestStep type="OpenTap.Plugins.BasicSteps.ProcessStep" Version="9.4.0-Development" Id="077f6709-5d32-495c-9204-5e7aed521a28">
               <Application>tap</Application>
-              <Arguments Parameter="Parameters \ Command Line Arguments" Scope="5c686743-7dcc-49e6-afb6-8e30a11212f2">sdk new project contains/path\separators</Arguments>
+              <Arguments Parameter="Parameters \ Command Line Arguments" Scope="5c686743-7dcc-49e6-afb6-8e30a11212f2">sdk new project symbols?&amp;/()=</Arguments>
               <WorkingDirectory Parameter="Parameters \ Directory">SdkTest/Test</WorkingDirectory>
               <WaitForEnd>true</WaitForEnd>
               <Timeout>0</Timeout>
@@ -86,7 +96,7 @@
         </TestStep>
       </ChildTestSteps>
       <BreakConditions>Inherit</BreakConditions>
-      <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project contains/path\separators</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
+      <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project symbols?&amp;/()=</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
     </TestStep>
     <TestStep type="OpenTap.Plugins.BasicSteps.SweepParameterStep" Version="9.4.0-Development" Id="8a6aa2a3-b87d-416a-b264-91886d44b78e">
       <SweepValues>

--- a/tests/test-sdk-templates.TapPlan
+++ b/tests/test-sdk-templates.TapPlan
@@ -110,6 +110,11 @@
           <Loop>8a6aa2a3-b87d-416a-b264-91886d44b78e</Loop>
           <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project HasNumbers123</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
         </SweepRow>
+        <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+          <Enabled>true</Enabled>
+          <Loop>8a6aa2a3-b87d-416a-b264-91886d44b78e</Loop>
+          <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project Has_Underscore</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
+        </SweepRow>
       </SweepValues>
       <Selected>
         <KeyValuePairOfString>
@@ -127,7 +132,7 @@
           <ChildTestSteps>
             <TestStep type="OpenTap.Plugins.BasicSteps.ProcessStep" Version="9.4.0-Development" Id="f8fc45cd-7757-4bb2-b64c-6818166927c9">
               <Application>tap</Application>
-              <Arguments Parameter="Parameters \ Command Line Arguments" Scope="8a6aa2a3-b87d-416a-b264-91886d44b78e">sdk new project HasNumbers123</Arguments>
+              <Arguments Parameter="Parameters \ Command Line Arguments" Scope="8a6aa2a3-b87d-416a-b264-91886d44b78e">sdk new project Has_Underscore</Arguments>
               <WorkingDirectory Parameter="Parameters \ Directory">SdkTest/Test</WorkingDirectory>
               <WaitForEnd>true</WaitForEnd>
               <Timeout>0</Timeout>
@@ -156,7 +161,7 @@
         </TestStep>
       </ChildTestSteps>
       <BreakConditions>Inherit</BreakConditions>
-      <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project HasNumbers123</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
+      <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project Has_Underscore</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
     </TestStep>
     <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.RemoveDirectory" Version="0.0.0" Id="64e78f64-481a-4c1c-a477-6b482f9774f3">
       <Path>SdkTest</Path>


### PR DESCRIPTION
Invalidates non alpha numeric chars for `tap sdk new xx` names if the name will be used for a C# identifier, since C# identifiers dont allow most non alpha numeric chars.
Closes: #317 
## Testing
Added sweep variables to the *test-sdk-templates* tap testplan to test that non alpha numeric chars fail.