### PR TITLE
Debian permission fixes

### DIFF
--- a/LinuxInstall/INSTALL.sh
+++ b/LinuxInstall/INSTALL.sh
@@ -44,7 +44,7 @@ echo "Unzipping tap"
 unzip "$(pwd)/*.TapPackage" -d "$DEST_DIR" # *: match OpenTAPLinux and just TAPLinux.
 
 cd "$DEST_DIR" || exit 1
-chmod -R +w .
+chmod -R +rws "$DEST_DIR"
 
 chmod +x tap
 

--- a/LinuxInstall/package/Debian/create-deb
+++ b/LinuxInstall/package/Debian/create-deb
@@ -7,53 +7,52 @@ pushd "$GIT_ROOT/LinuxInstall/package/Debian"
 
 # Build Deb package
 
-rm -rf ./OpenTAP
-mkdir -p OpenTAP/DEBIAN
-mkdir -p OpenTAP/usr/bin
-mkdir -p OpenTAP/usr/share/OpenTAP
-mkdir -p OpenTAP/usr/share/doc/OpenTAP
-mkdir -p OpenTAP/var/log/SessionLogs
+mkdir -p opentap/DEBIAN
+mkdir -p opentap/usr/bin
+mkdir -p opentap/usr/share/opentap
+mkdir -p opentap/usr/share/doc/opentap
+mkdir -p opentap/var/log/SessionLogs
 
-cp "$GIT_ROOT/LICENSE.txt" OpenTAP/usr/share/doc/OpenTAP/copyright
+cp "$GIT_ROOT/LICENSE.txt" opentap/usr/share/doc/opentap/copyright
 
-echo "Extracting OpenTAP"
-unzip -q ../OpenTAP.TapPackage -d OpenTAP/usr/share/OpenTAP
+echo "Extracting opentap"
+unzip -q ../OpenTAP.TapPackage -d opentap/usr/share/opentap
 
-pushd OpenTAP/usr/share/OpenTAP
+pushd opentap/usr/share/opentap
 chmod +x tap
 ln -s ../../../var/log/SessionLogs
 popd
-pushd OpenTAP/usr/bin
-ln -s ../share/OpenTAP/tap
+pushd opentap/usr/bin
+ln -s ../share/opentap/tap
 popd
 
-BYTES=$(du -sb OpenTAP | cut -f1)
+BYTES=$(du -sb opentap | cut -f1)
 DIVISOR=1024
 
 # Size in KB, rounded up -- addition and subtraction is necessary because we're using integer division
 SIZE_KB=$(((BYTES - 1) / DIVISOR + 1))
 
-# sed control-debian -e "s/@VERSION@/$VERSION/g" -e "s/@SIZE_KB@/$SIZE_KB/g" > OpenTAP/DEBIAN/control
-cp postinst.in OpenTAP/DEBIAN/postinst
-chmod 0555 OpenTAP/DEBIAN/postinst
-chmod +x OpenTAP/DEBIAN/postinst
+# sed control-debian -e "s/@VERSION@/$VERSION/g" -e "s/@SIZE_KB@/$SIZE_KB/g" > opentap/DEBIAN/control
+cp postinst.in opentap/DEBIAN/postinst
+chmod 0555 opentap/DEBIAN/postinst
+chmod +x opentap/DEBIAN/postinst
 
-VERSION="$(./OpenTAP/usr/share/OpenTAP/tap sdk gitversion)"
+VERSION="$(./opentap/usr/share/opentap/tap sdk gitversion)"
 # The last character in the version specifier cannot be a '-'
 while [ "${VERSION: -1}" = "-" ]; do
     VERSION="${VERSION::-1}"
 done
 
-sed control.in -e "s/\$(GitVersion)/$VERSION/g" -e "s/@SIZE_KB@/$SIZE_KB/g" > OpenTAP/DEBIAN/control
+sed control.in -e "s/\$(GitVersion)/$VERSION/g" -e "s/@SIZE_KB@/$SIZE_KB/g" > opentap/DEBIAN/control
 
 # Don't package log file generated from gitversion
