### PR TITLE
Handle exceptions instead of relying on an empty catch

### DIFF
--- a/Package/PluginInstaller.cs
+++ b/Package/PluginInstaller.cs
@@ -660,6 +660,7 @@ namespace OpenTap.Package
         {
             if (dir == null) return;
             if (!dir.Exists) return;
+            if (dir.EnumerateFiles().Any() || dir.EnumerateDirectories().Any()) return;
 
             try
             {


### PR DESCRIPTION
This is a nice little usability fix that avoids logging FirstChanceExceptions