### PR TITLE
Make package unit tests work on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,10 +190,6 @@ jobs:
       - name: Fix tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} # Fixes an issue with actions/checkout@v2. See https://github.com/actions/checkout/issues/290
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6.0.x'
       - name: Build
         run: dotnet publish -c Release OpenTAP.sln
       - name: Upload binaries
@@ -368,10 +364,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6.0.x'
       - name: Download binaries
         uses: actions/download-artifact@v2
         with:
@@ -380,7 +372,7 @@ jobs:
       - name: Test
         run: |
           chmod +x bin/Release/tap
-          bin/Release/tap run tests/regression.TapPlan --verbose --color
+          bin/Release/tap run tests/regression.TapPlan --verbose
 
   TestMacPlan:
     runs-on: macos-11
@@ -785,10 +777,6 @@ jobs:
     needs:
       - Installer-Linux
     steps:
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6.0.x'
       - name: Download Linux Installer
         uses: actions/download-artifact@v2
         with:
@@ -859,10 +847,6 @@ jobs:
       - name: Fix tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} # Fixes an issue with actions/checkout@v2. See https://github.com/actions/checkout/issues/290
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6.0.x'
       - name: Download Linux package
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,14 +191,14 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} # Fixes an issue with actions/checkout@v2. See https://github.com/actions/checkout/issues/290
       - name: Build
-        run: dotnet publish -c Release OpenTAP.sln
+        run: dotnet build -c Release
       - name: Upload binaries
         uses: actions/upload-artifact@v2
         with:
           name: linux-x64-bin
           retention-days: 5
           path: |
