### PR TITLE
659 Add IStringValueAnnotation implementation for DateTime

### DIFF
--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -1828,5 +1828,34 @@ namespace OpenTap.UnitTests
             a.Read();
             Assert.AreEqual(Overlapping.Z, o.Overlapping);
         }
+
+        class DateTimeClass
+        {
+            public DateTime MyDate { get; set; }
+        }
+        [Test]
+        public void TestTimeAnnotations ()
+        {
+            var times = new DateTimeClass();
+            var a = AnnotationCollection.Annotate(times);
+            var members = a.Get<IMembersAnnotation>().Members.ToLookup(m => m.Name);
+
+            var date = members[nameof(DateTimeClass.MyDate)].First();
+            var dsv = date.Get<IStringValueAnnotation>();
+            
+            Assert.AreEqual(default(DateTime), times.MyDate);
+            StringAssert.StartsWith("1/1/0001", dsv.Value);
+            times.MyDate = DateTime.Parse("11/30/1000");
+            a.Read();
+            StringAssert.StartsWith("11/30/1000", dsv.Value);
+            
+            dsv.Value = "07/27/1978";
+            a.Write();
+            
+            Assert.AreEqual(7, times.MyDate.Month);
+            Assert.AreEqual(27, times.MyDate.Day);
+            Assert.AreEqual(1978, times.MyDate.Year);
+
+        }
     }
 }

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -528,6 +528,31 @@ namespace OpenTap
         public IEnumerable<string> Errors => currentError == null ? Array.Empty<string>() : new[] { currentError };
     }
 
+    class DateTimeAnnotation : IStringValueAnnotation, ICopyStringValueAnnotation
+    {
+        private AnnotationCollection annotation;
+
+        public string Value
+        {
+            get
+            {
+                if (annotation.Get<IObjectValueAnnotation>(from: this).Value is DateTime dt)
+                    return dt.ToString(CultureInfo.CurrentCulture);
+                return "";
+            }
+            set
+            {
+                if (DateTime.TryParse(value, out var dt))
+                    annotation.Get<IObjectValueAnnotation>(from: this).Value = dt;
+            }
+        }
+
+        public DateTimeAnnotation(AnnotationCollection annotation)
+        {
+            this.annotation = annotation;
+        }
+    }
+    
     class TimeSpanAnnotation : IStringValueAnnotation, ICopyStringValueAnnotation
     {
         public string Value
@@ -2661,6 +2686,8 @@ namespace OpenTap
 
                 if (mem.ReflectionInfo.DescendsTo(typeof(TimeSpan)))
                     annotation.Add(new TimeSpanAnnotation(annotation));
+                if (mem.ReflectionInfo.DescendsTo(typeof(DateTime)))
+                    annotation.Add(new DateTimeAnnotation(annotation));
                 
                 Sequence.ProcessPattern(attributes, 
                     (UnitAttribute x) => annotation.Add(x), 


### PR DESCRIPTION
This adds a IStringValueAnnotation implementation for DateTime. We already have one for TimeSpan, so I think it makes sense to add one for DateTime as well.

Closes #659