### PR TITLE
118 expected exception

### DIFF
--- a/Engine.UnitTests/TestPlanTest.cs
+++ b/Engine.UnitTests/TestPlanTest.cs
@@ -36,6 +36,21 @@ namespace OpenTap.Engine.UnitTests
             }
         }
 
+        public class TestStepExpectedExceptionTest : TestStep
+        {
+            private Verdict _verdict;
+
+            public TestStepExpectedExceptionTest(Verdict verdict)
+            {
+                _verdict = verdict;
+            }
+
+            public override void Run()
+            {
+                throw new ExpectedException("", _verdict);
+            }
+        }
+
         public class TestStepPreExceptionTest : TestStep
         {
             public override void PrePlanRun()
@@ -177,6 +192,23 @@ namespace OpenTap.Engine.UnitTests
             {
                 EngineSettings.Current.AbortTestPlan = preAbortTestPlan;
             }
+        }
+
+        [TestCase(Verdict.Pass)]
+        [TestCase(Verdict.Aborted)]
+        [TestCase(Verdict.Inconclusive)]
+        [TestCase(Verdict.NotSet)]
+        [TestCase(Verdict.Error)]
+        [TestCase(Verdict.Fail)]
+        public void TestPlanStepExpectedExceptionTest(Verdict verdict)
+        {
+            TestPlan plan = new TestPlan();
+            TestStepExpectedExceptionTest step = new TestStepExpectedExceptionTest(verdict);
+
+            plan.Steps.Add(step);
+
+            TestPlanRun result = plan.Execute();
+            Assert.AreEqual(verdict, result.Verdict);
         }
 
         [Test]

--- a/Engine/ExpectedException.cs
+++ b/Engine/ExpectedException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenTap
+{
+    /// <summary>
+    /// Used to cancel a teststep without printing a stacktrace, will also set the verdice if necessary,
+    /// </summary>
+    public class ExpectedException : Exception
+    {
+        public ExpectedException(string message = "", Verdict verdict = Verdict.Error): base(message)
+        {
+            Verdict = verdict;
+        }
+
+        public Verdict Verdict { get; set; }
+
+        
+    }
+}

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -925,6 +925,18 @@ namespace OpenTap
                 TestPlan.Log.Info(e.Message);
                 Step.Verdict = Verdict.Error;
             }
+            catch (ExpectedException e)
+            {
+                if (string.IsNullOrWhiteSpace(e.Message))
+                {
+                    TestPlan.Log.Info("Test step {0} stopped expectedly.", Step.Name);
+                }
+                else
+                {
+                    TestPlan.Log.Info("Test step {0} stopped expectedly with message {1}.", Step.Name, e.Message);
+                }
+                Step.Verdict = e.Verdict;
+            }
             catch (Exception e)
             {
                 


### PR DESCRIPTION
Adds an expected exception for when a teststep throws expectedly.
Used for canceling a test step wihtout logging a stacktrace to the console.
The expected exception can also set the verdict of the test-step.

Fixes #118 