### PR TITLE
Replace 'tap sdk gitversion' invocations with GetVersion usage.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,19 @@ jobs:
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} # Fixes an issue with actions/checkout@v2. See https://github.com/actions/checkout/issues/290
       - name: tap sdk gitversion --fields 3
         id: asmVer
-        run: echo ::set-output name=ver::`tap sdk gitversion --fields 3`
+        run: |
+          echo ::set-output name=ver::$(tap sdk gitversion --fields 3)
+          echo $(tap sdk gitversion --fields 3)
       - name: tap sdk gitversion --fields 4
         id: longVer
-        run: echo ::set-output name=ver::`tap sdk gitversion --fields 4`
+        run: |
+          echo ::set-output name=ver::$(tap sdk gitversion --fields 4)
+          echo $(tap sdk gitversion --fields 4)
       - name: tap sdk gitversion
         id: gitVer
-        run: echo ::set-output name=ver::$(tap sdk gitversion)
+        run: |
+          echo ::set-output name=ver::$(tap sdk gitversion)
+          echo $(tap sdk gitversion)
 
   CheckSecrets:
     runs-on: ubuntu-latest
@@ -551,6 +557,7 @@ jobs:
       - Build-Win
       - Build-DevGuide
       - Build-ApiDoc
+      - GetVersion
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -593,7 +600,8 @@ jobs:
           $doc.FirstChild.RemoveChild($ele) # First Child is the Project element
           $doc.Save("$pwd/Directory.Build.props")
           cd ../../..
-          ./tap sdk gitversion --fields 4 --replace "Packages/SDK/Examples/Directory.Build.props"
+          $content=(Get-Content Packages/SDK/Examples/Directory.Build.props).Replace("`$(GitVersion)", "${{needs.GetVersion.outputs.LongVersion}}")
+          Set-Content Packages/SDK/Examples/Directory.Build.props $content
           ./tap package create -v -c ../../sdk/sdk.package.xml
           Move-Item "*.TapPackage" "../.."
       - uses: actions/upload-artifact@v2
@@ -638,6 +646,7 @@ jobs:
       - Build-Win
       - Package-Win
       - Package-Linux
+      - GetVersion
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -669,7 +678,8 @@ jobs:
       - name: Package
         run: |
           #cp bin\Release\runtimes\win-x64\native\git2-b7bad55.dll bin\Release
-          ./bin/Release/tap sdk gitversion --replace ./nuget/OpenTAP.nuspec --fields 4
+          $content=(Get-Content ./nuget/OpenTAP.nuspec).Replace("`$(GitVersion)", "${{needs.GetVersion.outputs.LongVersion}}")
+          Set-Content ./nuget/OpenTAP.nuspec $content
           New-Item -Force ./nuget/build/payload -ItemType Directory | Out-Null
           # Expand-Archive will only extract .zip extensions    
           Move-Item OpenTAP.*.x86.Windows.TapPackage OpenTAP.x86.zip 

--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 9.18.0
+version = 9.18.1
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.


### PR DESCRIPTION
Bump gitversion and improve consistency by always using GetVersion instead of mixing with manual `tap sdk gitversion` invocations.

Closes #663 