### PR TITLE
671 ChildStep Visibility Default To Collapsed:

### DIFF
--- a/Engine.UnitTests/ChildItemVisibilityTest.cs
+++ b/Engine.UnitTests/ChildItemVisibilityTest.cs
@@ -15,17 +15,18 @@ namespace OpenTap.UnitTests
             step.ChildTestSteps.Add(new SequenceStep());
             step.ChildTestSteps[0].ChildTestSteps.Add(new SequenceStep());
             
-            Assert.AreEqual(ChildItemVisibility.Visibility.Visible, ChildItemVisibility.GetVisibility(step));
+            Assert.AreEqual(ChildItemVisibility.Visibility.Collapsed, ChildItemVisibility.GetVisibility(step));
             ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Visible);
             Assert.IsTrue(ChildItemVisibility.GetVisibility(step) == ChildItemVisibility.Visibility.Visible);
             ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Collapsed);
             Assert.IsTrue(ChildItemVisibility.GetVisibility(step) == ChildItemVisibility.Visibility.Collapsed);
+            ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Visible);
 
             var xml = plan.SerializeToString();
             plan = (TestPlan)new TapSerializer().DeserializeFromString(xml);
             step = plan.ChildTestSteps[0];
-            Assert.AreEqual(ChildItemVisibility.Visibility.Collapsed, ChildItemVisibility.GetVisibility(step));
-            Assert.AreEqual(ChildItemVisibility.Visibility.Visible, ChildItemVisibility.GetVisibility(step.ChildTestSteps[0]));
+            Assert.AreEqual(ChildItemVisibility.Visibility.Visible, ChildItemVisibility.GetVisibility(step));
+            Assert.AreEqual(ChildItemVisibility.Visibility.Collapsed, ChildItemVisibility.GetVisibility(step.ChildTestSteps[0]));
         }
     }
 }

--- a/Engine/ChildItemVisibility.cs
+++ b/Engine/ChildItemVisibility.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
 
@@ -15,12 +14,16 @@ namespace OpenTap
             /// <summary> Child items are collapsed.</summary>
             Collapsed
         }
+
+        // when test steps are added to a test plan, 
+        // the default should be that the child steps are collapsed.
+        const Visibility DefaultVisibility = Visibility.Collapsed; 
         
         internal static readonly DynamicMember VisibilityProperty = new DynamicMember
         {
             Name = "OpenTap.Visibility",
-            Attributes = new object[] { new BrowsableAttribute(false), new DefaultValueAttribute(Visibility.Visible), new XmlAttributeAttribute() },
-            DefaultValue = Visibility.Visible,
+            Attributes = new object[] { new BrowsableAttribute(false), new DefaultValueAttribute(DefaultVisibility), new XmlAttributeAttribute() },
+            DefaultValue = DefaultVisibility,
             TypeDescriptor = TypeData.FromType(typeof(Visibility)),
             DeclaringType = TypeData.FromType(typeof(ChildItemVisibility)),
             Writable = true,


### PR DESCRIPTION
- Changed the behavior so the visibility of child items defaults to collapsed.
- Modified the test to verify this behavior.