### PR TITLE
ProcessStep environment variables

### DIFF
--- a/BasicSteps/ProcessStep.cs
+++ b/BasicSteps/ProcessStep.cs
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -11,6 +13,12 @@ using System.Threading;
 
 namespace OpenTap.Plugins.BasicSteps
 {
+    public class EnvironmentVariable
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+
     [Display("Run Program", Group: "Basic Steps", Description: "Runs a program, and optionally applies regular expressions (regex) to the output.")]
     public class ProcessStep : RegexOutputStep
     {
@@ -29,6 +37,9 @@ namespace OpenTap.Plugins.BasicSteps
         [Display("Working Directory", Order: -2.3, Description: "The directory where the program will be started in.")]
         [DirectoryPath]
         public string WorkingDirectory { get; set; } = "";
+
+        [Display("Environment Variables", Order: -2.25, Description: "The enironment variables passed to the program.")]
+        public VirtualCollection<EnvironmentVariable> EnvironmentVariables { get; set; } = new VirtualCollection<EnvironmentVariable>();
 
         [Display("Wait For Process to End", Order: -2.2,
             Description: "Wait for the process to terminate before continuing.")]
@@ -101,6 +112,11 @@ namespace OpenTap.Plugins.BasicSteps
 
             Int32 timeout = Timeout <= 0 ? Int32.MaxValue : Timeout;
             prepend = string.IsNullOrEmpty(LogHeader) ? "" : LogHeader + " ";
+
+            foreach (var environmentVariable in EnvironmentVariables)
+            {
+                Environment.SetEnvironmentVariable(environmentVariable.Name, environmentVariable.Value);
+            }
 
             var process = new Process
             {

--- a/BasicSteps/ProcessStep.cs
+++ b/BasicSteps/ProcessStep.cs
@@ -84,9 +84,28 @@ namespace OpenTap.Plugins.BasicSteps
         ManualResetEvent outputWaitHandle, errorWaitHandle;
         StringBuilder output;
 
+        public ProcessStep()
+        {
+            Rules.Add(HasNoDuplicateEnvironmentVariables, "Cannot have multiple environment variables with the same name.", nameof(EnvironmentVariables));
+        }
+
+        private bool HasNoDuplicateEnvironmentVariables()
+        {
+            HashSet<string> seenVariables = new HashSet<string>();
+            foreach (var variable in EnvironmentVariables)
+            {
+                if (seenVariables.Contains(variable.Name))
+                {
+                    return false;
+                }
+                seenVariables.Add(variable.Name);
+            }
+            return true;
+        }
+
         public override void Run()
         {
-            
+            ThrowOnValidationError(true);
             if (RunElevated &&!SubProcessHost.IsAdmin())
             {
                 // note, this part is currently never enabled.

--- a/Engine.UnitTests/ProcessStepTest.cs
+++ b/Engine.UnitTests/ProcessStepTest.cs
@@ -59,7 +59,7 @@ namespace OpenTap.UnitTests
             foreach (var variable in variables)
             {
                 string[] strs = variable.Split('=');
-                processStep.EnvironmentVariables.Add(new KeyValuePair<string, string>(strs[0], strs[1]));
+                processStep.EnvironmentVariables.Add(new ProcessStep.EnvironmentVariable { Name = strs[0], Value = strs[1] });
             }
             plan.Steps.Add(processStep);
 

--- a/Engine.UnitTests/ProcessStepTest.cs
+++ b/Engine.UnitTests/ProcessStepTest.cs
@@ -1,0 +1,70 @@
+﻿using NUnit.Framework;
+using OpenTap.Cli;
+using OpenTap.Plugins.BasicSteps;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenTap.UnitTests
+{
+    [Display("print", Groups: new[] { "test", "envvariables" }, Description: "Prints environment variables.")]
+    public class PrintEnvVarAction : ICliAction
+    {
+        public int Execute(CancellationToken cancellationToken)
+        {
+            var log = Log.CreateSource("Environment variables");
+            var variables = Environment.GetEnvironmentVariables();
+            log.Info("Environment variables:");
+            foreach (DictionaryEntry variable in variables)
+            {
+                log.Info($"\t{variable.Key} = {variable.Value}");
+            }
+
+            return (int)ExitCodes.Success;
+        }
+    }
+
+    [TestFixture]
+    public class ProcessStepTest
+    {
+        // Test single env variable.
+        [TestCase(Verdict.Pass, "Ping = Pong", "Ping=Pong")]
+        // Test multiple env variables.
+        [TestCase(Verdict.Pass, "Ping = Pong", "Ping=Pong", "Test=test123")]
+        [TestCase(Verdict.Pass, "Test = test123", "Ping=Pong", "Test=test123")]
+        [TestCase(Verdict.Pass, "(Ping = Pong|Test = test123)", "Ping=Pong", "Test=test123")]
+        // Test duplicate environment variable.
+        [TestCase(Verdict.Error, "", "Ping=Pong", "Ping=Pong")]
+        [TestCase(Verdict.Error, "", "Ping=Pong", "Ping=Ping")]
+        public void ProcessStepSetEnvironmentVariables(Verdict expectedVerdict, string regex, params string[] variables)
+        {
+            var plan = new TestPlan();
+            var processStep = new ProcessStep()
+            {
+                Application = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "tap.exe"),
+                WorkingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                Arguments = "test envvariables print",
+                RegularExpressionPattern = new Enabled<string>()
+                {
+                    IsEnabled = true,
+                    Value = regex,
+                },
+            };
+            foreach (var variable in variables)
+            {
+                string[] strs = variable.Split('=');
+                processStep.EnvironmentVariables.Add(new EnvironmentVariable() { Name = strs[0], Value = strs[1] });
+            }
+            plan.Steps.Add(processStep);
+
+            var result = plan.Execute();
+            Assert.AreEqual(expectedVerdict, result.Verdict);
+        }
+    }
+}

--- a/Engine.UnitTests/ProcessStepTest.cs
+++ b/Engine.UnitTests/ProcessStepTest.cs
@@ -59,7 +59,7 @@ namespace OpenTap.UnitTests
             foreach (var variable in variables)
             {
                 string[] strs = variable.Split('=');
-                processStep.EnvironmentVariables.Add(new EnvironmentVariable() { Name = strs[0], Value = strs[1] });
+                processStep.EnvironmentVariables.Add(new KeyValuePair<string, string>(strs[0], strs[1]));
             }
             plan.Steps.Add(processStep);
 

--- a/tests/test-cli-environment-variables.TapPlan
+++ b/tests/test-cli-environment-variables.TapPlan
@@ -130,8 +130,4 @@
   </Steps>
   <BreakConditions>Inherit</BreakConditions>
   <OpenTap.Description />
-  <Package.Dependencies>
-    <Package Name="Test" Version="^1.2.3-alpha+test" />
-    <Package Name="Test2" Version="^1.2.3+4" />
-  </Package.Dependencies>
 </TestPlan>

--- a/tests/test-cli-environment-variables.TapPlan
+++ b/tests/test-cli-environment-variables.TapPlan
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestPlan type="OpenTap.TestPlan" Locked="false">
+  <Steps>
+    <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.ExpectStep" Version="0.0.0" Id="a6a2a4e0-2a7c-4f3f-9543-c37fa2a1ba35">
+      <ExpectedVerdict>Pass</ExpectedVerdict>
+      <Enabled>true</Enabled>
+      <Name>Expect pass</Name>
+      <ChildTestSteps>
+        <TestStep type="OpenTap.Plugins.BasicSteps.ProcessStep" Version="9.4.0-Development" Id="72d4d5d8-8cd7-4ecc-b642-82660dfdb02d">
+          <Application>tap</Application>
+          <Arguments>test envvariables print</Arguments>
+          <WorkingDirectory></WorkingDirectory>
+          <EnvironmentVariables>
+            <EnvironmentVariable>
+              <Name>t</Name>
+              <Value>normal name</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>
+                <Base64>IHQ=</Base64>
+              </Name>
+              <Value>leading whitespace</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>
+                <Base64>dCA=</Base64>
+              </Name>
+              <Value>trailing whitespace</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>
+                <Base64>IA==</Base64>
+              </Name>
+              <Value>whitespace</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>=</Name>
+              <Value>equals symbol</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>'</Name>
+              <Value>special character 1</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>`</Name>
+              <Value>special character 2</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>&amp;</Name>
+              <Value>special character 3</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>/</Name>
+              <Value>special character 4</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>\</Name>
+              <Value>special character 5</Value>
+            </EnvironmentVariable>
+            <EnvironmentVariable>
+              <Name>µ</Name>
+              <Value>special character 6</Value>
+            </EnvironmentVariable>
+          </EnvironmentVariables>
+          <WaitForEnd>true</WaitForEnd>
+          <Timeout>0</Timeout>
+          <AddToLog>false</AddToLog>
+          <CheckExitCode>true</CheckExitCode>
+          <RegularExpressionPattern>
+            <Value>(.*)</Value>
+            <IsEnabled>false</IsEnabled>
+          </RegularExpressionPattern>
+          <VerdictOnMatch>Pass</VerdictOnMatch>
+          <VerdictOnNoMatch>Fail</VerdictOnNoMatch>
+          <ResultRegularExpressionPattern>
+            <Value>(.*)</Value>
+            <IsEnabled>false</IsEnabled>
+          </ResultRegularExpressionPattern>
+          <ResultName>Regex Result</ResultName>
+          <Behavior>GroupsAsDimensions</Behavior>
+          <DimensionTitles></DimensionTitles>
+          <Enabled>true</Enabled>
+          <Name>Run Program</Name>
+          <ChildTestSteps />
+          <BreakConditions>Inherit</BreakConditions>
+        </TestStep>
+      </ChildTestSteps>
+      <BreakConditions>Inherit</BreakConditions>
+    </TestStep>
+    <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.ExpectStep" Version="0.0.0" Id="449d8a7e-7925-4444-883f-48dbdbba8d71">
+      <ExpectedVerdict>Error</ExpectedVerdict>
+      <Enabled>true</Enabled>
+      <Name>Expect fail</Name>
+      <ChildTestSteps>
+        <TestStep type="OpenTap.Plugins.BasicSteps.ProcessStep" Version="9.4.0-Development" Id="6a6d9fa9-8a62-4977-a309-3f47e93e3fbb">
+          <Application>tap</Application>
+          <Arguments>test envvariables print</Arguments>
+          <WorkingDirectory></WorkingDirectory>
+          <EnvironmentVariables>
+            <EnvironmentVariable>
+              <Name></Name>
+              <Value>empty</Value>
+            </EnvironmentVariable>
+          </EnvironmentVariables>
+          <WaitForEnd>true</WaitForEnd>
+          <Timeout>0</Timeout>
+          <AddToLog>false</AddToLog>
+          <CheckExitCode>true</CheckExitCode>
+          <RegularExpressionPattern>
+            <Value>(.*)</Value>
+            <IsEnabled>false</IsEnabled>
+          </RegularExpressionPattern>
+          <VerdictOnMatch>Pass</VerdictOnMatch>
+          <VerdictOnNoMatch>Fail</VerdictOnNoMatch>
+          <ResultRegularExpressionPattern>
+            <Value>(.*)</Value>
+            <IsEnabled>false</IsEnabled>
+          </ResultRegularExpressionPattern>
+          <ResultName>Regex Result</ResultName>
+          <Behavior>GroupsAsDimensions</Behavior>
+          <DimensionTitles></DimensionTitles>
+          <Enabled>true</Enabled>
+          <Name>Run Program</Name>
+          <ChildTestSteps />
+          <BreakConditions>Inherit</BreakConditions>
+        </TestStep>
+      </ChildTestSteps>
+      <BreakConditions>Inherit</BreakConditions>
+    </TestStep>
+  </Steps>
+  <BreakConditions>Inherit</BreakConditions>
+  <OpenTap.Description />
+  <Package.Dependencies>
+    <Package Name="Test" Version="^1.2.3-alpha+test" />
+    <Package Name="Test2" Version="^1.2.3+4" />
+  </Package.Dependencies>
+</TestPlan>


### PR DESCRIPTION
Adds environment variables as a parameter to the ProcessStep, as a new feature requested by #476 
Duplicate environment variables will fail, however multiple different environment variables can be added.

Also added a new test CLI action to the engine unit tests to print environment variables this way it is possible to use a regex to prove the environment variables have been set.
Added 6 testcases to test the process step environmet variables
* One test for a single environment variable
* Three tests for multiple environment variables
* Two tests for duplicate environment variables
Closes #476 