### PR TITLE
112 give better warnings when attempting to upgrade OpenTAP with <OpenTapPackageReference>

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
 
   <PropertyGroup Condition="'$(OS)' != 'Unix'">
     <!-- .net462 revert: on windows we build -->   
-    <OpenTapAppTargetFramework>net462</OpenTapAppTargetFramework>
+    <OpenTapAppTargetFramework>net472</OpenTapAppTargetFramework>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/Engine.UnitTests/Tap.Engine.UnitTests.csproj
+++ b/Engine.UnitTests/Tap.Engine.UnitTests.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Package.UnitTests/MSBuildSdkTest.cs
+++ b/Package.UnitTests/MSBuildSdkTest.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Keysight.OpenTap.Sdk.MSBuild;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NUnit.Framework;
+using OpenTap.Image.Tests;
+
+namespace OpenTap.Package.UnitTests
+{
+    public class DictTaskItem : ITaskItem
+    {
+        public Dictionary<string, string> MetaData = new Dictionary<string, string>();
+
+        public DictTaskItem(string itemSpec)
+        {
+            ItemSpec = itemSpec;
+        }
+
+        public string GetMetadata(string metadataName)
+        {
+            return MetaData.TryGetValue(metadataName, out var v) ? v : "";
+        }
+
+        public void SetMetadata(string metadataName, string metadataValue)
+        {
+            MetaData[metadataName] = metadataValue;
+        }
+
+        public void RemoveMetadata(string metadataName)
+        {
+            MetaData.Remove(metadataName);
+        }
+
+        public void CopyMetadataTo(ITaskItem destinationItem)
+        {
+            // not needed
+        }
+
+        public IDictionary CloneCustomMetadata()
+        {
+            throw new NotImplementedException("Not needed.");
+        }
+
+        public string ItemSpec { get; set; }
+
+        public ICollection MetadataNames => MetaData.Keys.ToArray();
+        public int MetadataCount => MetaData.Count;
+    }
+
+    public class MockBuildEngine : IBuildEngine
+    {
+        private static TraceSource log = Log.CreateSource(nameof(MockBuildEngine));
+        internal List<BuildEventArgs> buildEvents = new List<BuildEventArgs>();
+
+        public void LogErrorEvent(BuildErrorEventArgs e)
+        {
+            buildEvents.Add(e);
+        }
+
+        public void LogWarningEvent(BuildWarningEventArgs e)
+        {
+            buildEvents.Add(e);
+        }
+
+        public void LogMessageEvent(BuildMessageEventArgs e)
+        {
+            buildEvents.Add(e);
+        }
+
+        public void LogCustomEvent(CustomBuildEventArgs e)
+        {
+            buildEvents.Add(e);
+        }
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties,
+            IDictionary targetOutputs)
+        {
+            return true;
+        }
+
+        public bool ContinueOnError { get; }
+        public int LineNumberOfTaskNode { get; }
+        public int ColumnNumberOfTaskNode { get; }
+        public string ProjectFileOfTaskNode { get; }
+    }
+
+    public class MockImageDeployer : IImageDeployer
+    {
+        public Action<ImageSpecifier, Installation, CancellationToken> OnInstall;
+
+        public void Install(ImageSpecifier spec, Installation install, CancellationToken cts)
+        {
+            OnInstall(spec, install, cts);
+        }
+    }
+
+    [TestFixture]
+    public class MSBuildSdkTest
+    {
+        [Test]
+        public void TestRejectOpenTap()
+        {
+            MockRepository mockRepository = new MockRepository("mock://localhost");
+            PackageRepositoryHelpers.RegisterRepository(mockRepository);
+
+            var openTapTaskItem = new DictTaskItem("OpenTAP")
+            {
+                MetaData = { ["Version"] = "9.12.0" }
+            };
+            ITaskItem[] packages = { openTapTaskItem };
+
+            ITaskItem[] repos =
+            {
+                new TaskItem("mock://localhost"),
+            };
+
+            void Install(ImageSpecifier spec, Installation install, CancellationToken cts)
+            {
+                var expected = Installation.Current.GetOpenTapPackage();
+                Assert.AreEqual(1, spec.Packages.Count);
+                spec.Repositories.Add(Path.GetDirectoryName(typeof(MSBuildSdkTest).Assembly.Location));
+                var img = spec.Resolve(cts);
+                Assert.AreEqual(expected, img.Packages.First());
+            }
+
+            var deployer = new MockImageDeployer
+            {
+                OnInstall = Install
+            };
+
+            var buildEngine = new MockBuildEngine();
+
+            var installBuildAction = new InstallOpenTapPackages
+            {
+                TapDir = ExecutorClient.ExeDir,
+                BuildEngine = buildEngine,
+                PackagesToInstall = packages,
+                Repositories = repos,
+                ImageDeployer = deployer
+            };
+
+            installBuildAction.Execute();
+
+            var OpenTapNugetPackage = Installation.Current.GetOpenTapPackage();
+
+            bool containsOpenTapWarning()
+            {
+                return buildEngine.buildEvents.Select(b => b.Message).Any(m =>
+                    m.Contains($"This project was restored using OpenTAP version '{OpenTapNugetPackage.Version}'"));
+            }
+
+            Assert.IsTrue(containsOpenTapWarning(),
+                "Requesting OpenTAP version 9.12 should issue a warning!");
+
+            buildEngine.buildEvents.Clear();
+            openTapTaskItem.SetMetadata("Version", "any");
+
+            installBuildAction.Execute();
+
+            Assert.IsFalse(containsOpenTapWarning(), "There should be no warning when requesting a compatible OpenTAP version!");
+        }
+    }
+}

