### PR TITLE
538 don't log errors when typedata providers call Installation.GetPackages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,7 @@ jobs:
     needs:
       - Build-Win
       - Build-ApiDoc
+      - GetVersion
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -432,9 +433,8 @@ jobs:
           #cp .\runtimes\win-x64\native\git2-b7bad55.dll .
           .\tap.exe package install -f ../../sign.TapPackage
           echo "${{ secrets.SIGN_SERVER_CERT }}" > $env:TAP_SIGN_CERT
-          $version=$(./tap sdk gitversion)
           cd ../Release-${{ matrix.Architecture }}
-          ..\Release-x64\tap.exe package create -v -c ../../package.xml -o ../../OpenTAP.$version.${{ matrix.Architecture }}.Windows.TapPackage
+          ..\Release-x64\tap.exe package create -v -c ../../package.xml -o ../../OpenTAP.${{needs.GetVersion.outputs.GitVersion}}.${{ matrix.Architecture }}.Windows.TapPackage
         env: 
           TAP_SIGN_ADDRESS: ${{ secrets.TAP_SIGN_ADDRESS }}
           TAP_SIGN_AUTH:  ${{ secrets.TAP_SIGN_AUTH }}
@@ -454,6 +454,7 @@ jobs:
       - Build-Win
       - Build-Linux
       - Build-ApiDoc
+      - GetVersion
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -498,8 +499,7 @@ jobs:
           echo "${{ secrets.SIGN_SERVER_CERT }}" > $env:TAP_SIGN_CERT
           cp .\runtimes\win-x64\native\git2-b7bad55.dll .
           ..\Release\tap package create -v -c ../../package.xml -o Packages/OpenTAP.Linux.TapPackage
-          $version=$(..\Release\tap sdk gitversion)
-          cp Packages/OpenTAP.Linux.TapPackage ../../OpenTAP.$version.Linux.TapPackage
+          cp Packages/OpenTAP.Linux.TapPackage ../../OpenTAP.${{needs.GetVersion.outputs.GitVersion}}.Linux.TapPackage
         env: 
           TAP_SIGN_ADDRESS: ${{ secrets.TAP_SIGN_ADDRESS }}
           TAP_SIGN_AUTH:  ${{ secrets.TAP_SIGN_AUTH }}

--- a/Engine.UnitTests/TestSelfReferentialTypeData.cs
+++ b/Engine.UnitTests/TestSelfReferentialTypeData.cs
@@ -9,22 +9,15 @@ namespace OpenTap.Engine.UnitTests
 {
     public class SelfReferentialTypeDataProvider : IStackedTypeDataProvider
     {
-        private static int fn(int a)
-        {
-            TypeData.GetTypeData(a);
-            return a;
-        }
-        
-        static IMemorizer<int, int> circularMemorizer = new Memorizer<int, int, int>(null, fn);
         public ITypeData GetTypeData(string identifier, TypeDataProviderStack stack)
         {
-            circularMemorizer.Invoke(2);
+            Installation.Current.GetPackages();
             return stack.GetTypeData(identifier);
         }
 
         public ITypeData GetTypeData(object obj, TypeDataProviderStack stack)
         {
-            circularMemorizer.Invoke(2);
+            Installation.Current.GetPackages();
             return stack.GetTypeData(obj);
         }
 
@@ -46,7 +39,7 @@ namespace OpenTap.Engine.UnitTests
                     Log.AddListener(l);
                     l.MessageLogged += (msg) => errors.AddRange(msg.Where(m => m.EventType == (int)LogEventType.Error));
                     // Trigger typedata search
-                    TypeData.GetTypeData(1);
+                    Installation.Current.GetPackages();
                     CollectionAssert.IsEmpty(errors, $"Operation had errors: {string.Join(", ", errors)}");
                 }
             }

