### PR TITLE
230 improve handling of unloadable plugins

### DIFF
--- a/Engine/PluginManager.cs
+++ b/Engine/PluginManager.cs
@@ -189,7 +189,10 @@ namespace OpenTap
         {
             PluginSearcher searcher = GetSearcher();
             return searcher.PluginTypes
-                .Where(st => !st.TypeAttributes.HasFlag(TypeAttributes.Interface) && !st.TypeAttributes.HasFlag(TypeAttributes.Abstract))
+                .Where(st =>
+                    !st.TypeAttributes.HasFlag(TypeAttributes.Interface)
+                    && !st.TypeAttributes.HasFlag(TypeAttributes.Abstract)
+                    && st.Status != LoadStatus.FailedToLoad)
                 .ToList().AsReadOnly();
         }
 


### PR DESCRIPTION
Make GetAllPlugins not return plugins which failed to load.

In general, it looks like we currently handle unloadable plugins okay. `GetAllPlugins` should be easier to use now that it doesn't return incompatible plugins.

`TypeData.GetDerivedTypes` does not need to be modified because all the `DescendsTo` logic already returns false if a candidate for a derived type fails to load.

Closes #230 