### PR TITLE
Workflow fixes for pull requests from forked repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,29 @@ jobs:
 
   CheckSecrets:
     runs-on: ubuntu-latest
+    environment: sign
     outputs:
       gitlab_registry_token_is_set: ${{ steps.check_GITLAB_REGISTRY_TOKEN.outputs.is_set }}
+      sign_is_set: ${{ steps.check_sign.outputs.is_set }}
     steps:
       - id: check_GITLAB_REGISTRY_TOKEN
         name: Check whether GITLAB_REGISTRY_TOKEN is set
         run: |
           if [ -z "${{ secrets.GITLAB_REGISTRY_TOKEN }}" ]; then
+            echo "Not set"
+            echo "::set-output name=is_set::false"
+          else
+            echo "Set"
+            echo "::set-output name=is_set::true"
+          fi
+      - id: check_sign
+        name: Check whether sign secrets are set
+        run: |
+          if [ -z "${{ secrets.SIGN_SERVER_CERT }}" -o \
+               -z "${{ secrets.TAP_SIGN_ADDRESS }}" -o \
+               -z "${{ secrets.TAP_SIGN_AUTH }}"    -o \
+               -z "${{ secrets.S3_KEY_ID }}"        -o \
+               -z "${{ secrets.S3_SECRET }}" ]; then
             echo "Not set"
             echo "::set-output name=is_set::false"
           else
@@ -390,12 +406,14 @@ jobs:
   ### Package ###
   ###############
   Package-Win:
+    if: needs.CheckSecrets.outputs.sign_is_set == 'true'
     runs-on: windows-2022
     environment: sign
     strategy:
       matrix:
         Architecture: [x86, x64]
     needs:
+      - CheckSecrets
       - Build-Win
       - Build-ApiDoc
       - GetVersion
@@ -458,9 +476,11 @@ jobs:
             OpenTAP.*.Windows.TapPackage
 
   Package-Linux:
+    if: needs.CheckSecrets.outputs.sign_is_set == 'true'
     runs-on: windows-2022
     environment: sign
     needs:
+      - CheckSecrets
       - Build-Win
       - Build-Linux
       - Build-ApiDoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,28 @@ jobs:
         id: gitVer
         run: echo ::set-output name=ver::$(tap sdk gitversion)
 
+  CheckSecrets:
+    runs-on: ubuntu-latest
+    outputs:
+      gitlab_registry_token_is_set: ${{ steps.check_GITLAB_REGISTRY_TOKEN.outputs.is_set }}
+    steps:
+      - id: check_GITLAB_REGISTRY_TOKEN
+        name: Check whether GITLAB_REGISTRY_TOKEN is set
+        run: |
+          if [ -z "${{ secrets.GITLAB_REGISTRY_TOKEN }}" ]; then
+            echo "Not set"
+            echo "::set-output name=is_set::false"
+          else
+            echo "Set"
+            echo "::set-output name=is_set::true"
+          fi
+
   ##############
   ### BUILDS ###
   ##############
   Build-DevGuide:
+    needs: CheckSecrets
+    if: needs.CheckSecrets.outputs.gitlab_registry_token_is_set == 'true'
     runs-on: ubuntu-latest
     container:
       image: registry.gitlab.com/opentap/buildrunners/documentationgeneration:latest
@@ -73,6 +91,8 @@ jobs:
             sdk/Examples/OpenTAP Developer Guide.pdf
 
   Build-ApiDoc:
+    needs: CheckSecrets
+    if: needs.CheckSecrets.outputs.gitlab_registry_token_is_set == 'true'
     runs-on: ubuntu-latest
     container:
       image: registry.gitlab.com/opentap/buildrunners/doxygen:alpine


### PR DESCRIPTION
Resolves #595

The fix is inspired by [Using secrets](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets), [Using encripted secrets in a workflow](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow), and [Context availability](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability).

Commit 838bf92738c5ccce5412a5a04162d8c76f872884 is for my own benefit when running workflows on the `g-galante/opentap` fork with my own local `GITLAB_REGISTRY_TOKEN`.

Not all jobs are protected from failing for missing secrets, but the fix is easily extensible to cover them in case somebody needs to test workflows in his/her own fork with only a subset of the secrets defined.