### PR TITLE
655 TestStep Break Exception

### DIFF
--- a/BasicSteps/RepeatStep.cs
+++ b/BasicSteps/RepeatStep.cs
@@ -102,7 +102,7 @@ namespace OpenTap.Plugins.BasicSteps
             this.iteration += 1;
             OnPropertyChanged(nameof(IterationInfo));
             var additionalParams = new List<ResultParameter> { new ResultParameter("", "Iteration", this.iteration) };
-            var runs = RunChildSteps(additionalParams, BreakLoopRequested);
+            var runs = RunChildSteps(additionalParams, BreakLoopRequested, throwOnBreak: false);
             foreach (var r in runs)
             {
                 r.WaitForCompletion();

--- a/BasicSteps/SweepLoop.cs
+++ b/BasicSteps/SweepLoop.cs
@@ -453,7 +453,7 @@ namespace OpenTap.Plugins.BasicSteps
                 logMessage.Append(")");
                 Log.Info(logMessage.ToString());
                 //Fix issue 687: Ensure the latest Sweep params are applied before running any child steps
-                RunChildSteps(AdditionalParams, BreakLoopRequested);
+                RunChildSteps(AdditionalParams, BreakLoopRequested, throwOnBreak: false);
 
                 crossPlanSweepIndex++;
                 acrossRunsGotoEnabledSweepIndex();
@@ -482,7 +482,7 @@ namespace OpenTap.Plugins.BasicSteps
                     affectedSteps.ForEach(step => step.OnPropertyChanged(""));
                     var AdditionalParams = RegisterAdditionalParams(i);
                     Log.Info(logMessage.ToString());
-                    var runs = RunChildSteps(AdditionalParams, BreakLoopRequested).ToList();
+                    var runs = RunChildSteps(AdditionalParams, BreakLoopRequested, throwOnBreak: false).ToArray();
                     
                     if (BreakLoopRequested.IsCancellationRequested) break;
                     runs.ForEach(r => r.WaitForCompletion());

--- a/BasicSteps/SweepLoopRange.cs
+++ b/BasicSteps/SweepLoopRange.cs
@@ -347,7 +347,7 @@ namespace OpenTap.Plugins.BasicSteps
 
                 Log.Info("Running child steps with {0} = {1} ", names, Value);
 
-                var runs = RunChildSteps(AdditionalParams, BreakLoopRequested).ToList();
+                var runs = RunChildSteps(AdditionalParams, BreakLoopRequested, throwOnBreak: false).ToArray();
                 if (BreakLoopRequested.IsCancellationRequested) break;
                 runs.ForEach(r => r.WaitForCompletion());
                 if (runs.LastOrDefault()?.BreakConditionsSatisfied() == true)

--- a/BasicSteps/SweepParameterRangeStep.cs
+++ b/BasicSteps/SweepParameterRangeStep.cs
@@ -186,7 +186,7 @@ namespace OpenTap.Plugins.BasicSteps
 
                 Log.Info("Running child steps with {0} = {1} ", names, Value);
 
-                var runs = RunChildSteps(AdditionalParams, BreakLoopRequested).ToList();
+                var runs = RunChildSteps(AdditionalParams, BreakLoopRequested, throwOnBreak: false).ToArray();
                 if (BreakLoopRequested.IsCancellationRequested) break;
                 runs.ForEach(r => r.WaitForCompletion());
                 if (runs.LastOrDefault()?.BreakConditionsSatisfied() == true)

--- a/BasicSteps/SweepParameterStep.cs
+++ b/BasicSteps/SweepParameterStep.cs
@@ -286,7 +286,7 @@ namespace OpenTap.Plugins.BasicSteps
 
                 Log.Info("Running child steps with {0}", Value.GetIterationString());
 
-                var runs = RunChildSteps(AdditionalParams, BreakLoopRequested).ToList();
+                var runs = RunChildSteps(AdditionalParams, BreakLoopRequested, throwOnBreak: false).ToArray();
                 if (BreakLoopRequested.IsCancellationRequested) break;
                 runs.ForEach(r => r.WaitForCompletion());
                 if (runs.LastOrDefault()?.BreakConditionsSatisfied() == true)

--- a/BasicSteps/TimeGuardStep.cs
+++ b/BasicSteps/TimeGuardStep.cs
@@ -41,11 +41,7 @@ namespace OpenTap.Plugins.BasicSteps
                 semStarted.Release();
                 try
                 {
-                    RunChildSteps();
-                }
-                catch (Exception)
-                {
-                    
+                    RunChildSteps(throwOnBreak: false);
                 }
                 finally
                 {

--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -233,10 +233,10 @@ namespace OpenTap
                             MetadataReader metadata = header.GetMetadataReader();
                             AssemblyDefinition def = metadata.GetAssemblyDefinition();
 
-                            // if we were asked to only prvide distinct assembly names and 
+                            // if we were asked to only provide distinct assembly names and 
                             // this assembly name has already been encountered, just return that.
-                            var fileIdentifer = Option.HasFlag(Options.IncludeSameAssemblies) ? file : def.GetAssemblyName().FullName;
-                            if (asmNameToAsmData.TryGetValue(fileIdentifer, out AssemblyData data))
+                            var fileIdentifier = Option.HasFlag(Options.IncludeSameAssemblies) ? file : def.GetAssemblyName().FullName;
+                            if (asmNameToAsmData.TryGetValue(fileIdentifier, out AssemblyData data))
                                 return data;
 
                             thisAssembly.Name = metadata.GetString(def.Name);
@@ -253,7 +253,7 @@ namespace OpenTap
                                 nameToAsmMap2[PathUtils.NormalizePath(thisAssembly.Location)] = thisRef;
                             }
 
-                            asmNameToAsmData[fileIdentifer] = thisAssembly;
+                            asmNameToAsmData[fileIdentifier] = thisAssembly;
 
                             foreach (var asmRefHandle in metadata.AssemblyReferences)
                             {

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -758,6 +758,7 @@ namespace OpenTap
                                 ExceptionDispatchInfo.Capture(run.Exception).Throw();
                             run.ThrowDueToBreakConditions();
                         }
+                        else break;
                     }
                     
                     TapThread.ThrowIfAborted();

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -59,7 +59,10 @@ namespace OpenTap
             }
             protected internal set => Parameters.SetIndexed((nameof(Verdict), GROUP), ref verdictIndex, value);
         }
