### PR TITLE
445 bump newtonsoft

### DIFF
--- a/Package/Tap.Package.csproj
+++ b/Package/Tap.Package.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.27.0.0-preview-0175" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Mono.Cecil" Version="0.10.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NuGet.Client" Version="4.2.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />


### PR DESCRIPTION
There is a minor vulnerability in newtonsoft 12.0.2 which was fixed in 12.0.3. Let's bump!

Closes #445 