### PR TITLE
575 and 78 Cleanup help message

### DIFF
--- a/Engine/Cli/CliActionExecutor.cs
+++ b/Engine/Cli/CliActionExecutor.cs
@@ -272,13 +272,9 @@ namespace OpenTap.Cli
                 string tapCommand = OperatingSystem.Current == OperatingSystem.Windows ? "tap.exe" : "tap";
 
                 log.Info("OpenTAP Command Line Interface ({0})", getVersion());
-                if (args.Length == 0)
+                if (args.Length != 0)
                 {
-                    log.Info($"\"{tapCommand}\" is not a recognized command.");
-                }
-                else
-                {
-                    log.Info($"\"{tapCommand} {string.Join(" ", args)}\" is not a recognized command.");
+                    log.Error($"\"{tapCommand} {string.Join(" ", args)}\" is not a recognized command.");
                 }
                 log.Info($"Usage: \"{tapCommand} <command> [<subcommand(s)>] [<args>]\"\n");
 

--- a/Engine/Cli/CliActionExecutor.cs
+++ b/Engine/Cli/CliActionExecutor.cs
@@ -269,13 +269,22 @@ namespace OpenTap.Cli
 
                     return TypeData.FromType(typeof(CliActionExecutor)).Assembly.SemanticVersion.ToString(); // OpenTAP is not installed. lets just return this. 
                 }
+                string tapCommand = OperatingSystem.Current == OperatingSystem.Windows ? "tap.exe" : "tap";
 
-                Console.WriteLine("OpenTAP Command Line Interface ({0})", getVersion());
-                Console.WriteLine("Usage: tap <command> [<subcommand(s)>] [<args>]\n");
+                log.Info("OpenTAP Command Line Interface ({0})", getVersion());
+                if (args.Length == 0)
+                {
+                    log.Info($"\"{tapCommand}\" is not a recognized command.");
+                }
+                else
+                {
+                    log.Info($"\"{tapCommand} {string.Join(" ", args)}\" is not a recognized command.");
+                }
+                log.Info($"Usage: \"{tapCommand} <command> [<subcommand(s)>] [<args>]\"\n");
 
                 if (selectedcmd == null)
                 {
-                    Console.WriteLine("Valid commands are:");
+                    log.Info("Valid commands are:");
                     foreach (var cmd in actionTree.SubCommands)
                     {
                         print_command(cmd, 0, actionTree.GetMaxCommandTreeLength(LevelPadding) + LevelPadding);
@@ -283,12 +292,11 @@ namespace OpenTap.Cli
                 }
                 else
                 {
-                    Console.Write("Valid subcommands of ");
+                    log.Info($"Valid subcommands of");
                     print_command(selectedcmd, 0, actionTree.GetMaxCommandTreeLength(LevelPadding) + LevelPadding);
                 }
 
-                Console.WriteLine($"\nRun \"{(OperatingSystem.Current == OperatingSystem.Windows ? "tap.exe" : "tap")} " +
-                                   "<command> [<subcommand>] -h\" to get additional help for a specific command.\n");
+                log.Info($"\nRun \"{tapCommand} <command> [<subcommand(s)>] -h\" to get additional help for a specific command.\n");
 
                 if (args.Length == 0 || args.Any(s => s.ToLower() == "--help" || s.ToLower() == "-h"))
                     return (int)ExitCodes.Success;

--- a/Engine/Cli/CliActionExecutor.cs
+++ b/Engine/Cli/CliActionExecutor.cs
@@ -271,11 +271,11 @@ namespace OpenTap.Cli
                 }
                 string tapCommand = OperatingSystem.Current == OperatingSystem.Windows ? "tap.exe" : "tap";
 
-                log.Info("OpenTAP Command Line Interface ({0})", getVersion());
                 if (args.Length != 0)
                 {
                     log.Error($"\"{tapCommand} {string.Join(" ", args)}\" is not a recognized command.");
                 }
+                log.Info("OpenTAP Command Line Interface ({0})", getVersion());
                 log.Info($"Usage: \"{tapCommand} <command> [<subcommand(s)>] [<args>]\"\n");
 
                 if (selectedcmd == null)


### PR DESCRIPTION
Cleanup the help message a bit to make it more uniform, update it to use log.info() rather than Console.WriteLine(),
this also means that messages now arrive in the console in the correct order.
Also prints an error message for incorrect command usage.

**Closes** #575 and #78

**Example of message before:**
```
PS C:\Users\fredandr\opentap\bin\Debug> .\tap.exe package notvalid
OpenTAP Command Line Interface (9.18.0-alpha.18+cf121119.i215-UninstallingMultiplePacka)
Usage: tap <command> [<subcommand(s)>] [<args>]

Valid subcommands of
Run "tap.exe <command> [<subcommand>] -h" to get additional help for a specific command.

package
   create                 Create a package based on an XML description file.
   download               Download one or more packages.
   install                Install one or more packages.
   list                   List locally installed packages and browse the online package repository.
   show                   Show information about a package.
   test                   Run tests on one or more packages.
   uninstall              Uninstall one or more packages.
   verify                 Verify the integrity of one or all installed packages by checking their fingerprints.
PS C:\Users\fredandr\opentap\bin\Debug>
```

**Example of message after:**
```
PS C:\Users\fredandr\opentap\bin\Debug> .\tap.exe package notvalid
OpenTAP Command Line Interface (9.18.0-alpha.18+cf121119.i215-UninstallingMultiplePacka)
"tap.exe package notvalid" is not a recognized command.
Usage: "tap.exe <command> [<subcommand(s)>] [<args>]"

Valid subcommands of
package
   create                 Create a package based on an XML description file.
   download               Download one or more packages.
   install                Install one or more packages.
   list                   List locally installed packages and browse the online package repository.
   show                   Show information about a package.
   test                   Run tests on one or more packages.
   uninstall              Uninstall one or more packages.
   verify                 Verify the integrity of one or all installed packages by checking their fingerprints.

Run "tap.exe <command> [<subcommand(s)>] -h" to get additional help for a specific command.

PS C:\Users\fredandr\opentap\bin\Debug>
```