### PR TITLE
Fix warnings when installing system-wide packages

### DIFF
--- a/Package/PackageActionHelpers.cs
+++ b/Package/PackageActionHelpers.cs
@@ -202,7 +202,7 @@ namespace OpenTap.Package
                 if (force)
                     log.Info($"Ignoring potential depencencies (--force option specified).");
                 else
-                    log.Info($"Ignoring potential depencencies (--no-dependencies option specified).");
+                    log.Debug($"Ignoring potential depencencies (--no-dependencies option specified).");
                 return gatheredPackages.ToList();
             }
 

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -226,7 +226,7 @@ namespace OpenTap.Package
                     var processRunner = new SubProcessHost
                     {
                         ForwardLogs = true,
-                        MutedSources = new[] { "CLI", "Session", "Resolver", "AssemblyFinder", "PluginManager", "TestPlan", "UpdateCheck", "Installation" }
+                        MutedSources = { "CLI", "Session", "Resolver", "AssemblyFinder", "PluginManager", "TestPlan", "UpdateCheck", "Installation" }
                     };
 
                     var result = processRunner.Run(installStep, true, cancellationToken);

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -223,7 +223,11 @@ namespace OpenTap.Package
                         Force = Force
                     };
 
-                    var processRunner = new SubProcessHost {ForwardLogs = true};
+                    var processRunner = new SubProcessHost
+                    {
+                        ForwardLogs = true,
+                        MutedSources = new[] { "CLI", "Session", "Resolver", "AssemblyFinder", "PluginManager", "TestPlan", "UpdateCheck", "Installation" }
+                    };
 
                     var result = processRunner.Run(installStep, true, cancellationToken);
                     if (result != Verdict.Pass)

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -191,7 +191,7 @@ namespace OpenTap.Package
                 RaiseProgressUpdate(10, "Gathering dependencies.");
                 bool checkDependencies = (!IgnoreDependencies && !Force) || CheckOnly;
                 var issue = DependencyChecker.CheckDependencies(installationPackages, packagesToInstall,
-                    checkDependencies ? LogEventType.Error : LogEventType.Warning);
+                    IgnoreDependencies ? LogEventType.Information : checkDependencies ? LogEventType.Error : LogEventType.Warning);
                 if (checkDependencies)
                 {
                     if (issue == DependencyChecker.Issue.BrokenPackages)
@@ -218,6 +218,7 @@ namespace OpenTap.Package
                     var installStep = new PackageInstallStep()
                     {
                         Packages = systemWide,
+                        Repositories = repositories.Select(r => r.Url).ToArray(),
                         Target = PackageDef.SystemWideInstallationDirectory,
                         Force = Force
                     };

--- a/Package/PackageInstallHelpers/PackageInstallStep.cs
+++ b/Package/PackageInstallHelpers/PackageInstallStep.cs
@@ -13,24 +13,10 @@ namespace OpenTap.Package.PackageInstallHelpers
         public string Target { get; set; }
         public PackageDef[] Packages { get; set; }
         public bool Force { get; set; }
+        public string[] Repositories { get; set; }
 
         public override void Run()
         {
-            var repositories = new HashSet<string>();
-
-            foreach (var pkg in Packages)
-            {
-                switch (pkg.PackageSource)
-                {
-                    case IRepositoryPackageDefSource s1:
-                        repositories.Add(s1.RepositoryUrl);
-                        break;
-                    case IFilePackageDefSource s2:
-                        repositories.Add(Path.GetDirectoryName(s2.PackageFilePath));
-                        break;
-                }
-            }
-
             var action = new PackageInstallAction()
             {
                 InstallDependencies = false,
@@ -41,7 +27,7 @@ namespace OpenTap.Package.PackageInstallHelpers
                         new VersionSpecifier(p.Version, VersionMatchBehavior.Exact), p.Architecture, p.OS))
                     .ToArray(),
                 Target = Target,
-                Repository = repositories.ToArray()
+                Repository = Repositories
             };
 
             try

--- a/Shared/SubProcessHost.cs
+++ b/Shared/SubProcessHost.cs
@@ -21,8 +21,7 @@ namespace OpenTap
     {
         public bool ForwardLogs { get; set; } 
         public string LogHeader { get; set; } = "";
-        public string[] MutedSources { get; set; } = Array.Empty<string>();
-
+        public HashSet<string> MutedSources { get; } = new HashSet<string>();
 
         public static bool IsAdmin()
         {

--- a/Shared/SubProcessHost.cs
+++ b/Shared/SubProcessHost.cs
@@ -20,7 +20,8 @@ namespace OpenTap
     class SubProcessHost
     {
         public bool ForwardLogs { get; set; } 
-        public string LogHeader { get; set; } = "Subprocess";
+        public string LogHeader { get; set; } = "";
+        public string[] MutedSources { get; set; } = Array.Empty<string>();
 
 
         public static bool IsAdmin()
@@ -201,7 +202,13 @@ namespace OpenTap
                             for(int i = 0; i < events.Length; i++)
                                 events[i].Message = LogHeader + ": " + events[i].Message;
                         }
-                        events.ForEach(((ILogContext2)Log.Context).AddEvent);
+
+                        var _evt = events;
+                        if (MutedSources.Any())
+                        {
+                            _evt = events.Where(e => !MutedSources.Contains(e.Source)).ToArray();
+                        }
+                        _evt.ForEach(((ILogContext2)Log.Context).AddEvent);
                     }
                 }
 

--- a/package.xml
+++ b/package.xml
@@ -25,8 +25,6 @@
         <File Path="OpenTap.dll">
             <SetAssemblyInfo Attributes="Version" />
             <Sign Certificate="Keysight Technologies, Inc" Condition="$(Sign)==true"/>
-            <!-- we specifically don't want to include this since there are conflicting versions for .net framework and .netstandard -->
-            <IgnoreDependency>System.Security.Principal.Windows</IgnoreDependency>
         </File>
         <File Path="OpenTap.Package.dll">
             <SetAssemblyInfo Attributes="Version" />
@@ -46,9 +44,7 @@
         <File Condition="$(Platform) != Windows" Path="tap.runtimeconfig.json"/>
         <File Condition="$(Platform) != Windows" Path="tap.dll"/>
         <File Path="tap.pdb"/>  
-        <File Path="OpenTap.dll">
-            <IgnoreDependency>System.Security.Principal.Windows</IgnoreDependency> 
-        </File>
+        <File Path="OpenTap.dll"/>
         <File Path="OpenTap.pdb"/>
         <File Path="OpenTap.Package.dll"/>
         <File Path="OpenTap.Package.pdb"/>


### PR DESCRIPTION
This removes a few warnings that were simply incorrect

Other warnings have been demoted to 'info' when the user has explicitly set the '--no-dependencies' option

Bogus 'Duplicate packages' warning has been removed when an Installation has the systemwide dir as a target

This also includes a minor bugfix to the repositories used in elevated processes, and a butfix to the default Architecture in Installations

Closes #509 