### PR TITLE
Add secret flag to disable isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,7 +454,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET }}
       - name: Install Sign
         working-directory: bin/Release-x64
-        run: .\tap.exe package install -f -v ../../sign.TapPackage        
+        run: .\tap.exe package install -f -v --no-isolation ../../sign.TapPackage        
       - name: Write Sign Cert
         env: 
           TAP_SIGN_CERT: ${{ github.workspace }}/sign.cer
@@ -468,7 +468,7 @@ jobs:
           Sign: ${{github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/v')}}          
           Platform: "Windows"
           Architecture:  "${{ matrix.Architecture }}"
-        run: ..\Release-x64\tap.exe package create -v -c ../../package.xml -o ../../OpenTAP.${{steps.gitversion.outputs.GitVersion}}.${{ matrix.Architecture }}.Windows.TapPackage          
+        run: ..\Release-x64\tap.exe package create -v -c ../../package.xml -o ../../OpenTAP.${{ needs.GetVersion.outputs.GitVersion }}.${{ matrix.Architecture }}.Windows.TapPackage          
       - uses: actions/upload-artifact@v2
         with:
           name: win-${{ matrix.Architecture }}-package
@@ -530,7 +530,7 @@ jobs:
           echo "${{ secrets.SIGN_SERVER_CERT }}" > $env:TAP_SIGN_CERT
           cp .\runtimes\win-x64\native\git2-b7bad55.dll .
           ..\Release\tap package create -v -c ../../package.xml -o Packages/OpenTAP.Linux.TapPackage
-          cp Packages/OpenTAP.Linux.TapPackage ../../OpenTAP.${{needs.GetVersion.outputs.GitVersion}}.Linux.TapPackage
+          cp Packages/OpenTAP.Linux.TapPackage ../../OpenTAP.${{ needs.GetVersion.outputs.GitVersion }}.Linux.TapPackage
         env: 
           TAP_SIGN_ADDRESS: ${{ secrets.TAP_SIGN_ADDRESS }}
           TAP_SIGN_AUTH:  ${{ secrets.TAP_SIGN_AUTH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,7 +677,7 @@ jobs:
           Move-Item ./bin/Release/Keysight.OpenTap.Sdk.MSBuild.dll ./nuget/build
           Move-Item ./bin/Release/DotNet.Glob.NetStandard1.1.dll ./nuget/build/DotNet.Glob.dll
           echo "Install opentap"    
-          ./bin/Release/tap package install ./OpenTap.x64.zip -t ./nuget/build/payload -f
+          ./bin/Release/tap package install ./OpenTap.x64.zip -t ./nuget/build/payload -f -v --no-isolation
           # package.xml, tap.dll, and tap.runtimeconfig.json of an installation should always come from 
           # one of the Runtime directories. Delete it from the payload directory.
           Remove-Item ./nuget/build/payload/Packages/OpenTAP/package.xml

--- a/Package/PackageActions/IsolatedPackageAction.cs
+++ b/Package/PackageActions/IsolatedPackageAction.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -25,6 +26,11 @@ namespace OpenTap.Package
         /// </summary>
         [CommandLineArgument("force", Description = "Try to run in spite of errors.", ShortName = "f")]
         public bool Force { get; set; }
+        
+        [Browsable(false)]
+        [CommandLineArgument("no-isolation", Description = "Avoid starting an isolated process.")]
+        internal bool NoIsolation { get; set; }
+        
 
         /// <summary>
         /// Executes this the action. Derived types should override LockedExecute instead of this.
@@ -46,7 +52,7 @@ namespace OpenTap.Package
                 FileSystemHelper.EnsureDirectory(Target);
             }
 
-            if (ExecutorClient.IsExecutorMode) // do we support running isolated?
+            if (ExecutorClient.IsExecutorMode && NoIsolation == false) // do we support running isolated?
             {
                 if (!ExecutorClient.IsRunningIsolated) // are we already running isolated?
                 {

--- a/Package/PackageActions/IsolatedPackageAction.cs
+++ b/Package/PackageActions/IsolatedPackageAction.cs
@@ -27,9 +27,12 @@ namespace OpenTap.Package
         [CommandLineArgument("force", Description = "Try to run in spite of errors.", ShortName = "f")]
         public bool Force { get; set; }
         
+        /// <summary>
+        /// Avoid starting an isolated process. This can cause installations to fail if the DLLs that must be overwritten are loaded.
+        /// </summary>
         [Browsable(false)]
         [CommandLineArgument("no-isolation", Description = "Avoid starting an isolated process.")]
-        internal bool NoIsolation { get; set; }
+        public bool NoIsolation { get; set; }
         
 
         /// <summary>


### PR DESCRIPTION
This adds a secret flag to disable running isolated. Currently, when our pipelines fail due to Sign not being installed correctly, it is difficult to debug because there is no log output from the isolated process. 

We can't even tell if the problem happens inside the isolated process, or if the isolation logic fails for some reason on the runner.

With this change, if the problem does occur again, we at least have a chance to debug the issue from the logs.