### PR TITLE
fix incorrect assembly versions for dependencies folders

### DIFF
--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 9.18.2
+version = 9.18.3
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.

--- a/Engine.UnitTests/AssemblyDataTest.cs
+++ b/Engine.UnitTests/AssemblyDataTest.cs
@@ -12,7 +12,7 @@ namespace OpenTap.UnitTests
             // semverTest can be a bool or a SemanticVersion.
             
             
-            var testasm = new AssemblyData("./test.dll", null) { RawVersion = versionstr };
+            var testasm = new AssemblyData("./test.dll", null) { RawVersion = versionstr, Version = version == null ? null : Version.Parse(version)};
             if(semverTest is bool isSemver2 && isSemver2 == true)
                 Assert.AreEqual(SemanticVersion.Parse(versionstr), testasm.SemanticVersion);
             else if (semverTest is SemanticVersion semver2)
@@ -30,7 +30,7 @@ namespace OpenTap.UnitTests
         [Test]
         public void AssemblyDataVersionTest()
         {
-            var testasm = new AssemblyData("./test.dll", null) { RawVersion = "0.3.0-beta.8+7b4c999b" };
+            var testasm = new AssemblyData("./test.dll", null) { RawVersion = "0.3.0-beta.8+7b4c999b", Version = Version.Parse("0.3.0.0")};
             Assert.AreEqual(SemanticVersion.Parse("0.3.0-beta.8+7b4c999b"), testasm.SemanticVersion);
             Assert.AreEqual(new Version(0,3,0,0), testasm.Version);
             assemblyDataVersionTest2("0.3.0-beta.8+7b4c999b", true, "0.3.0.0");

--- a/Engine.UnitTests/AssemblyDataTest.cs
+++ b/Engine.UnitTests/AssemblyDataTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using NUnit.Framework;
 
 namespace OpenTap.UnitTests
@@ -37,6 +38,22 @@ namespace OpenTap.UnitTests
             assemblyDataVersionTest2("0.3.0.0", new SemanticVersion(0, 3, 0, null, null), "0.3.0.0");
             assemblyDataVersionTest2("1.0", true, "1.0");
             assemblyDataVersionTest2("asd", false, null);
+        }
+
+        [Test]
+        public void ConflictingAssemblyVersionTest()
+        {
+            var s = PluginManager.GetSearcher();
+            var globAsm = s.Assemblies.FirstOrDefault(a => a.Name.Contains("DotNet.Glob"));
+            
+            Assert.AreEqual(SemanticVersion.Parse("3.0.1"),  SemanticVersion.Parse(globAsm.SemanticVersion.ToString(3)));
+            Assert.AreEqual(Version.Parse("3.0.1.0"), globAsm.Version);
+            
+            var newtonsoftAsm = s.Assemblies.FirstOrDefault(a => a.Name.Contains("Newtonsoft.Json"));
+            Assert.AreEqual(SemanticVersion.Parse("12.0.3"), SemanticVersion.Parse(newtonsoftAsm.SemanticVersion.ToString(3)));
+            // The newtonsoft package is actually version 12.0.0.3, but the assembly version is 12.0.0.0 for some reason.
+            // This was changed in 9.18.2 due to a regression, but it has been so for a long long time.  
+            Assert.AreEqual(Version.Parse("12.0.0.0"), newtonsoftAsm.Version);
         }
 
         [Test]

