### PR TITLE
329 SweepLoopError

### DIFF
--- a/BasicSteps/BasicStepsAnnotator.cs
+++ b/BasicSteps/BasicStepsAnnotator.cs
@@ -408,6 +408,7 @@ namespace OpenTap.Plugins.BasicSteps
             TapSerializer tapSerializer;
             object cloneIfPossible(object value, object context)
             {
+                if (value == null) return null;
                 if (StringConvertProvider.TryGetString(value, out string result))
                 {
                     if (StringConvertProvider.TryFromString(result, TypeData.GetTypeData(value), context, out object result2))

--- a/BasicSteps/SweepParam.cs
+++ b/BasicSteps/SweepParam.cs
@@ -86,6 +86,7 @@ namespace OpenTap.Plugins.BasicSteps
         TapSerializer serializer = null;
         object cloneObject(object newValue)
         {
+            if (newValue == null) return null;
             if (StringConvertProvider.TryGetString(newValue, out string str))
             {
                 if (StringConvertProvider.TryFromString(str, TypeData.GetTypeData(newValue), this.Step, out object result))


### PR DESCRIPTION
Fixed an issue caused by trying to null values with a TapSerializer, which is not possible. This caused an error in the LegacySweepLoop.

The reason why this occurs with DialogStep is that the picture Source is null and not "" when it is created.