### PR TITLE
Add SessionLog initialization option to not lock session log files

### DIFF
--- a/Engine/FileTraceListener.cs
+++ b/Engine/FileTraceListener.cs
@@ -7,6 +7,7 @@ using System.IO;
 using OpenTap.Diagnostic;
 using System.Threading;
 using System.Collections.Generic;
+using System.Text;
 
 namespace OpenTap
 {
@@ -46,15 +47,25 @@ namespace OpenTap
         {
         }
         
-        internal void ChangeFileName(string fileName)
+        internal void ChangeFileName(string fileName, bool noExclusiveWriteLock)
         {
             string dir = Path.GetDirectoryName(fileName);
             if (string.IsNullOrWhiteSpace(dir) == false)
                 Directory.CreateDirectory(Path.GetDirectoryName(fileName));
 
+            StreamWriter newwriter = null;
+            if (noExclusiveWriteLock)
+            {
+                // Initialize a stream where the underlying file can be deleted. If the file is deleted, writes just go into the void.
+                var stream = new FileStream(fileName, FileMode.Append, FileAccess.Write, FileShare.Read | FileShare.Delete);
+                newwriter = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
+            }
+            else
+            {
+                newwriter = new StreamWriter(fileName, true, System.Text.Encoding.UTF8) { AutoFlush = true };
+            }
+            
             var OldWriter = base.Writer;
-
-            var newwriter = new StreamWriter(fileName, true, System.Text.Encoding.UTF8) { AutoFlush = true };
             base.Writer = newwriter;
             
             OldWriter.Close();

--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -347,7 +347,7 @@ namespace OpenTap
                     }
                     else
                     {
-                        traceListener.ChangeFileName(path);
+                        traceListener.ChangeFileName(path, NoExclusiveWriteLock);
                     }
                     fileNameChanged = true;
                     break;

--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -333,7 +333,7 @@ namespace OpenTap
                         if (NoExclusiveWriteLock)
                         {
                             // Initialize a stream where the underlying file can be deleted. If the file is deleted, writes just go into the void.
-                            var stream = new FileStream(path, FileMode.Append, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete);
+                            var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read | FileShare.Delete);
                             traceListener = new FileTraceListener(stream);
                         }
                         else