--- a/Engine/AssemblyData.cs
+++ b/Engine/AssemblyData.cs
@@ -74,7 +74,7 @@ namespace OpenTap
             {
                 if (ReferenceEquals(version, NoVersion))
                 {
-                    if (Version.TryParse(RawVersion, out var versionParsed))
+                    if (Version.TryParse(RawVersion, out var versionParsed) || Version.TryParse(AssemblyDefinitionRawVersion, out versionParsed))
                     {
                         version = versionParsed;
                     }
@@ -120,7 +120,9 @@ namespace OpenTap
         
         /// <summary> Raw version as set by the assembly. </summary>
         internal string RawVersion { get; set; }
-        
+
+        internal string AssemblyDefinitionRawVersion { get; set; }
+
         internal AssemblyData(string location, Assembly preloadedAssembly = null)
         {
             Location = location;

--- a/Engine/AssemblyData.cs
+++ b/Engine/AssemblyData.cs
@@ -61,14 +61,11 @@ namespace OpenTap
 
         /// <summary> The loaded state of the assembly. </summary>
         internal LoadStatus Status => assembly != null ? LoadStatus.Loaded : (failedLoad ? LoadStatus.FailedToLoad : LoadStatus.NotLoaded);
-
-        // NoVersion - marker version instead of null to show that no version has been parsed. Null is a valid value for version.
-        static readonly Version NoVersion = new Version(Int32.MaxValue, 0, 0, 0);
-
+        
         /// <summary>
         /// Gets the version of this Assembly. This will return null if the version cannot be parsed.
         /// </summary>
-        public Version Version { get; internal set; } = NoVersion;
+        public Version Version { get; internal set; } = null;
 
         // NoSemanticVersion - marker version instead of null to show that no version has been parsed. Null is a valid value for version.
         static readonly SemanticVersion NoSemanticVersion = new SemanticVersion(-1, 0, 0, "", "invalidversion");
@@ -86,7 +83,7 @@ namespace OpenTap
                 {
                     if (SemanticVersion.TryParse(RawVersion, out var version))
                         semanticVersion = version;
-                    else if (Version != NoVersion)
+                    else if (Version != null)
                         semanticVersion = new SemanticVersion(Version.Major, Version.Minor, Version.Revision, null, null);
                     else
                         semanticVersion = null;

--- a/Engine/AssemblyData.cs
+++ b/Engine/AssemblyData.cs
@@ -64,32 +64,12 @@ namespace OpenTap
 
         // NoVersion - marker version instead of null to show that no version has been parsed. Null is a valid value for version.
         static readonly Version NoVersion = new Version(Int32.MaxValue, 0, 0, 0);
-        Version version = NoVersion;
+
         /// <summary>
         /// Gets the version of this Assembly. This will return null if the version cannot be parsed.
         /// </summary>
-        public Version Version
-        {
-            get
-            {
-                if (ReferenceEquals(version, NoVersion))
-                {
-                    if (Version.TryParse(RawVersion, out var versionParsed) || Version.TryParse(AssemblyDefinitionRawVersion, out versionParsed))
-                    {
-                        version = versionParsed;
-                    }
-                    else if (SemanticVersion is SemanticVersion semver)
-                    {
-                        version = new Version(semver.Major, semver.Minor, 0, semver.Patch);
-                    }
-                    else
-                        version = null;
-                }
-                
-                return version;
-            }
-        }
-        
+        public Version Version { get; internal set; } = NoVersion;
+
         // NoSemanticVersion - marker version instead of null to show that no version has been parsed. Null is a valid value for version.
         static readonly SemanticVersion NoSemanticVersion = new SemanticVersion(-1, 0, 0, "", "invalidversion");
         
@@ -106,8 +86,8 @@ namespace OpenTap
                 {
                     if (SemanticVersion.TryParse(RawVersion, out var version))
                         semanticVersion = version;
-                    else if (Version.TryParse(RawVersion, out var version2))
-                        semanticVersion = new SemanticVersion(version2.Major, version2.Minor, version2.Revision, null, null);
+                    else if (Version != NoVersion)
+                        semanticVersion = new SemanticVersion(Version.Major, Version.Minor, Version.Revision, null, null);
                     else
                         semanticVersion = null;
                 }
@@ -120,8 +100,6 @@ namespace OpenTap
         
         /// <summary> Raw version as set by the assembly. </summary>
         internal string RawVersion { get; set; }
-
-        internal string AssemblyDefinitionRawVersion { get; set; }
 
         internal AssemblyData(string location, Assembly preloadedAssembly = null)
         {

--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -270,7 +270,7 @@ namespace OpenTap
                                 thisAssembly.RawVersion = def.Version.ToString();
                             }
 
-                            thisAssembly.AssemblyDefinitionRawVersion = def.Version.ToString();
+                            thisAssembly.Version = def.Version;
 
                             if (!nameToAsmMap.ContainsKey(thisRef))
                             {

--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -270,6 +270,8 @@ namespace OpenTap
                                 thisAssembly.RawVersion = def.Version.ToString();
                             }
 
+                            thisAssembly.AssemblyDefinitionRawVersion = def.Version.ToString();
+
                             if (!nameToAsmMap.ContainsKey(thisRef))
                             {
                                 nameToAsmMap.Add(thisRef, thisAssembly);


### PR DESCRIPTION
Try to parse AssemblyVersion as Version in case AssemblyInformationalVersion cannot be parsed as an AssemblyVersion.

Closes #676 