### PR TITLE
Waiting for ressource race condition

### DIFF
--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -95,10 +95,16 @@ namespace OpenTap
 
         internal static void PrintWaitingMessage(IEnumerable<IResource> resources)
         {
-            Log.Info("Waiting for resources to open:");
-            foreach (var resource in resources)
+            // Save disconnected ressources to avoid race conditions.
+            var waitingRessources = resources.Where(r => !r.IsConnected).ToList();
+            if (waitingRessources.Count == 0)
             {
-                if (resource.IsConnected) continue;
+                return;
+            }
+
+            Log.Info("Waiting for resources to open:");
+            foreach (var resource in waitingRessources)
+            {
                 Log.Info(" - {0}", resource);
             }
         }

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -96,8 +96,8 @@ namespace OpenTap
         internal static void PrintWaitingMessage(IEnumerable<IResource> resources)
         {
             // Save disconnected ressources to avoid race conditions.
-            var waitingRessources = resources.Where(r => !r.IsConnected).ToList();
-            if (waitingRessources.Count == 0)
+            var waitingRessources = resources.Where(r => !r.IsConnected).ToArray();
+            if (waitingRessources.Length == 0)
             {
                 return;
             }


### PR DESCRIPTION
Fixed race condition when ressources are waiting to open, by saving the disconnected ressources to a list before starting to print the message.

This should fix #121
Testing on this one is hard as it is hard to recreate the race condition reliably. Thus no testing has been done yet.