--- a/sdk/OpenTap.Sdk.MSBuild/OpenTapLoader.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/OpenTapLoader.cs
@@ -16,7 +16,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
         /// <returns></returns>
         string numberedFileName(string logName)
         {
-            var logNameNoExt = Path.GetFileNameWithoutExtension(logName);
+            var logNameNoExt = Path.Combine(Path.GetDirectoryName(logName), Path.GetFileNameWithoutExtension(logName));
             var num = 1;
             while (File.Exists(logName))
             {

--- a/sdk/OpenTap.Sdk.MSBuild/OpenTapLoader.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/OpenTapLoader.cs
@@ -37,6 +37,8 @@ namespace Keysight.OpenTap.Sdk.MSBuild
         /// </summary>
         public void Dispose()
         {
+            Log.Flush();
+            SessionLogs.Flush();
             _onDispose();
         }
     }

--- a/sdk/OpenTap.Sdk.MSBuild/OpenTapLoader.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/OpenTapLoader.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using OpenTap;
+
+namespace Keysight.OpenTap.Sdk.MSBuild
+{
+    class SessionLogContext : IDisposable
+    {
+        private Action _onDispose;
+
+        /// <summary>
+        /// Calling this method forces the runtime to resolve OpenTAP because SessionLogs is from the OpenTAP assembly.
+        /// </summary>
+        public SessionLogContext(string tapDir, Action OnDispose)
+        {
+            _onDispose = OnDispose;
+            
+            var timestamp = System.Diagnostics.Process.GetCurrentProcess().StartTime.ToString("yyyy-MM-dd HH-mm-ss");
+
+            // Path example: <TapDir>/SessionLogs/SessionLog <timestamp>.txt
+            string pathEnding = $"SessionLog {timestamp}";
+
+            if (Assembly.GetEntryAssembly() != null && !String.IsNullOrWhiteSpace(Assembly.GetEntryAssembly().Location))
+            {
+                string exeName = Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location);
+                // Path example: <TapDir>/SessionLogs/tap/tap <timestamp>.txt
+                pathEnding = $"{exeName} {timestamp}";
+            }
+
+            SessionLogs.Initialize($"{tapDir}/SessionLogs/{pathEnding}.txt", true);
+        }
+
+        /// <summary>
+        /// Ensure the session log is closed when this context is disposed.
+        /// </summary>
+        public void Dispose()
+        {
+            _onDispose();
+        }
+    }
+
+    class OpenTapContext
+    {
+        /// <summary>
+        /// Compute the payload directory based on the current platform
+        /// </summary>
+        /// <returns></returns>
+        private static string CorrectPayloadDir()
+        {
+            var thisAsmDir = Path.GetDirectoryName(typeof(OpenTapContext).Assembly.Location)!;
+            return Path.Combine(thisAsmDir, "payload");
+        }
+
+        /// <summary>
+        /// Help the runtime resolve OpenTAP. The correct OpenTAP dll is in a subdirectory and will not be found by
+        /// the default resolver. Also, the resolver will look for the debug version (9.4.0.0) because that's what this
+        /// assembly was compiled against. This is sort of a hack, but it should be fine.
+        /// </summary>
+        /// <param name="tapDir"></param>
+        public static IDisposable Create(string tapDir)
+        {
+            // This alters the value returned by 'ExecutorClient.ExeDir' which would otherwise return the location of
+            // OpenTap.dll which in an MSBuild context would be the nuget directory which leads to unexpected behavior
+            // because the expected location is the build directory in all common use cases.
+            Environment.SetEnvironmentVariable("OPENTAP_INIT_DIRECTORY", tapDir, EnvironmentVariableTarget.Process);
+
+            var tapInstall = Path.Combine(tapDir, "tap");
+            if (File.Exists(tapInstall) == false)
+                tapInstall = Path.Combine(tapDir, "tap.exe");
+            if (File.Exists(tapInstall) == false)
+                throw new Exception($"No tap install found in directory {tapDir}");
+            
+            Environment.SetEnvironmentVariable("OPENTAP_NO_UPDATE_CHECK", "true");
+            Environment.SetEnvironmentVariable("OPENTAP_DEBUG_INSTALL", "true");
+            
+            var root = CorrectPayloadDir();
+            var openTapDll = Path.Combine(root, "OpenTap.dll");
+            var openTapPackageDll = Path.Combine(root, "OpenTap.Package.dll");
+
+            Assembly resolve(object sender, ResolveEventArgs args)
+            {
+                if (args.Name.StartsWith("OpenTap.Package"))
+                    return Assembly.LoadFile(openTapPackageDll);
+                if (args.Name.StartsWith("OpenTap"))
+                    return Assembly.LoadFile(openTapDll);
+                return null;
+            }
+
+            AppDomain.CurrentDomain.AssemblyResolve += resolve;
+
+            IDisposable defer()
+            {
+                var ctx = new SessionLogContext(tapDir, () =>
+                {
+                    AppDomain.CurrentDomain.AssemblyResolve -= resolve;
+                });
+                return ctx;
+            }
+
+            return defer();
+        }
+    }
+}

--- a/sdk/OpenTap.Sdk.MSBuild/OpenTapLoader.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/OpenTapLoader.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using OpenTap;
 
 namespace Keysight.OpenTap.Sdk.MSBuild
@@ -39,8 +38,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             var timestamp = buildProc.StartTime.ToString("yyyy-MM-dd HH-mm-ss");
             var pid = buildProc.Id;
 
-            // Path example: <TapDir>/SessionLogs/SessionLog <timestamp>.txt
-            string pathEnding = $"SessionLog {timestamp}";
+            string pathEnding = $"SessionLog.{pid} {timestamp}";
 
             if (Assembly.GetEntryAssembly() != null && !String.IsNullOrWhiteSpace(Assembly.GetEntryAssembly().Location))
             {
@@ -48,8 +46,8 @@ namespace Keysight.OpenTap.Sdk.MSBuild
                 // Path example: <TapDir>/SessionLogs/tap/tap <timestamp>.txt
                 pathEnding = $"{exeName}.{pid} {timestamp}";
             }
-            
-            var logName = $"{tapDir}/SessionLogs/{pathEnding}.txt";
+
+            var logName = Path.GetFullPath(Path.Combine(tapDir, "SessionLogs", pathEnding + ".txt"));
             logName = numberedFileName(logName);
 
             SessionLogs.Initialize(logName, true);


### PR DESCRIPTION
This fixes an issue that prevented `git clean -dfx` from working because OpenTAP keeps log files open.

Closes #518 