### PR TITLE
Split package create into multiple steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,22 +452,23 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET }}
-      - name: Package
-        run: |
-          $env:Platform = "Windows"
-          $env:Architecture =  "${{ matrix.Architecture }}"
-          cd bin/Release-x64
-          # this is only needed for .net6 
-          #cp .\runtimes\win-x64\native\git2-b7bad55.dll .
-          .\tap.exe package install -f ../../sign.TapPackage
-          echo "${{ secrets.SIGN_SERVER_CERT }}" > $env:TAP_SIGN_CERT
-          cd ../Release-${{ matrix.Architecture }}
-          ..\Release-x64\tap.exe package create -v -c ../../package.xml -o ../../OpenTAP.${{needs.GetVersion.outputs.GitVersion}}.${{ matrix.Architecture }}.Windows.TapPackage
+      - name: Install Sign
+        working-directory: bin/Release-x64
+        run: .\tap.exe package install -f ../../sign.TapPackage        
+      - name: Write Sign Cert
+        env: 
+          TAP_SIGN_CERT: ${{ github.workspace }}/sign.cer
+        run:  echo "${{ secrets.SIGN_SERVER_CERT }}" > $env:TAP_SIGN_CERT
+      - name: Create Package
+        working-directory: bin/Release-${{ matrix.Architecture }}
         env: 
           TAP_SIGN_ADDRESS: ${{ secrets.TAP_SIGN_ADDRESS }}
           TAP_SIGN_AUTH:  ${{ secrets.TAP_SIGN_AUTH }}
           TAP_SIGN_CERT: ${{ github.workspace }}/sign.cer
-          Sign: ${{github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/v')}}
+          Sign: ${{github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/v')}}          
+          Platform: "Windows"
+          Architecture:  "${{ matrix.Architecture }}"
+        run: .\tap.exe package create -v -c ../../package.xml -o ../../OpenTAP.${{steps.gitversion.outputs.GitVersion}}.${{ matrix.Architecture }}.Windows.TapPackage          
       - uses: actions/upload-artifact@v2
         with:
           name: win-${{ matrix.Architecture }}-package


### PR DESCRIPTION
package-win fails intermittently, and it is hard to tell from the logs what's going wrong.

It should at least help, if not fix the issue, if we split it into multiple steps.