-
+        
+        /// <summary> Exception causing the Verdict to be 'Error' in any. </summary>
+        public Exception Exception { get; internal set; }
+        
         /// <summary> Length of time it took to run. </summary>
         public virtual TimeSpan Duration
         {

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -60,7 +60,7 @@ namespace OpenTap
             protected internal set => Parameters.SetIndexed((nameof(Verdict), GROUP), ref verdictIndex, value);
         }
         
-        /// <summary> Exception causing the Verdict to be 'Error' in any. </summary>
+        /// <summary> Exception causing the Verdict to be 'Error'. </summary>
         public Exception Exception { get; internal set; }
         
         /// <summary> Length of time it took to run. </summary>

--- a/doc/Developer Guide/Test Step/Readme.md
+++ b/doc/Developer Guide/Test Step/Readme.md
@@ -341,7 +341,7 @@ Test step can have any number of child test steps. Exactly which can be controll
 
 To execute child test steps within a test step run, the RunChildStep method can be used to run a single child step or RunChildSteps can be used to run all of them.
 
-Depending on the verdict of the child steps, the break condition setting of the parent step and the way RunChildSteps is called there are a number of different ways that the control flow will be affected.
+Depending on the verdict of the child steps, the break condition setting of the parent step, and the way RunChildSteps is called, there are a number of different ways that the control flow will be affected.
 
 The default implementation should look something like this:
 ```cs
@@ -354,13 +354,13 @@ The default implementation should look something like this:
 ```
 
 `RunChildSteps` will take care of setting the verdict of the calling test step based on the verdict of the child test steps. The default algorithm here is to take the most severe verdict and use that for the parent test step. 
-For example, if the child test steps has verdict Pass, Inconclusive and Fail, the parent test step will get the Fail verdict.   
+For example, if the child test steps have verdicts Pass, Inconclusive and Fail, the parent test step will get the Fail verdict.   
 
-`RunChildSteps` may throw an exception, this happens if the break conditions for the parent test step are satisfied. 
-If the break conditions are satisfied due to an exeception being thrown, resulting in an Error verdict, the same exception will be thrown.
-To avoid this behavior the overload `RunChildSteps(throwOnBreak: false)` can be used, but the exceptions are still available from the returned list of test step runs.
+`RunChildSteps` may throw an exception. This happens if the break conditions for the parent test step are satisfied. 
+If the break conditions are satisfied due to an exception being thrown, resulting in an Error verdict, the same exception will be thrown.
+To avoid this behavior, the overload `RunChildSteps(throwOnBreak: false)` can be used, but the exceptions are still available from the returned list of test step runs.
 
-To override a verdict set by `RunChildSteps` the exception need to be caught or `throwOnBreak` needs to be set. After this the `Verdict` property can be set directly.
+To override a verdict set by `RunChildSteps`, the exception must be caught, or `throwOnBreak` must be set. After this, the `Verdict` property can be set directly.
 ```cs
     public override void Run()
     {
@@ -369,7 +369,7 @@ To override a verdict set by `RunChildSteps` the exception need to be caught or 
     }
 ```
 
