### PR TITLE
603 throw OperationCanceledException on UAC cancel

### DIFF
--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -254,6 +254,11 @@ namespace OpenTap.Package
 
                 installer.PackagePaths.AddRange(downloadedPackageFiles);
             }
+            catch (OperationCanceledException e)
+            {
+                log.Info(e.Message);
+                return (int) ExitCodes.UserCancelled;
+            }
             catch (Exception e)
             {
                 log.Info("Could not download one or more packages.");

--- a/Shared/SubProcessHost.cs
+++ b/Shared/SubProcessHost.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
@@ -115,7 +116,17 @@ namespace OpenTap
         {
             var plan = new TestPlan();
             plan.ChildTestSteps.Add(step);
-            return Run(plan, elevate, token);
+            try
+            {
+                return Run(plan, elevate, token);
+            }
+            catch (Win32Exception ex)
+            {
+                // This happens when the UAC dialog is cancelled. It should be treated as an OperationCanceledException.
+                if (ex.Message.Contains("The operation was canceled by the user"))
+                    throw new OperationCanceledException(ex.Message);
+                throw;
+            }
         }
 
         public Verdict Run(TestPlan step, bool elevate, CancellationToken token)


### PR DESCRIPTION
It looks like the UAC dialog throws a Win32Exception when the user clicks 'no'. This should be interpreted as an OperationCanceledException.

Closes #603