### PR TITLE
525 cannot save component settings with groups

### DIFF
--- a/Engine.UnitTests/ComponentSettingsTest.cs
+++ b/Engine.UnitTests/ComponentSettingsTest.cs
@@ -95,7 +95,30 @@ namespace OpenTap.UnitTests
                 Assert.IsTrue(ex.Message.Contains(content));
             }
         }
-        
+
+        [Display("Test Settings", Groups: new []{"Test Settings", "With Groups"})]
+        public class TestSettingsWithGroups : ComponentSettings<TestSettingsWithGroups>
+        {
+            public int Value { get; set; }
+        }
+
+        [Test]
+        public void TestSaveSettingsWithGroup()
+        {
+            var s = ComponentSettings<TestSettingsWithGroups>.Current;
+            s.Value = 0;
+            Assert.AreEqual(0, s.Value);
+            s.Save();
+            var newValue = 123;
+            s.Value = newValue;
+            Assert.AreEqual(newValue, s.Value);
+            s.Save();
+            s.Reload();
+            s.Invalidate();
+            s = ComponentSettings<TestSettingsWithGroups>.Current;
+            Assert.AreEqual(newValue, s.Value);
+        }
+
         [Test]
         public void TestPersistenceOfSaveAll()
         {

--- a/Engine/ComponentSettingsContext.cs
+++ b/Engine/ComponentSettingsContext.cs
@@ -84,8 +84,13 @@ namespace OpenTap
             bool isProfile = settingsGroup?.Profile ?? false;
             string groupName = settingsGroup == null ? "" : settingsGroup.GroupName;
 
+            // DisplayAttribute.GetFullName() joins the groups with ' \ ', but adding this space makes the save path invalid.
+            var disp = type.GetDisplayAttribute();
+            var groups = disp.Group.Length == 0 ? new[] { disp.Name } : disp.Group.Append(disp.Name);
+            string fullName = string.Join("\\", groups);
+
             return Path.Combine(GetSettingsDirectory(groupName, isProfile),
-                type.GetDisplayAttribute().GetFullName() + ".xml");
+                fullName + ".xml");
         }
 
         public void Save(ComponentSettings setting)


### PR DESCRIPTION
This fixes a bug which caused the computed savepath for component settings with groups to be invalid.

Closes #525 