### PR TITLE
548 bump smartinstaller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -710,7 +710,7 @@ jobs:
       - GetVersion
       - Package-Win
     container:
-      image: registry.gitlab.com/opentap/buildrunners/smartinstaller:1.0.0-beta.3
+      image: registry.gitlab.com/opentap/buildrunners/smartinstaller:1.1.0-beta.7
       credentials:
         username: github
         password: ${{ secrets.GITLAB_REGISTRY_TOKEN}}


### PR DESCRIPTION
From what I could tell, the current smartinstaller image we use was built February 9, and we merged some localization fixes in the smartinstaller on February 23. Let's try bumping the smart installer to the latest beta and see if it fixes the problem.

Closes #548
Closes #534 