-Child test steps can be run in a separate thread. This should be done with the TapThread.Start method. Before returning from the parent step the child step thread should be waited for or alternatively this should be done in a Defer operation. A great example of using parallelism can be found in the [Parallel Step](https://github.com/opentap/opentap/blob/main/BasicSteps/ParallelStep.cs).
+Child test steps can be run in a separate thread. This should be done with the TapThread.Start method. Before returning from the parent step, the child step thread should be waited for, or alternatively this should be done in a Defer operation. A great example of using parallelism can be found in the [Parallel Step](https://github.com/opentap/opentap/blob/main/BasicSteps/ParallelStep.cs).
 
 ## Serialization
 Default values of properties should be defined in the constructor. Upon saving a test plan, the test plan's **OpenTAP.Serializer** adds each step's public property to the test plan's XML file. Upon loading a test plan from a file, the OpenTAP.Serializer first instantiates the class with values from the constructor and then fills the property values from the values found in the test plan file. 

--- a/doc/Developer Guide/Test Step/Readme.md
+++ b/doc/Developer Guide/Test Step/Readme.md
@@ -50,7 +50,7 @@ namespace MyOpenTAPProject
         public override void Run()
         {
             // ToDo: Add test case code here.
-            RunChildSteps(); //If step has child steps.
+            RunChildSteps(); // If step has child steps, run them.
             UpgradeVerdict(Verdict.Pass);
         }
 
@@ -63,7 +63,8 @@ namespace MyOpenTAPProject
     }
 }
 ```
-## TestStep Hierarchy
+
+## Test Step Hierarchy
 
 Each TestStep object contains a list of TestSteps called *Child Steps*. A hierarchy of test steps can be built with an endless number of levels. The child steps:
 
@@ -334,7 +335,42 @@ For different approaches to publishing results, see the examples in:
 
 -	`TAP_PATH\Packages\SDK\Examples\PluginDevelopment\TestSteps\PublishResults`
 
-	
+## Child Test Steps
+
+Test step can have any number of child test steps. Exactly which can be controlled by using `AllowAnyChildAttribute`, and `AllowChildOfType`. 
+
+To execute child test steps within a test step run, the RunChildStep method can be used to run a single child step or RunChildSteps can be used to run all of them.
+
+Depending on the verdict of the child steps, the break condition setting of the parent step and the way RunChildSteps is called there are a number of different ways that the control flow will be affected.
+
+The default implementation should look something like this:
+```cs
+    public override void Run()
+    {
+        // Insert here things to do before running child steps 
+        RunChildSteps();
+        // Insert here things to do after running child steps.
+    }
+```
+
+`RunChildSteps` will take care of setting the verdict of the calling test step based on the verdict of the child test steps. The default algorithm here is to take the most severe verdict and use that for the parent test step. 
+For example, if the child test steps has verdict Pass, Inconclusive and Fail, the parent test step will get the Fail verdict.   
+
+`RunChildSteps` may throw an exception, this happens if the break conditions for the parent test step are satisfied. 
+If the break conditions are satisfied due to an exeception being thrown, resulting in an Error verdict, the same exception will be thrown.
+To avoid this behavior the overload `RunChildSteps(throwOnBreak: false)` can be used, but the exceptions are still available from the returned list of test step runs.
+
+To override a verdict set by `RunChildSteps` the exception need to be caught or `throwOnBreak` needs to be set. After this the `Verdict` property can be set directly.
+```cs
+    public override void Run()
+    {
+        RunChildSteps(throwOnBreak: false);
+        Verdict = Verdict.Pass; // force the verdict to be 'Pass'
+    }
+```
+
+Child test steps can be run in a separate thread. This should be done with the TapThread.Start method. Before returning from the parent step the child step thread should be waited for or alternatively this should be done in a Defer operation. A great example of using parallelism can be found in the [Parallel Step](https://github.com/opentap/opentap/blob/main/BasicSteps/ParallelStep.cs).
+
 ## Serialization
 Default values of properties should be defined in the constructor. Upon saving a test plan, the test plan's **OpenTAP.Serializer** adds each step's public property to the test plan's XML file. Upon loading a test plan from a file, the OpenTAP.Serializer first instantiates the class with values from the constructor and then fills the property values from the values found in the test plan file. 
 


### PR DESCRIPTION
This PR fixes a breaking change introduced in 9.17.

If the behavior from 9.18 is wanted new API points can be used for that.

Closes #655