-            bin/Release/publish/*
+            bin/Release/*
 
   Build-Win:
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   GetVersion:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # Map a step output to a job output
     outputs:
       ShortVersion: ${{ steps.asmVer.outputs.ver }}
@@ -51,7 +51,7 @@ jobs:
         run: echo ::set-output name=ver::$(tap sdk gitversion)
 
   CheckSecrets:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: sign
     outputs:
       gitlab_registry_token_is_set: ${{ steps.check_GITLAB_REGISTRY_TOKEN.outputs.is_set }}
@@ -88,7 +88,7 @@ jobs:
   Build-DevGuide:
     needs: CheckSecrets
     if: needs.CheckSecrets.outputs.gitlab_registry_token_is_set == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: registry.gitlab.com/opentap/buildrunners/documentationgeneration:latest
       credentials:
@@ -109,7 +109,7 @@ jobs:
   Build-ApiDoc:
     needs: CheckSecrets
     if: needs.CheckSecrets.outputs.gitlab_registry_token_is_set == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: registry.gitlab.com/opentap/buildrunners/doxygen:alpine
       credentials:
@@ -143,7 +143,7 @@ jobs:
           path: API
 
   Build-Pages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - Build-ApiDoc
     steps:
@@ -181,7 +181,7 @@ jobs:
           external_repository: opentap/opentap.github.io
 
   Build-Linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -742,7 +742,7 @@ jobs:
           path: OpenTAP.tar
           
   Installer-Windows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: sign
     needs:
       - GetVersion
@@ -901,7 +901,7 @@ jobs:
   Publish-TapPackages:
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/v')
     environment: packages.opentap.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - Package-Win
       - Package-Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,25 @@ jobs:
           $ErrorActionPreference = "Stop"
           dotnet vstest bin/OpenTap.UnitTests.dll --logger:"console;verbosity=detailed" -- RunConfiguration.TestSessionTimeout=1200000
 
+  TestEngine-Linux:
+    runs-on: ubuntu-20.04
+    needs: Build-Linux
+    strategy:
+      matrix:
+        retries: [ 0, 1 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Download binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-x64-bin
+          path: bin/
+      - name: Test
+        run: |
+          chmod +x bin/tap
+          dotnet vstest bin/OpenTap.UnitTests.dll --logger:"console;verbosity=detailed"
+
   TestPackage:
     runs-on: windows-2022
     needs: Build-Win
@@ -324,6 +343,22 @@ jobs:
           #Copy-Item .\bin\Release\runtimes\win-x64\native\git2-b7bad55.dll .\bin\Release
           cd bin/Release
           dotnet vstest /framework:.NETFramework,Version=v4.62 /Platform:x64 OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed"
+
+  TestPackage-Linux:
+    runs-on: ubuntu-20.04
+    needs: Build-Linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Download binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-x64-bin
+          path: bin/
+      - name: Test
+        run: |
+          chmod +x bin/tap
+          dotnet vstest bin/OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed"
 
   TestWindowsPlan:
     runs-on: windows-2022

--- a/Package.UnitTests/CliTests.cs
+++ b/Package.UnitTests/CliTests.cs
@@ -138,6 +138,7 @@ namespace OpenTap.Package.UnitTests
         {
             var package = new PackageDef();
             package.Name = "Dummy Something";
+            package.OS = "Windows,Linux";
             package.Version = SemanticVersion.Parse("1.0.0");
             package.Description = "Cached version";
 
@@ -262,6 +263,7 @@ namespace OpenTap.Package.UnitTests
         {
             var depDef = new PackageDef();
             depDef.Name = "Pkg1";
+            depDef.OS = "Windows,Linux";
             depDef.Version = SemanticVersion.Parse("1.0");
             depDef.AddFile("Dependency.txt");
             string dep0File = DummyPackageGenerator.GeneratePackage(depDef);
@@ -295,6 +297,7 @@ namespace OpenTap.Package.UnitTests
         {
             var depDef = new PackageDef();
             depDef.Name = "Pkg1";
+            depDef.OS = "Windows,Linux";
             depDef.Version = SemanticVersion.Parse("1.0");
             depDef.AddFile("Dependency.txt");
             string dep0File = DummyPackageGenerator.GeneratePackage(depDef);
@@ -449,12 +452,14 @@ namespace OpenTap.Package.UnitTests
         {
             var dep0Def = new PackageDef();
             dep0Def.Name = "UninstallPackage";
+            dep0Def.OS = "Windows,Linux";
             dep0Def.Version = SemanticVersion.Parse("0.1");
             dep0Def.AddFile("UninstallText.txt");
             string dep0File = DummyPackageGenerator.GeneratePackage(dep0Def);
 
             var dep1Def = new PackageDef();
             dep1Def.Name = "UninstallPackage";
+            dep1Def.OS = "Windows,Linux";
             dep1Def.Version = SemanticVersion.Parse("0.2");
             dep1Def.AddFile("SubDir/UninstallText.txt");
             Directory.CreateDirectory("SubDir");
@@ -478,18 +483,21 @@ namespace OpenTap.Package.UnitTests
         {
             var dep0Def = new PackageDef();
             dep0Def.Name = "Dependency";
+            dep0Def.OS = "Windows,Linux";
             dep0Def.Version = SemanticVersion.Parse("0.1");
             dep0Def.AddFile("Dependency0.txt");
             string dep0File = DummyPackageGenerator.GeneratePackage(dep0Def);
 
             var dep1Def = new PackageDef();
             dep1Def.Name = "Dependency";
+            dep1Def.OS = "Windows,Linux";
             dep1Def.Version = SemanticVersion.Parse("1.0");
             dep1Def.AddFile("Dependency1.txt");
             string dep1File = DummyPackageGenerator.GeneratePackage(dep1Def);
 
             var dummyDef = new PackageDef();
             dummyDef.Name = "Dummy";
+            dummyDef.OS = "Windows,Linux";
             dummyDef.Version = SemanticVersion.Parse("1.0");
             dummyDef.AddFile("Dummy.txt");
             dummyDef.Dependencies.Add(new PackageDependency("Dependency", VersionSpecifier.Parse("1.0")));
@@ -586,6 +594,7 @@ namespace OpenTap.Package.UnitTests
 
             var package = new PackageDef();
             package.Name = "NoDowngradeTest";
+            package.OS = "Windows,Linux";
             package.Version = SemanticVersion.Parse("1.0.1");
             var newPath = DummyPackageGenerator.GeneratePackage(package);
 

--- a/Package.UnitTests/Image/MockRepository.cs
+++ b/Package.UnitTests/Image/MockRepository.cs
@@ -80,16 +80,16 @@ namespace OpenTap.Image.Tests
                     DefinePackage("Python", "2.3.1+945a9e89", CpuArchitecture.AnyCPU, "windows,linux", ("OpenTAP", "^9.15.2+39e6c2a2")),
                     DefinePackage("Demonstration",  "9.0.0", CpuArchitecture.AnyCPU, "windows", ("OpenTAP", "^9.9.0")),
                     DefinePackage("Demonstration",  "9.0.1", CpuArchitecture.AnyCPU, "windows", ("OpenTAP", "^9.10.0")),
-                    DefinePackage("Demonstration",  "9.0.2", CpuArchitecture.AnyCPU, "windows", ("OpenTAP", "^9.11.0")),
+                    DefinePackage("Demonstration",  "9.0.2", CpuArchitecture.AnyCPU, "windows,linux", ("OpenTAP", "^9.11.0")),
                     DefinePackage("Demonstration",  "9.0.5+3cab80c8", CpuArchitecture.AnyCPU, "windows,linux", ("OpenTAP", "^9.5.0+45ab79bc")),
-                    DefinePackage("Demonstration",  "9.1.0", CpuArchitecture.AnyCPU, "windows", ("OpenTAP", "^9.12.0")),
+                    DefinePackage("Demonstration",  "9.1.0", CpuArchitecture.AnyCPU, "windows,linux", ("OpenTAP", "^9.12.0")),
                     DefinePackage("Demonstration",  "9.2.0", CpuArchitecture.AnyCPU, "windows", ("OpenTAP", "^9.12.0")),
-                    DefinePackage("MyDemoTestPlan", "1.0.0", CpuArchitecture.AnyCPU, "windows", ("OpenTAP", "^9.12.1"), ("Demonstration", "^9.0.2")),
+                    DefinePackage("MyDemoTestPlan", "1.0.0", CpuArchitecture.AnyCPU, "windows,linux", ("OpenTAP", "^9.12.1"), ("Demonstration", "^9.0.2")),
                     DefinePackage("MyDemoTestPlan", "1.1.0", CpuArchitecture.AnyCPU, "windows", ("OpenTAP", "^9.13.1"), ("Demonstration", "^9.0.2")),
-                    DefinePackage("PackageWithMissingDependency","1.0.0", CpuArchitecture.AnyCPU, "windows", ("MissingPackage", "9.13.1")),
-                    DefinePackage("ExactDependency","1.0.0", CpuArchitecture.AnyCPU, "windows", ("OpenTAP", "9.13.1")),
-                    DefinePackage("Cyclic",         "1.0.0", CpuArchitecture.AnyCPU, "windows", ("Cyclic2", "1.0.0")),
-                    DefinePackage("Cyclic2",        "1.0.0", CpuArchitecture.AnyCPU, "windows", ("Cyclic", "1.0.0")),
+                    DefinePackage("PackageWithMissingDependency","1.0.0", CpuArchitecture.AnyCPU, "windows,linux", ("MissingPackage", "9.13.1")),
+                    DefinePackage("ExactDependency","1.0.0", CpuArchitecture.AnyCPU, "windows,linux", ("OpenTAP", "9.13.1")),
+                    DefinePackage("Cyclic",         "1.0.0", CpuArchitecture.AnyCPU, "windows,linux", ("Cyclic2", "1.0.0")),
+                    DefinePackage("Cyclic2",        "1.0.0", CpuArchitecture.AnyCPU, "windows,linux", ("Cyclic", "1.0.0")),
                     DefinePackage("Native",         "1.0.0", CpuArchitecture.x86,    "windows"),
                     DefinePackage("Native",         "1.0.0", CpuArchitecture.x64,    "windows"),
                     DefinePackage("Native",         "1.0.0", CpuArchitecture.x86,    "linux"),
@@ -140,7 +140,7 @@ namespace OpenTap.Image.Tests
                 };
         }
 
-        private PackageDef DefinePackage(string name, string version, CpuArchitecture arch = CpuArchitecture.AnyCPU, string os = "windows", params (string name, string version)[] dependencies)
+        private PackageDef DefinePackage(string name, string version, CpuArchitecture arch = CpuArchitecture.AnyCPU, string os = "windows,linux", params (string name, string version)[] dependencies)
         {
             return new PackageDef
             {

--- a/Package.UnitTests/Image/Resolve.cs
+++ b/Package.UnitTests/Image/Resolve.cs
@@ -107,12 +107,12 @@ namespace OpenTap.Image.Tests
         [TestCase("B", "3.0.0", "Windows", CpuArchitecture.x64, "3.0.0")] // full version means exact
         [TestCase("B", "beta", "Windows", CpuArchitecture.x64, "3.2.1-beta.1")]
         [TestCase("B", "3.2.1-beta.1", "Windows", CpuArchitecture.x64, "3.2.1-beta.1")]
-        [TestCase("B", "beta", "", CpuArchitecture.AnyCPU, "3.2.1-beta.1")] // means we want latest, but minimum beta
-        [TestCase("B", "3-beta", "", CpuArchitecture.AnyCPU, "3.2.1-beta.1")] // means we want latest 3 beta
+        [TestCase("B", "beta", "Windows", CpuArchitecture.AnyCPU, "3.2.1-beta.1")] // means we want latest, but minimum beta
+        [TestCase("B", "3-beta", "Windows", CpuArchitecture.AnyCPU, "3.2.1-beta.1")] // means we want latest 3 beta
         [TestCase("B", "2-beta", "Linux", CpuArchitecture.x86, "2.1.0-beta.1")] // means we want latest 2 beta
-        [TestCase("B", "^3-beta", "", CpuArchitecture.AnyCPU, "3.2.1-beta.1")] // means we want latest 3, minimum beta
+        [TestCase("B", "^3-beta", "Windows", CpuArchitecture.AnyCPU, "3.2.1-beta.1")] // means we want latest 3, minimum beta
         [TestCase("B", "^2-beta", "Linux", CpuArchitecture.x86, "2.1.0-beta.1")] // means we want latest 2 beta
-        [TestCase("B", "any", "", CpuArchitecture.AnyCPU, "3.2.2-alpha.1")]  // any means we want latest, even if it is a prerelease
+        [TestCase("B", "any", "Windows", CpuArchitecture.AnyCPU, "3.2.2-alpha.1")]  // any means we want latest, even if it is a prerelease
         [TestCase("C", "^1.0-beta", "Linux", CpuArchitecture.x86, "1.0.0-beta.1")]
         [TestCase("C", "1.0-beta", "Linux", CpuArchitecture.x86, "1.0.0-beta.1")]
         [TestCase("C", "^1-beta", "Linux", CpuArchitecture.x86, "1.0.0-beta.1")]

--- a/Package.UnitTests/Image/Workflows.cs
+++ b/Package.UnitTests/Image/Workflows.cs
@@ -154,7 +154,7 @@ namespace OpenTap.Image.Tests
             imageSpecifier.Packages = new List<PackageSpecifier>
             {
                 new PackageSpecifier("OpenTAP"),
-                new PackageSpecifier("OSIntegration")
+                new PackageSpecifier("OSIntegration", os: "Windows")
             };
 
             Stopwatch stopwatch = Stopwatch.StartNew();


### PR DESCRIPTION
Resolves #621

The Linux package unit test are fixed and added to the CI workflow so that they can be kept in sync and help catch bugs on Linux.

Everything is pretty straightforward except for the change in commit 8c5297f173439d89f92ecd9fdcfb23ea15faec85, which is required because the package unit tests depend on `OpenTAP` being installed in the `bin/Release` directory by:
https://github.com/opentap/opentap/blob/8509ab759666df08f7a5c61a3bf87071ba620644/Tap.Upgrader/Tap.Upgrader.csproj#L23-L25