### PR TITLE
613 Instrument2Instrument Reference error:

### DIFF
--- a/Engine/SerializerPlugins/ResourceSerializer.cs
+++ b/Engine/SerializerPlugins/ResourceSerializer.cs
@@ -158,7 +158,19 @@ namespace OpenTap.Plugins
                 var container = ComponentSettingsList.GetContainer(type);
                 var index = container.IndexOf(obj);
                 if (index == -1)
+                {
+                    if (container is IComponentSettingsList lst)
+                    {
+                        if (lst.GetRemovedAliveResources().Contains(obj))
+                        {  // skip serializing if the referenced instrument has been deleted.
+                            elem.Remove();
+                            return true;
+                        }
+                    }
+                    // serialize it normally / in-place.
                     return false;
+                }
+
                 if (index != -1)
                 {
                     if (obj is Connection con)

--- a/Shared/ReflectionHelper.cs
+++ b/Shared/ReflectionHelper.cs
@@ -1149,6 +1149,14 @@ namespace OpenTap
             foreach (var value in values)
                 lst.Add(value);
         }
+        
+        [Obsolete("Cannot add to array", true)]
+        public static void AddRange<T>(this T[] lst, IEnumerable<T> values)
+        {
+            // This function is intentionally added to avoid adding the arrays.
+            // They also implement IList, so they normally hit the other overload.
+            throw new NotSupportedException();
+        }
 
         /// <summary>
         /// Creates a HashSet from an IEnumerable.

--- a/Shared/Tap.Shared.projitems
+++ b/Shared/Tap.Shared.projitems
@@ -31,5 +31,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)ProcessCliAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PipeReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SudoHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WeakHashSet.cs" />
   </ItemGroup>
 </Project>

--- a/Shared/WeakHashSet.cs
+++ b/Shared/WeakHashSet.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+class WeakHashSet<T> where T: class
+{
+    readonly ConditionalWeakTable<T, object> table = new ConditionalWeakTable<T, object>();
+
+    private readonly List<WeakReference<T>> lst = new List<WeakReference<T>>(); 
+    static object value = new object();
+    public bool Contains(T obj) => table.TryGetValue(obj, out var _);
+
+    public bool Add(T obj)
+    {
+        if (table.TryGetValue(obj, out var _))
+            return false;
+        table.Add(obj, value);
+        var free = lst.FirstOrDefault(x => x.TryGetTarget(out _) == false);
+        if(free != null)
+            free.SetTarget(obj);
+        else
+            lst.Add(new WeakReference<T>(obj));
+        return true;
+    }
+
+    public IEnumerable<T> GetElements()
+    {
+        foreach (var item in lst)
+        {
+            if (item.TryGetTarget(out T x))
+                yield return x;
+        }
+    }
+}


### PR DESCRIPTION
- Added detection of using deleted resources and failing the test plan run if that is the case.
- Added annotation so that resources annotations will show an error if a deleted resources is being used.
- Added that XMlSerializer should not serialize deleted resources.
- Added a unit test to verify that it works as intended.

Closes #613 