--- a/Engine.UnitTests/TestSelfReferentialTypeData.cs
+++ b/Engine.UnitTests/TestSelfReferentialTypeData.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using OpenTap.Diagnostic;
+using OpenTap.Package;
+
+namespace OpenTap.Engine.UnitTests
+{
+    public class SelfReferentialTypeDataProvider : IStackedTypeDataProvider
+    {
+        private static int fn(int a)
+        {
+            TypeData.GetTypeData(a);
+            return a;
+        }
+        
+        static IMemorizer<int, int> circularMemorizer = new Memorizer<int, int, int>(null, fn);
+        public ITypeData GetTypeData(string identifier, TypeDataProviderStack stack)
+        {
+            circularMemorizer.Invoke(2);
+            return stack.GetTypeData(identifier);
+        }
+
+        public ITypeData GetTypeData(object obj, TypeDataProviderStack stack)
+        {
+            circularMemorizer.Invoke(2);
+            return stack.GetTypeData(obj);
+        }
+
+        public double Priority { get; }
+    }
+
+    [TestFixture]
+    public class TestSelfReferentialTypeData
+    {
+        [Test]
+        public void TestTypeDataLookupTerminates()
+        {
+            try
+            {
+                using (Session.Create())
+                {
+                    var errors = new List<Event>();
+                    var l = new EventTraceListener();
+                    Log.AddListener(l);
+                    l.MessageLogged += (msg) => errors.AddRange(msg.Where(m => m.EventType == (int)LogEventType.Error));
+                    // Trigger typedata search
+                    TypeData.GetTypeData(1);
+                    CollectionAssert.IsEmpty(errors, $"Operation had errors: {string.Join(", ", errors)}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Cycle was not prevented: '{ex.Message}'");
+            }
+        }
+    }
+}

--- a/Package/Installation.cs
+++ b/Package/Installation.cs
@@ -266,7 +266,26 @@ namespace OpenTap.Package
         }
 
 
-        static IMemorizer<string, PackageDef> installedPackageMemorizer = new Memorizer<string, PackageDef, string>(null, loadPackageDef)
+        /// <summary>
+        /// Memorizer which returns null when a cyclic memorizer call is detected.
+        /// This prevents ugly and misleading error messages from occurring during
+        /// calls to Installation.Current.GetPackages() from ITypeDataProvider implementations
+        /// </summary>
+        class IgnoreCyclicCallMemorizer<T1, T2, T3> : Memorizer<T1, T2, T3>
+        {
+            public IgnoreCyclicCallMemorizer(Func<T1, T2> func) : base(null, func)
+            {
+                
+            }
+
+            public override T2 OnCyclicCallDetected(T1 key)
+            {
+                return default;
+            }
+        }
+
+
+        static IMemorizer<string, PackageDef> installedPackageMemorizer = new IgnoreCyclicCallMemorizer<string, PackageDef, string>(loadPackageDef)
         {
             Validator = file => new FileInfo(file).LastWriteTimeUtc.Ticks
         };

--- a/Shared/ReflectionHelper.cs
+++ b/Shared/ReflectionHelper.cs
@@ -649,6 +649,11 @@ namespace OpenTap
             return getKey == null ? (MemorizerKey)(object)arg : getKey(arg);
         }
 
+        public virtual ResultT OnCyclicCallDetected(ArgT key)
+        {
+            throw new Exception("Cyclic memorizer invoke detected.");
+        }
+
         public ResultT this[ArgT arg] => Invoke(arg);
 
         public ResultT Invoke(ArgT arg)
@@ -688,7 +693,7 @@ namespace OpenTap
                 {   // Avoid running into a StackOverflowException.
 
                     if (CylicInvokeResponse == CyclicInvokeMode.ThrowException)
-                        throw new Exception("Cyclic memorizer invoke detected."); 
+                        return OnCyclicCallDetected(arg);
                     return default(ResultT);
                 }
                 try


### PR DESCRIPTION
This adds a virtual method to the Memorizer which allow inheritors to define how cycles should be handled.

Closes #538 