-rm -rf ./OpenTAP/var/log/SessionLogs/*
+rm -rf ./opentap/var/log/SessionLogs/*
 
-chmod 755 OpenTAP/DEBIAN
+chmod 755 opentap/DEBIAN
 
 echo "Building .deb package"
-dpkg --build OpenTAP
+dpkg --build opentap
 
-mv OpenTAP.deb ..
+mv opentap.deb ..
 
 echo "Built .deb package"

--- a/LinuxInstall/package/Debian/create-deb
+++ b/LinuxInstall/package/Debian/create-deb
@@ -10,21 +10,21 @@ pushd "$GIT_ROOT/LinuxInstall/package/Debian"
 rm -rf ./OpenTAP
 mkdir -p OpenTAP/DEBIAN
 mkdir -p OpenTAP/usr/bin
-mkdir -p OpenTAP/usr/share/tap
-mkdir -p OpenTAP/usr/share/doc/tap
+mkdir -p OpenTAP/usr/share/OpenTAP
+mkdir -p OpenTAP/usr/share/doc/OpenTAP
 mkdir -p OpenTAP/var/log/SessionLogs
 
-cp "$GIT_ROOT/LICENSE.txt" OpenTAP/usr/share/doc/tap/copyright
+cp "$GIT_ROOT/LICENSE.txt" OpenTAP/usr/share/doc/OpenTAP/copyright
 
 echo "Extracting OpenTAP"
-unzip -q ../OpenTAP.TapPackage -d OpenTAP/usr/share/tap
+unzip -q ../OpenTAP.TapPackage -d OpenTAP/usr/share/OpenTAP
 
-pushd OpenTAP/usr/share/tap
+pushd OpenTAP/usr/share/OpenTAP
 chmod +x tap
 ln -s ../../../var/log/SessionLogs
 popd
 pushd OpenTAP/usr/bin
-ln -s ../share/tap/tap
+ln -s ../share/OpenTAP/tap
 popd
 
 BYTES=$(du -sb OpenTAP | cut -f1)
@@ -38,7 +38,7 @@ cp postinst.in OpenTAP/DEBIAN/postinst
 chmod 0555 OpenTAP/DEBIAN/postinst
 chmod +x OpenTAP/DEBIAN/postinst
 
-VERSION="$(./OpenTAP/usr/share/tap/tap sdk gitversion)"
+VERSION="$(./OpenTAP/usr/share/OpenTAP/tap sdk gitversion)"
 # The last character in the version specifier cannot be a '-'
 while [ "${VERSION: -1}" = "-" ]; do
     VERSION="${VERSION::-1}"

--- a/LinuxInstall/package/Debian/postinst.in
+++ b/LinuxInstall/package/Debian/postinst.in
@@ -6,16 +6,17 @@ getent group OpenTAP || groupadd OpenTAP && echo "Created OpenTAP group"
 
 echo "Changing permissions of OpenTAP folder (/usr/share/OpenTAP)"
 chgrp -R OpenTAP /usr/share/OpenTAP
+# set sticky bit for the directory so new files will belong to the OpenTAP group
 chmod -R g+rwxs /usr/share/OpenTAP
 
 echo "OpenTAP group configured."
 
-# Attempt to add a user to the sudo group if a regular user installed OpenTAP using sudo.
+# Attempt to add a user to the OpenTAP group if a regular user installed OpenTAP using sudo.
 if [ ! -z "$SUDO_USER" ]; then
-    if [ ! "$SUDO_USER" == "root" ]; then
-        usermod -a -G OpenTAP "$SUDO_USER"
-        echo "Added user $SUDO_USER to the OpenTAP group"
-    fi
+  if [ ! "$SUDO_USER" == "root" ]; then
+    usermod -a -G OpenTAP "$SUDO_USER"
+    echo "Added user $SUDO_USER to the OpenTAP group"
+  fi
 fi
 
 echo "A user must be a member of the OpenTAP group to use OpenTAP."

--- a/LinuxInstall/package/Debian/postinst.in
+++ b/LinuxInstall/package/Debian/postinst.in
@@ -1,27 +1,25 @@
 #!/bin/bash
 set -e
 
-# create tap group if it doesn't exist
-getent group tap || groupadd tap && echo "created tap group"
+# create OpenTAP group if it doesn't exist
+getent group OpenTAP || groupadd OpenTAP && echo "Created OpenTAP group"
 
-echo "changing permissions of tap folder (/usr/share/tap)"
-chgrp -R tap /usr/share/tap
-chmod -R g+rwx /usr/share/tap
+echo "Changing permissions of OpenTAP folder (/usr/share/OpenTAP)"
+chgrp -R OpenTAP /usr/share/OpenTAP
+chmod -R g+rwxs /usr/share/OpenTAP
 
-echo "tap group configured."
+echo "OpenTAP group configured."
 
-# Only attempt to add a user to the sudo group if
-# The SUDO_USER variable is defined, meaning the script was called in a sudo shell, and not by root itself, and
-# The sudo user is not root. No point in adding root to the tap group
+# Attempt to add a user to the sudo group if a regular user installed OpenTAP using sudo.
 if [ ! -z "$SUDO_USER" ]; then
     if [ ! "$SUDO_USER" == "root" ]; then
-        usermod -a -G tap "$SUDO_USER"
-        echo "Added user $SUDO_USER to tap group"
+        usermod -a -G OpenTAP "$SUDO_USER"
+        echo "Added user $SUDO_USER to the OpenTAP group"
     fi
 fi
 
-echo "A user must be a member of the tap group to use OpenTAP."
-echo "Add users to the tap group with the following command:"
-echo "    usermod -a -G tap \$USER"
-echo "This tap install is global. If this is a multi-user system, consider creating a user-level tap install with"
+echo "A user must be a member of the OpenTAP group to use OpenTAP."
+echo "Add users to the OpenTAP group with the following command:"
+echo "    usermod -a -G OpenTAP \$USER"
+echo "This OpenTAP install is global. If this is a multi-user system, consider creating a user-level OpenTAP install with"
 echo "    tap package install OpenTAP --target /local/install/dir"

--- a/LinuxInstall/package/Debian/postinst.in
+++ b/LinuxInstall/package/Debian/postinst.in
@@ -1,26 +1,27 @@
 #!/bin/bash
 set -e
 
-# create OpenTAP group if it doesn't exist
-getent group OpenTAP || groupadd OpenTAP && echo "Created OpenTAP group"
+# create opentap group if it doesn't exist
+getent group opentap || groupadd opentap && echo "Created opentap group"
 
-echo "Changing permissions of OpenTAP folder (/usr/share/OpenTAP)"
-chgrp -R OpenTAP /usr/share/OpenTAP
-# set sticky bit for the directory so new files will belong to the OpenTAP group
-chmod -R g+rwxs /usr/share/OpenTAP
+echo "Changing permissions of opentap folder (/usr/share/opentap)"
+chgrp -R opentap /usr/share/opentap
+# set sticky bit for the directory so new files will belong to the opentap group
+chmod -R g+rwxs /usr/share/opentap
 
-echo "OpenTAP group configured."
+echo "opentap group configured."
 
-# Attempt to add a user to the OpenTAP group if a regular user installed OpenTAP using sudo.
+# Attempt to add a user to the opentap group if a regular user installed opentap using sudo.
 if [ ! -z "$SUDO_USER" ]; then
   if [ ! "$SUDO_USER" == "root" ]; then
-    usermod -a -G OpenTAP "$SUDO_USER"
-    echo "Added user $SUDO_USER to the OpenTAP group"
+    usermod -a -G opentap "$SUDO_USER"
+    echo "Added user $SUDO_USER to the opentap group"
   fi
 fi
 
-echo "A user must be a member of the OpenTAP group to use OpenTAP."
-echo "Add users to the OpenTAP group with the following command:"
-echo "    usermod -a -G OpenTAP \$USER"
-echo "This OpenTAP install is global. If this is a multi-user system, consider creating a user-level OpenTAP install with"
+echo "A user must be a member of the 'opentap' group to use opentap."
+echo "Add users to the 'opentap' group with the following command:"
+echo "    usermod -a -G opentap \$USER"
+echo "This OpenTAP installation is global. If this is a multi-user system, consider creating a user-level OpenTAP
+installation with"
 echo "    tap package install OpenTAP --target /local/install/dir"

--- a/LinuxInstall/tap.sh
+++ b/LinuxInstall/tap.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+# umask sets the calling process' file mode creation mask
+# 002 is the default mask for users. The default mask for root is 0022.
+
+# set umask to 002 which is equivalent to &'ing the permission flags of files created by OpenTAP with -rw-rw-r--
+# the default umask for the 'root' user is 022, which would & with -rw-r--r--
+# This would cause files created by sudo to be non-writable by the OpenTAP group,
+# which can brick the functionality of the installation.
+umask 002
 if [[ $(uname) == Darwin ]]; then
     # Mac uses BSD readlink which supports different flags
 

--- a/LinuxInstall/tap.sh
+++ b/LinuxInstall/tap.sh
@@ -5,11 +5,13 @@
 
 # set umask to 002 which is equivalent to &'ing the permission flags of files created by OpenTAP with -rw-rw-r--
 # the default umask for the 'root' user is 022, which would & with -rw-r--r--
-# This would cause files created by sudo to be non-writable by the OpenTAP group,
-# which can brick the functionality of the installation.
+# This would cause files created when running as root to be non-writable by the OpenTAP group,
+# which can cause e.g. package installs and logfiles to behave unexpectedly.
 umask 002
+
+TapDllPath="";
 if [[ $(uname) == Darwin ]]; then
-    # Mac uses BSD readlink which supports different flags
+  # Mac uses BSD readlink which supports different flags
 
     # relativePath is empty if this is a regular file
     # Otherwise it is a relative path from the link to the real file
@@ -17,17 +19,31 @@ if [[ $(uname) == Darwin ]]; then
     relativePath="$(readlink "$path")"
     # Keep looping until the file is resolved to a regular file
     while [[ "$relativePath" ]]; do
-        # File is a link; follow it
-        pushd "$(dirname "$path")" >/dev/null
-        pushd "$(dirname "$relativePath")" >/dev/null
-        path="$(pwd)/$(basename "$0")"
-        popd >/dev/null
-        popd >/dev/null
-        relativePath="$(readlink "$path")"
+      # File is a link; follow it
+      pushd "$(dirname "$path")" >/dev/null
+      pushd "$(dirname "$relativePath")" >/dev/null
+      path="$(pwd)/$(basename "$0")"
+      popd >/dev/null
+      popd >/dev/null
+      relativePath="$(readlink "$path")"
     done
-    exec dotnet "$path.dll" "$@"
-# We are on linux -- Use GNU Readline normally
+
+    TapDllPath="$path.dll";
+  else
+    # We are on linux -- Use GNU Readline normally
+    TapDllPath="$(dirname "$(readlink -f "$0")")/tap.dll";
+fi
+
+TapDllDir="$(dirname "$TapDllPath")"
+# -x checks if TapDllPath exists and is executable
+# -w checks if TapDllDir exists and is writable by the current user.
+if [ -w "$TapDllDir" ]; then
+  # If the user cannot write to the installation, OpenTAP will not work correctly.
+  # Instead, we should give a hint about how to resolve the issue.
+  # use exec to replace the current process instead of starting a child process
+  exec dotnet "$TapDllPath" "$@"
 else
-    # use exec to replace the current process instead of starting a child process
-    exec dotnet "$(dirname "$(readlink -f "$0")")/tap.dll" "$@" 
+  TapDllGroupOwner="$(stat -c "%G" "$TapDllDir")"
+  echo "User $USER does not have write access in the OpenTAP installation at '$TapDllDir'."
+  echo "This installation belongs to the group '$TapDllGroupOwner'. The user can be added to this group with the command 'usermod -a -G $TapDllGroupOwner $USER'."
 fi

--- a/Package/Installer.cs
+++ b/Package/Installer.cs
@@ -207,6 +207,7 @@ namespace OpenTap.Package
                 if (ex is OperationCanceledException)
                     return (int)ExitCodes.UserCancelled;
 
+                log.Debug(ex);
                 return (int) ExitCodes.GeneralException;
             }
 
@@ -354,6 +355,11 @@ namespace OpenTap.Package
             {
                 // the file doesn't even exist!
                 return false;
+            }
+            catch (UnauthorizedAccessException)
+            {
+              log.Warning($"File {file.FullName} cannot be deleted by the current user. ({Environment.UserName})");
+              throw;
             }
             catch (IOException)
             {

--- a/Package/PackageInstallHelpers/FileLocks.cs
+++ b/Package/PackageInstallHelpers/FileLocks.cs
@@ -114,7 +114,8 @@ namespace OpenTap.Package.PackageInstallHelpers
             // Open 'file' in read/write + append mode. If the file does not exist it will be created with the
             // most permissive access settings possible
             fileDescriptor =
-                PosixNative.open(file, PosixNative.O_RDWR | PosixNative.O_APPEND | PosixNative.O_CREAT, PosixNative.ALL_READ_WRITE);
+                PosixNative.open(file, PosixNative.O_RDONLY | PosixNative.O_APPEND | PosixNative.O_CREAT, PosixNative.ALL_READ_WRITE);
+
             if (fileDescriptor == -1) throw new IOException($"Failed create file lock on {file}");
             _waitHandle = new ManualResetEvent(false);
         }
@@ -228,6 +229,8 @@ namespace OpenTap.Package.PackageInstallHelpers
         public const int O_CREAT = 64; //00000100;
         public const int O_TRUNC = 512; //00001000;
         public const int O_APPEND = 1024; //00002000;
+
+        public const int O_RDONLY = 0; //00000000;
         public const int O_RDWR = 2; //00000002;
         /// <summary>
         /// Place a shared lock. More than one process may hold a shared lock for a given file at a given time. 


### PR DESCRIPTION
This renames the 'tap' user group to 'OpenTAP',
and updates the install location from '/usr/share/tap' to /usr/share/OpenTAP'.

It also includes a bugfix which prevented isolated package actions from working
if the .lock file was initially created by root.

Closes #637  
Closes #638 
Closes #643 
Closes #647 