### PR TITLE
599 remove RedirectAssembly

### DIFF
--- a/Engine/PluginManager.cs
+++ b/Engine/PluginManager.cs
@@ -287,31 +287,6 @@ namespace OpenTap
             }
         }
 
-
-        /// <summary>
-        /// This method is required to redirect searches for certain assemblies, in case they are not the same version number.
-        /// Without this runtime errors can occur in strange circumstances, such as when running a program from a shortened path. E.g. C:\progra~1\Keysight\Tap\keysight.tap.gui.exe
-        /// </summary>
-        internal static void RedirectAssembly(string shortName, Version targetVersion)
-        {
-            Assembly handler(object sender, ResolveEventArgs args)
-            {
-                // Use latest strong name & version when trying to load SDK assemblies
-                var requestedAssembly = new AssemblyName(args.Name);
-                if (requestedAssembly.Name != shortName)
-                    return null;
-
-                requestedAssembly.Version = targetVersion;
-
-                AppDomain.CurrentDomain.AssemblyResolve -= handler;
-
-                return Assembly.Load(requestedAssembly);
-            }
-
-            AppDomain.CurrentDomain.AssemblyResolve += handler;
-        }
-
-
         static bool isLoaded = false;
         static object loadLock = new object();
         /// <summary> Sets up the PluginManager assembly resolution systems. Under normal circumstances it is not needed to call this method directly.</summary>
@@ -327,15 +302,13 @@ namespace OpenTap
                 string tapEnginePath = Assembly.GetExecutingAssembly().Location;
                 if(String.IsNullOrEmpty(tapEnginePath))
                 {
-                    // if Tap.Engine was loaded from memory/bytes instead of from a file, it does not have a location.
+                    // if OpenTap.dll was loaded from memory/bytes instead of from a file, it does not have a location.
                     // This is the case if the process was launched through tap.exe. 
                     // In that case just use the location of tap.exe, it is the same
                     tapEnginePath = Assembly.GetEntryAssembly().Location;
                 }
                 DirectoriesToSearch = new List<string> { Path.GetDirectoryName(tapEnginePath) };
                 assemblyResolver = new TapAssemblyResolver(DirectoriesToSearch);
-
-                RedirectAssembly("System.Collections.Immutable", Version.Parse("1.2.1.0"));
 
                 // Custom Assembly resolvers.
                 AppDomain.CurrentDomain.GetAssemblies().ToList().ForEach(assemblyResolver.AddAssembly);

--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -428,6 +428,7 @@ namespace OpenTap
                     }
                     catch
                     {
+                        // fixes an issue in the plugin searcher if it tries to scan an assembly with native types in it.
                     }
                 }
             }


### PR DESCRIPTION
The RedirectAssembly method was added in 2017 to fix a bug that prevented running
tap8 from a tap7 installation, but today it has resurfaced as a bug:
https://forum.opentap.io/t/editor-exe-hangs-when-using-another-system-collections-immutable-dll-version/698/6

The bug seems to be fixed by removing this legacy workaround

Closes #599