### PR TITLE
649 Dispose Root Session: Fix

### DIFF
--- a/Engine.UnitTests/Tap.Engine.UnitTests.csproj
+++ b/Engine.UnitTests/Tap.Engine.UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Engine.UnitTests/TestCliActions/SessionDisposeTestCliAction.cs
+++ b/Engine.UnitTests/TestCliActions/SessionDisposeTestCliAction.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using OpenTap.Cli;
+
+namespace OpenTap.Engine.UnitTests
+{
+        [Display("session-dispose-test", Description: "A test that adds a session local that needs to be disposed..", Group: "test")]
+    public class SessionDisposeTestCliAction : ICliAction
+    {
+        private static TraceSource log = Log.CreateSource("session-dispose"); 
+        class DisposableClassTest : IDisposable
+        {
+            public void Dispose()
+            {
+                // log cannot be used at this point.
+                Console.WriteLine("session-dispose-test disposed");
+            }
+        }
+
+        static readonly SessionLocal<DisposableClassTest> Local = new SessionLocal<DisposableClassTest>(autoDispose: true);
+        public int Execute(CancellationToken cancellationToken)
+        {
+            Local.Value = new DisposableClassTest();
+            log.Info("Set disposable");
+            TapThread.Start(() =>
+            {
+                while (true)
+                {
+                    TapThread.Sleep(1000);
+                }
+            });
+            return 0;
+        }
+    }
+}

--- a/Engine/ThreadManager.cs
+++ b/Engine/ThreadManager.cs
@@ -4,6 +4,7 @@
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 using System;
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -293,6 +294,13 @@ namespace OpenTap
         public void Abort()
         {
             Abort(null);
+        }
+
+        /// <summary> Aborts the thread without throwing an exception. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void AbortNoThrow()
+        {
+            abortTokenSource.Cancel();
         }
 
         /// <summary>

--- a/tests/regression.TapPlan
+++ b/tests/regression.TapPlan
@@ -19,6 +19,11 @@
           <Name>Test Plan: {Referenced Plan}</Name>
           <BreakConditions>Inherit</BreakConditions>
         </TestStep>
+        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="f05ae695-da0b-47c1-9562-32a89c3c424c">
+          <Filepath>../../tests/session-dispose.TapPlan</Filepath>
+          <Enabled>true</Enabled>
+          <Name>Test Plan: {Referenced Plan}</Name>
+        </TestStep>
         <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Version="9.4.0-Development" Id="321543e3-31fc-4923-ae06-674cc13bc232">
           <Filepath>../../tests/ILGitVersionBug.TapPlan</Filepath>
           <StepMapping>

--- a/tests/session-dispose.TapPlan
+++ b/tests/session-dispose.TapPlan
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestPlan type="OpenTap.TestPlan">
+  <Steps>
+    <TestStep type="OpenTap.Plugins.BasicSteps.ProcessStep" Version="9.4.0.0" Id="4f3b9fb7-adf2-4573-b7d8-0f7fcddbb811">
+      <Application>tap</Application>
+      <Arguments>test session-dispose-test</Arguments>
+      <WaitForEnd>true</WaitForEnd>
+      <Timeout>360000</Timeout>
+      <AddToLog>true</AddToLog>
+      <RegularExpressionPattern>
+        <Value>session-dispose-test disposed</Value>
+        <IsEnabled>true</IsEnabled>
+      </RegularExpressionPattern>
+      <VerdictOnMatch>Pass</VerdictOnMatch>
+      <VerdictOnNoMatch>Fail</VerdictOnNoMatch>
+      <Name>Run Program {Application}</Name>
+    </TestStep>
+  </Steps>
+</TestPlan>


### PR DESCRIPTION
- added the possibility of disposing the root session. This can be added to applications running tap.
- Added a test step for testing it.
- Added a regression testplan for testing it.