### PR TITLE
481 Re-add the childStepsChanged event when ChildTestSteps instance is changed

### DIFF
--- a/BasicSteps/SweepLoopRange.cs
+++ b/BasicSteps/SweepLoopRange.cs
@@ -50,7 +50,8 @@ namespace OpenTap.Plugins.BasicSteps
         [EnabledIf("SweepBehavior", SweepBehavior.Linear, HideIfDisabled = true)]
         [XmlIgnore] // this is inferred from the other properties and should not be set by the serializer
         [Browsable(true)]
-        public decimal SweepStep {
+        public decimal SweepStep
+        {
             get
             {
                 if (SweepPoints == 0) return 0;
@@ -185,8 +186,15 @@ namespace OpenTap.Plugins.BasicSteps
             Rules.Add(() => ((SweepBehavior != SweepBehavior.Exponential)) || (Math.Sign(SweepStop) == Math.Sign(SweepStart)), "Sweep start and end value must have the same sign.", "SweepEnd", "SweepStart");
 
             ChildTestSteps.ChildStepsChanged += childStepsChanged;
+            PropertyChanged += SweepLoopRange_PropertyChanged;
         }
-        
+
+        void SweepLoopRange_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ChildTestSteps))
+                ChildTestSteps.ChildStepsChanged += childStepsChanged;
+        }
+
         readonly Dictionary<IMemberData, object> membersCache = new Dictionary<IMemberData, object>();
         void childStepsChanged(TestStepList sender, TestStepList.ChildStepsChangedAction Action, ITestStep Object, int Index)
         {

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -1294,6 +1294,9 @@ namespace OpenTap
         }
     }
 
+    /// <summary>
+    /// Marks a property as not a setting. This is a performance optimization for when finding resources throughout the test plan.
+    /// </summary>
     internal class SettingsIgnoreAttribute : Attribute
     { }
 }


### PR DESCRIPTION
During serialization we overwrite the value of TestStepList on teststeps
which caused issues for Sweep Loop Range because it sets up the event in its constructor.

It now listens for the PropertyChanged event and sets up the callback in this case.

Closes #481