### PR TITLE
InformativePropertyException

### DIFF
--- a/Engine/SerializerPlugins/ObjectSerializer.cs
+++ b/Engine/SerializerPlugins/ObjectSerializer.cs
@@ -592,7 +592,14 @@ namespace OpenTap.Plugins
             }
             catch(Exception ex)
             {
-                Serializer.PushError(element, $"Object value was not read correctly.", ex);
+                if (ex is TargetInvocationException tarEx && tarEx.InnerException is ArgumentException arEx)
+                {
+                    Serializer.PushError(element, arEx.Message, tarEx);
+                }
+                else
+                {
+                    Serializer.PushError(element, $"Object value was not read correctly.", ex);
+                }
                 return false;
             }
             try

--- a/Engine/SerializerPlugins/ObjectSerializer.cs
+++ b/Engine/SerializerPlugins/ObjectSerializer.cs
@@ -592,9 +592,9 @@ namespace OpenTap.Plugins
             }
             catch(Exception ex)
             {
-                if (ex is TargetInvocationException tarEx && tarEx.InnerException is ArgumentException arEx)
+                if (ex is TargetInvocationException tarEx)
                 {
-                    Serializer.PushError(element, arEx.Message, tarEx);
+                    Serializer.PushError(element, tarEx.InnerException.Message, tarEx);
                 }
                 else
                 {

--- a/Engine/SerializerPlugins/ObjectSerializer.cs
+++ b/Engine/SerializerPlugins/ObjectSerializer.cs
@@ -594,7 +594,7 @@ namespace OpenTap.Plugins
             {
                 if (ex is TargetInvocationException tarEx)
                 {
-                    Serializer.PushError(element, tarEx.InnerException.Message, tarEx);
+                    Serializer.PushError(element, tarEx.InnerException.Message, tarEx.InnerException);
                 }
                 else
                 {


### PR DESCRIPTION
Fixed #606 by printing exception message when loading tapplan, instead of "Object value was not read correctly".

Im not sure if it might be worth it to print the exception message as the default, instead of only doing it in specific cases. I could imagine the exception would almost always contain more detailed and better information than any message we can write in the object serializer.