--- a/Package.UnitTests/Tap.Package.UnitTests.csproj
+++ b/Package.UnitTests/Tap.Package.UnitTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />    
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
+    <ProjectReference Include="..\sdk\OpenTap.Sdk.MSBuild\OpenTap.Sdk.MSBuild.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/OpenTap.Sdk.MSBuild/BuildVariableExpander.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/BuildVariableExpander.cs
@@ -7,7 +7,8 @@ using Microsoft.Build.Execution;
 
 namespace Keysight.OpenTap.Sdk.MSBuild
 {
-    internal static class ExtensionClass{
+    internal static class ExtensionClass
+    {
         internal static string ElemOrAttributeValue(this XElement ele, string name, string defaultValue)
         {
             return ele.Attribute(name)?.Value ?? ele.Element(name)?.Value ?? defaultValue;
@@ -15,7 +16,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
 
         internal static XElement[] GetPackageElements(this XElement ele, string packageName)
         {
-            var tagNames = new[] {"OpenTapPackageReference", "AdditionalOpenTapPackage"};
+            var tagNames = new[] { "OpenTapPackageReference", "AdditionalOpenTapPackage" };
 
             var itemGroups = ele.Elements().Where(e => e.Name.LocalName == "ItemGroup");
             var packageInstallElements = new List<XElement>();
@@ -30,6 +31,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             return packageInstallElements.ToArray();
         }
     }
+
     internal class BuildVariableExpander
     {
 

--- a/sdk/OpenTap.Sdk.MSBuild/InstallOpenTapPackages.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/InstallOpenTapPackages.cs
@@ -17,6 +17,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
     [Serializable]
     public class InstallOpenTapPackages : Task, ICancelableTask
     {
+        public IImageDeployer ImageDeployer { get; set; }
         /// <summary>
         /// Full qualified path to the .csproj file for which packages are being installed
         /// </summary>
@@ -48,6 +49,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
         {
             get
             {
+                if (string.IsNullOrWhiteSpace(SourceFile)) return null;
                 if (_document != null)
                     return _document;
 
@@ -69,7 +71,10 @@ namespace Keysight.OpenTap.Sdk.MSBuild
                 var version = item.GetMetadata("Version");
                 var repository = item.GetMetadata("Repository");
 
-                foreach (var elem in Document.GetPackageElements(packageName))
+                var doc = Document;
+                if (doc == null) return new[] { 0 };
+
+                foreach (var elem in doc.GetPackageElements(packageName))
                 {
                     if (elem is IXmlLineInfo lineInfo && lineInfo.HasLineInfo())
                     {
@@ -114,26 +119,31 @@ namespace Keysight.OpenTap.Sdk.MSBuild
         {
             cts.Cancel();
         }
-
+        
+        /// <summary>
+        /// We *must* be in an OpenTapContext before calling this method because
+        /// it depends on OpenTAP DLLs.
+        /// </summary>
+        /// <returns></returns>
         private bool InstallPackages()
         {
-            using (var installer = new OpenTapImageInstaller(TapDir, cts.Token))
+            var repos = Repositories?.SelectMany(r =>
+                    r.ItemSpec.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries))
+                .ToList() ?? new List<string>();
+
+            repos.AddRange(PackagesToInstall.Select(p => p.GetMetadata("Repository"))
+                .Where(m => string.IsNullOrWhiteSpace(m) == false));
+
+            repos = repos.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+            using (var imageInstaller = new OpenTapImageInstaller(TapDir, cts.Token))
             {
-                installer.LogMessage += OnInstallerLogMessage;
-
-                var repos = Repositories?.SelectMany(r =>
-                        r.ItemSpec.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries))
-                    .ToList() ?? new List<string>();
-
-                repos.AddRange(PackagesToInstall.Select(p => p.GetMetadata("Repository"))
-                    .Where(m => string.IsNullOrWhiteSpace(m) == false));
-
-                if (!repos.Any(r => r.ToLower().Contains("packages.opentap.io")))
-                    repos.Add("packages.opentap.io");
+                imageInstaller.LogMessage += OnInstallerLogMessage;
+                imageInstaller.ImageDeployer = ImageDeployer;
 
                 try
                 {
-                    return installer.InstallImage(PackagesToInstall, repos.Distinct(StringComparer.OrdinalIgnoreCase).ToArray());
+                    return imageInstaller.InstallImage(PackagesToInstall, repos);
                 }
                 catch (Exception ex)
                 {

--- a/sdk/OpenTap.Sdk.MSBuild/InstallOpenTapPackages.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/InstallOpenTapPackages.cs
@@ -17,7 +17,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
     [Serializable]
     public class InstallOpenTapPackages : Task, ICancelableTask
     {
-        public IImageDeployer ImageDeployer { get; set; }
+        internal IImageDeployer ImageDeployer { get; set; }
         /// <summary>
         /// Full qualified path to the .csproj file for which packages are being installed
         /// </summary>

--- a/sdk/OpenTap.Sdk.MSBuild/OpenTapImageInstaller.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/OpenTapImageInstaller.cs
@@ -10,7 +10,7 @@ using OpenTap.Package;
 
 namespace Keysight.OpenTap.Sdk.MSBuild
 {
-    public interface IImageDeployer
+    internal interface IImageDeployer
     {
         void Install(ImageSpecifier spec, Installation install, CancellationToken cts);
     }

--- a/sdk/OpenTap.Sdk.MSBuild/OpenTapImageInstaller.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/OpenTapImageInstaller.cs
@@ -10,15 +10,33 @@ using OpenTap.Package;
 
 namespace Keysight.OpenTap.Sdk.MSBuild
 {
+    public interface IImageDeployer
+    {
+        void Install(ImageSpecifier spec, Installation install, CancellationToken cts);
+    }
+
+    internal class DefaultImageDeployer : IImageDeployer
+    {
+        public void Install(ImageSpecifier spec, Installation install, CancellationToken cts)
+        {
+            if (!spec.Repositories.Any(r => r.ToLower().Contains("packages.opentap.io")))
+                spec.Repositories.Add("packages.opentap.io");
+            spec.MergeAndDeploy(install, cts);
+        }
+    }
+
     internal class OpenTapImageInstaller : IDisposable
     {
         public string TapDir { get; set; }
         public CancellationToken CancellationToken { get; set; }
+        public PackageDef OpenTapNugetPackage { get; set; }
+        public IImageDeployer ImageDeployer { get; set; }
 
         /// <summary>
         /// This object represents a trace listener of the type EventTraceListener from the <see cref="OpenTAP"/> assembly
         /// </summary>
         private EventTraceListener traceListener;
+
         void onEvent(IEnumerable<Event> events)
         {
             // These sources are really loud and not relevant to the image install.
@@ -63,7 +81,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
         /// <param name="packagesToInstall"></param>
         /// <param name="repositories"></param>
         /// <returns></returns>
-        public bool InstallImage(ITaskItem[] packagesToInstall, string[] repositories)
+        public bool InstallImage(ITaskItem[] packagesToInstall, List<string> repositories)
         {
             bool success = true;
 
@@ -71,17 +89,21 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             {
                 var install = new Installation(TapDir);
 
+                OpenTapNugetPackage = install.GetOpenTapPackage();
+
                 var imageSpecifier = ImageSpecifierFromTaskItems(packagesToInstall);
                 imageSpecifier.Repositories.AddRange(repositories);
-                var opentap = install.GetOpenTapPackage();
 
-                imageSpecifier.Packages.Add(new PackageSpecifier(opentap.Name,
-                    new VersionSpecifier(opentap.Version.Major, opentap.Version.Minor, opentap.Version.Patch,
-                        opentap.Version.PreRelease, opentap.Version.BuildMetadata, VersionMatchBehavior.Exact)));
+                var openTapSpec = new PackageSpecifier("OpenTAP",
+                    VersionSpecifier.Parse(OpenTapNugetPackage.Version.ToString()));
+
+                imageSpecifier.Packages.Add(openTapSpec);
+
+                ImageDeployer ??= new DefaultImageDeployer();
 
                 try
                 {
-                    imageSpecifier.MergeAndDeploy(install, CancellationToken);
+                    ImageDeployer.Install(imageSpecifier, install, CancellationToken);
                 }
                 catch (ImageResolveException ex)
                 {
@@ -129,9 +151,29 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             foreach (var i in items)
             {
                 var name = i.ItemSpec;
-                // The version of OpenTAP installed through nuget is added manually and should not be considered from task items
-                if (name == "OpenTAP") continue;
                 var versionString = i.GetMetadata("Version");
+
+                // The version of OpenTAP installed through nuget is added manually and should not be considered from task items
+                if (name == "OpenTAP")
+                {
+                    // The version was omitted - this is fine
+                    if (string.IsNullOrWhiteSpace(versionString)) continue;
+                    if (VersionSpecifier.TryParse(versionString, out var versionSpecifier))
+                    {
+                        // The requested version is compatible with the installed version -- this is fine
+                        if (versionSpecifier.IsCompatible(OpenTapNugetPackage.Version)) continue;
+                    }
+
+                    LogMessage(
+                        $"This project was restored using OpenTAP version '{OpenTapNugetPackage.Version}', but version " +
+                        $"'{versionString}' was requested. Changing the version of OpenTAP installed through nuget " +
+                        $"can have unpredictable results and is not supported. Please omit the version from this element.",
+                        (int)LogEventType.Warning, i);
+
+                    continue;
+
+                }
+
                 var archString = i.GetMetadata("Architecture");
                 var os = i.GetMetadata("OS");
 

--- a/sdk/OpenTap.Sdk.MSBuild/Properties/AssemblyInfo.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/Properties/AssemblyInfo.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("9.4.0.0")]
 [assembly: AssemblyFileVersion("9.4.0.0")]
 [assembly: AssemblyInformationalVersion("9.4.0-Development")]
+[assembly: InternalsVisibleTo("OpenTap.Package.UnitTests")]


### PR DESCRIPTION
This adds a specific warning for the special case where another version of OpenTAP is specified with

<OpenTapPackageReference Include='OpenTAP' Version=' ... />

This also adds some mechanisms to make it easier to test MSBuild actions without compiling actual projects (which is tested by TestWindowsPlan anyway)

Closes #112