### PR TITLE
Pipeline warning fixes: missing artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,11 +269,6 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           dotnet vstest bin/OpenTap.UnitTests.dll --logger:"console;verbosity=detailed" -- RunConfiguration.TestSessionTimeout=1200000
-      - uses: actions/upload-artifact@v2
-        with:
-          name: win-testresults
-          path: |
-            TestResult.xml
 
   TestPackage:
     runs-on: windows-2022
@@ -296,12 +291,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           #Copy-Item .\bin\Release\runtimes\win-x64\native\git2-b7bad55.dll .\bin\Release
           cd bin/Release
-          dotnet vstest /framework:.NETFramework,Version=v4.62 /Platform:x64 OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: win-testresults
-          path: |
-            bin/Release/TestResult.xml
+          dotnet vstest /framework:.NETFramework,Version=v4.62 /Platform:x64 OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed"
 
   TestWindowsPlan:
     runs-on: windows-2022
@@ -598,11 +588,6 @@ jobs:
           mv OpenTAP.*.TapPackage OpenTAP.TapPackage
           tap package install "Package Diff" --version any
           tap package diff OpenTAP.TapPackage -o diff
-      - uses: actions/upload-artifact@v2
-        with:
-          name: api-diff-${{ matrix.Package }}
-          retention-days: 14
-          path: diff.html
 
   Package-NuGet:
     runs-on: windows-2022
@@ -854,7 +839,7 @@ jobs:
         with:
           name: package-deb
           retention-days: 14
-          path: LinuxInstall/package/Debian/OpenTAP.deb
+          path: LinuxInstall/package/OpenTAP.deb
 
   ###############
   ### Publish ###

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,7 +564,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        Package: [win-x86, win-x64, linux-x64]
+        Package: [win-x64, linux-x64]
     needs:
       - Package-Win
       - Package-Linux


### PR DESCRIPTION
This fixes a few pipeline warnings that we have just been ignoring since moving to GitHub