### PR TITLE
Added Host config in Authentication settings and method to retrieve p…

### DIFF
--- a/Engine.UnitTests/AuthenticationTests.cs
+++ b/Engine.UnitTests/AuthenticationTests.cs
@@ -57,10 +57,9 @@ namespace OpenTap.UnitTests
         [Test]
         public void RelativeUrl()
         {
-            
             string host = "https://thisdoesnotexist.io/";
             // REST-API
-            AuthenticationSettings.Current.Host = host;
+            AuthenticationSettings.Current.BaseAddress = host;
 
 
             // Plugin in REST-API Process

--- a/Engine.UnitTests/AuthenticationTests.cs
+++ b/Engine.UnitTests/AuthenticationTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
 using OpenTap.Authentication;
 using System;
 using System.Collections.Generic;
@@ -57,7 +58,7 @@ namespace OpenTap.UnitTests
         [Test]
         public void RelativeUrl()
         {
-            string host = "https://thisdoesnotexist.io/";
+            string host = "https://ks8500.alb.is.keysight.com/";
             // REST-API
             AuthenticationSettings.Current.BaseAddress = host;
 
@@ -65,6 +66,28 @@ namespace OpenTap.UnitTests
             // Plugin in REST-API Process
             HttpClient client = AuthenticationSettings.Current.GetClient();
             Assert.AreEqual(host, client.BaseAddress.ToString());
+
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, "/packages/3.0/GetPackageNames");
+            requestMessage.Headers.Accept.Clear();
+            requestMessage.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+
+            var response = client.SendAsync(requestMessage).GetAwaiter().GetResult();
+            List<string> packageNames = JsonConvert.DeserializeObject<List<string>>(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+            Assert.IsTrue(packageNames.Any());
+        }
+
+        [Test]
+        public void RelativeUrlSetAddressAfter()
+        {
+            string host = "https://ks8500.alb.is.keysight.com/";
+
+            using (HttpClient client = AuthenticationSettings.Current.GetClient())
+            {
+                AuthenticationSettings.Current.BaseAddress = host;
+                Assert.AreEqual(host, client.BaseAddress.ToString());
+            }
+
+            Assert.AreEqual(0, AuthenticationSettings.Current.clientReferences.Count);
         }
     }
 }

--- a/Engine.UnitTests/AuthenticationTests.cs
+++ b/Engine.UnitTests/AuthenticationTests.cs
@@ -75,19 +75,5 @@ namespace OpenTap.UnitTests
             List<string> packageNames = JsonConvert.DeserializeObject<List<string>>(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
             Assert.IsTrue(packageNames.Any());
         }
-
-        [Test]
-        public void RelativeUrlSetAddressAfter()
-        {
-            string host = "https://ks8500.alb.is.keysight.com/";
-
-            using (HttpClient client = AuthenticationSettings.Current.GetClient())
-            {
-                AuthenticationSettings.Current.BaseAddress = host;
-                Assert.AreEqual(host, client.BaseAddress.ToString());
-            }
-
-            Assert.AreEqual(0, AuthenticationSettings.Current.clientReferences.Count);
-        }
     }
 }

--- a/Engine.UnitTests/AuthenticationTests.cs
+++ b/Engine.UnitTests/AuthenticationTests.cs
@@ -54,26 +54,5 @@ namespace OpenTap.UnitTests
             tokens = TokenInfo.ParseTokens(response, "http://packages.opentap.io");
             Assert.AreEqual(1, tokens.Count);
         }
-
-        [Test]
-        public void RelativeUrl()
-        {
-            string host = "https://ks8500.alb.is.keysight.com/";
-            // REST-API
-            AuthenticationSettings.Current.BaseAddress = host;
-
-
-            // Plugin in REST-API Process
-            HttpClient client = AuthenticationSettings.Current.GetClient();
-            Assert.AreEqual(host, client.BaseAddress.ToString());
-
-            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, "/packages/3.0/GetPackageNames");
-            requestMessage.Headers.Accept.Clear();
-            requestMessage.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-
-            var response = client.SendAsync(requestMessage).GetAwaiter().GetResult();
-            List<string> packageNames = JsonConvert.DeserializeObject<List<string>>(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
-            Assert.IsTrue(packageNames.Any());
-        }
     }
 }

--- a/Engine.UnitTests/AuthenticationTests.cs
+++ b/Engine.UnitTests/AuthenticationTests.cs
@@ -1,10 +1,8 @@
-﻿using Newtonsoft.Json;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using OpenTap.Authentication;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -26,8 +24,9 @@ namespace OpenTap.UnitTests
     ""session_state"": ""05d7a6f2-70dd-48e3-806b-dc9ccb5e7f3e"",
     ""scope"": ""openid profile email""
 }";
-            var tokens = TokenInfo.ParseTokens(response, "http://packages.opentap.io");
-            Assert.AreEqual(3, tokens.Count);
+            AuthenticationSettings.Current.AddTokensFromResponse(response, "http://packages.opentap.io");
+            Assert.AreEqual(3, AuthenticationSettings.Current.Tokens.Count);
+            AuthenticationSettings.Current.Tokens.Clear();
 
 
             response = @"{
@@ -40,8 +39,9 @@ namespace OpenTap.UnitTests
     ""session_state"": ""05d7a6f2-70dd-48e3-806b-dc9ccb5e7f3e"",
     ""scope"": ""openid profile email""
 }";
-            tokens = TokenInfo.ParseTokens(response, "http://packages.opentap.io");
-            Assert.AreEqual(2, tokens.Count);
+            AuthenticationSettings.Current.AddTokensFromResponse(response, "http://packages.opentap.io");
+            Assert.AreEqual(2, AuthenticationSettings.Current.Tokens.Count);
+            AuthenticationSettings.Current.Tokens.Clear();
 
             response = @"{
     ""access_token"": ""eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJIaHlId25IdDRnclRDYVhtRHNlSVhHX2U3ajVNb3YzakhLTjZWVlZsZ0lNIn0.eyJleHAiOjE2NDg3MTEwMDQsImlhdCI6MTY0ODcxMDcwNCwianRpIjoiM2NkZDRkYzEtMGE2Mi00YzBjLTljNzQtMmFhZTUwNDk2YWM1IiwiaXNzIjoiaHR0cHM6Ly9rZXljbG9hay5rczg1MDAuYWxiLmlzLmtleXNpZ2h0LmNvbS9hdXRoL3JlYWxtcy9rczg1MDAiLCJhdWQiOiJhY2NvdW50Iiwic3ViIjoiMWY1NmRkMGItNzFkOS00MjAwLWI0YzYtZDE5NWNlNGUxYzJiIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiZGVubmlzIiwic2Vzc2lvbl9zdGF0ZSI6IjA1ZDdhNmYyLTcwZGQtNDhlMy04MDZiLWRjOWNjYjVlN2YzZSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsiZGVmYXVsdC1yb2xlcy1rczg1MDAiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSBlbWFpbCIsInNpZCI6IjA1ZDdhNmYyLTcwZGQtNDhlMy04MDZiLWRjOWNjYjVlN2YzZSIsImNsaWVudElkIjoiZGVubmlzIiwiY2xpZW50SG9zdCI6IjEwLjE0OS4xMDkuMjUyIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJzZXJ2aWNlLWFjY291bnQtZGVubmlzIiwiY2xpZW50QWRkcmVzcyI6IjEwLjE0OS4xMDkuMjUyIn0.GWKY9EV4sqpLg0GGfmqnGcfjBGhN2NunJrfIysaeRJaYnfsmo3rt-_awpbg15q6IXFipr8N6kE965Y0rxeODxAmRVIf8pb-GkaT0qMOpUidiZrUz3FC0WDXymH3gBayOaKOIa03qVOn5fURmGV4nbQyuJemgQYXW8fcFQpu8xrsM9leYGzVXU4zdxNR-jSfYq1iNN2je9E-EhlglxmvQnirRcoGJsymLxg0s6M_s6cQnQBOihuKsEPE8C3zBeVoCXYJ3kkY0Q6GGK2e8EoRhvrNQ-pyK58yJv5YEnC6Erxe06tfFBZ_XX596YerAqkI4XlHpuEBddqGP0HSYlwtcjA"",
@@ -51,8 +51,9 @@ namespace OpenTap.UnitTests
     ""session_state"": ""05d7a6f2-70dd-48e3-806b-dc9ccb5e7f3e"",
     ""scope"": ""openid profile email""
 }";
-            tokens = TokenInfo.ParseTokens(response, "http://packages.opentap.io");
-            Assert.AreEqual(1, tokens.Count);
+            AuthenticationSettings.Current.AddTokensFromResponse(response, "http://packages.opentap.io");
+            Assert.AreEqual(1, AuthenticationSettings.Current.Tokens.Count);
+            AuthenticationSettings.Current.Tokens.Clear();
         }
     }
 }

--- a/Engine.UnitTests/AuthenticationTests.cs
+++ b/Engine.UnitTests/AuthenticationTests.cs
@@ -3,6 +3,7 @@ using OpenTap.Authentication;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -51,6 +52,20 @@ namespace OpenTap.UnitTests
 }";
             tokens = TokenInfo.ParseTokens(response, "http://packages.opentap.io");
             Assert.AreEqual(1, tokens.Count);
+        }
+
+        [Test]
+        public void RelativeUrl()
+        {
+            
+            string host = "https://thisdoesnotexist.io/";
+            // REST-API
+            AuthenticationSettings.Current.Host = host;
+
+
+            // Plugin in REST-API Process
+            HttpClient client = AuthenticationSettings.Current.GetClient();
+            Assert.AreEqual(host, client.BaseAddress.ToString());
         }
     }
 }

--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -30,8 +30,6 @@ namespace OpenTap.Authentication
             async Task<HttpResponseMessage> SendWithRetry(HttpRequestMessage request,
                 CancellationToken cancellationToken)
             {
-                ;
-
                 foreach (var wait in waits)
                 {
                     await Task.Delay(wait, cancellationToken);

--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -24,13 +24,14 @@ namespace OpenTap.Authentication
                 TimeSpan.FromSeconds(1),
                 TimeSpan.FromSeconds(2),
                 TimeSpan.FromSeconds(5),
-                TimeSpan.FromSeconds(10),  
+                TimeSpan.FromSeconds(10),
             };
 
             async Task<HttpResponseMessage> SendWithRetry(HttpRequestMessage request,
                 CancellationToken cancellationToken)
-            {;
-                
+            {
+                ;
+
                 foreach (var wait in waits)
                 {
                     await Task.Delay(wait, cancellationToken);
@@ -44,7 +45,7 @@ namespace OpenTap.Authentication
                 throw new InvalidOperationException();
             }
 
-            
+
 
 
             public AuthenticationClientHandler(string domain = null, bool withRetryPolicy = false)
@@ -68,6 +69,7 @@ namespace OpenTap.Authentication
         public IList<TokenInfo> RefreshTokens { get; set; } = new List<TokenInfo>();
         /// <summary> Identity tokens.</summary>
         public IList<TokenInfo> IdentityTokens { get; set; } = new List<TokenInfo>();
+        public string Host { get; internal set; }
 
         void PrepareRequest(HttpRequestMessage request, string domain, CancellationToken cancellationToken)
         {
@@ -82,7 +84,7 @@ namespace OpenTap.Authentication
 
         /// <summary> Constructs a HttpClientHandler that can be used with HttpClient. </summary>
         public static HttpClientHandler GetClientHandler(string domain = null) => new AuthenticationClientHandler(domain);
-        
+
         /// <summary> Constructs a HttpClientHandler that can be used with HttpClient. </summary>
         public static HttpClientHandler GetClientHandleWithRetryPolicy(string domain = null) => new AuthenticationClientHandler(domain, withRetryPolicy: true);
 
@@ -128,7 +130,7 @@ namespace OpenTap.Authentication
             cancel.ThrowIfCancellationRequested();
 
             // Try refresh
-            
+
             return AccessTokens.FirstOrDefault(x => x.Domain == domain);
         }
 
@@ -155,6 +157,11 @@ namespace OpenTap.Authentication
                         throw new ArgumentOutOfRangeException();
                 }
             }
+        }
+
+        internal HttpClient GetClient()
+        {
+            return new HttpClient(GetClientHandler()) { BaseAddress = new Uri(Host) };
         }
     }
 }

--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -116,8 +115,8 @@ namespace OpenTap.Authentication
         /// Get preconfigured HttpClient with BaseAddress and AuthenticationClientHandler.
         /// It is up to the caller of this method to control the lifetime of the HttpClient
         /// </summary>
-        /// <param name="domain"></param>
-        /// <param name="withRetryPolicy"></param>
+        /// <param name="domain">An access token will attempt to be included which are valid against this domain.</param>
+        /// <param name="withRetryPolicy">If the request should be retried in case of transient errors.</param>
         /// <returns>HttpClient object</returns>
         public HttpClient GetClient(string domain = null, bool withRetryPolicy = false)
         {

--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -63,6 +63,10 @@ namespace OpenTap.Authentication
             }
         }
 
+        /// <summary>
+        /// Token store containing access, refresh and identity tokens.
+        /// These tokens are used in the HttpClients returned by GetClient() to authenticate requests.
+        /// </summary>
         public IList<TokenInfo> Tokens { get; set; } = new List<TokenInfo>();
 
         /// <summary> Parses tokens from OAuth response string (json format) and adds them to current Tokens list. </summary>

--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -62,12 +63,24 @@ namespace OpenTap.Authentication
             }
         }
 
-        /// <summary> Access tokens.</summary>
-        public IList<TokenInfo> AccessTokens { get; set; } = new List<TokenInfo>();
-        /// <summary> Refresh tokens.</summary>
-        public IList<TokenInfo> RefreshTokens { get; set; } = new List<TokenInfo>();
-        /// <summary> Identity tokens.</summary>
-        public IList<TokenInfo> IdentityTokens { get; set; } = new List<TokenInfo>();
+        public IList<TokenInfo> Tokens { get; set; } = new List<TokenInfo>();
+
+        /// <summary> Parses tokens from OAuth response string (json format) and adds them to current Tokens list. </summary>
+        public void AddTokensFromResponse(string response, string domain)
+        {
+
+            var json = JsonDocument.Parse(response);
+
+            if (json.RootElement.TryGetProperty("access_token", out var accessTokenData))
+                Tokens.Add(new TokenInfo(accessTokenData.GetString(), TokenType.AccessToken, domain));
+
+            if (json.RootElement.TryGetProperty("refresh_token", out var refreshTokenData))
+                Tokens.Add(new TokenInfo(refreshTokenData.GetString(), TokenType.RefreshToken, domain));
+
+            if (json.RootElement.TryGetProperty("id_token", out var idTokenData))
+                Tokens.Add(new TokenInfo(idTokenData.GetString(), TokenType.IdentityToken, domain));
+
+        }
 
         /// <summary> Configuration used as BaseAddress in returned HttpClients.
         /// This string will be prepended to all relative urls, e.g. '/api/packages' will become '{BaseAddress}/api/packages'
@@ -78,90 +91,22 @@ namespace OpenTap.Authentication
         {
             TokenInfo token = null;
             if (domain != null)
-                token = GetValidAccessToken(domain, cancellationToken);
+                token = Tokens.FirstOrDefault(t => t.Domain == domain && t.Type == TokenType.AccessToken);
             if (token == null)
-                token = GetValidAccessToken(request.RequestUri.Host, cancellationToken);
+                token = Tokens.FirstOrDefault(t => t.Domain == request.RequestUri.Host && t.Type == TokenType.AccessToken);
             if (token != null)
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.TokenData);
-        }
-
-        /// <summary> Constructs a HttpClientHandler that can be used with HttpClient. </summary>
-        public static HttpClientHandler GetClientHandler(string domain = null) => new AuthenticationClientHandler(domain);
-
-        /// <summary> Constructs a HttpClientHandler that can be used with HttpClient. </summary>
-        public static HttpClientHandler GetClientHandleWithRetryPolicy(string domain = null) => new AuthenticationClientHandler(domain, withRetryPolicy: true);
-
-        /// <summary> Registers a refresh token.  </summary>
-        void RegisterRefreshToken(TokenInfo token)
-        {
-            UnregisterRefreshToken(token.Domain);
-            RefreshTokens.Add(token);
-        }
-
-        /// <summary> Registers an access token.  </summary>
-        void RegisterAccessToken(TokenInfo token)
-        {
-            UnregisterAccessToken(token.Domain);
-            AccessTokens.Add(token);
-        }
-
-        void RegisterIdentityToken(TokenInfo token)
-        {
-            UnregisterIdentityToken(token.Domain);
-            IdentityTokens.Add(token);
-        }
-
-        private void UnregisterIdentityToken(string domain)
-        {
-            IdentityTokens.RemoveIf(x => x.Domain == domain);
-        }
-
-        /// <summary> Unregisters an access token.</summary>
-        public void UnregisterAccessToken(string domain)
-        {
-            AccessTokens.RemoveIf(x => x.Domain == domain);
-        }
-        /// <summary> Unregisters a refresh token.</summary>
-        public void UnregisterRefreshToken(string domain)
-        {
-            RefreshTokens.RemoveIf(x => x.Domain == domain);
-        }
-
-        /// <summary> Gets a valid access token matching the site. If the current token has expired, the refresh action will be used to refresh it. </summary>
-        public TokenInfo GetValidAccessToken(string domain, CancellationToken cancel)
-        {
-            cancel.ThrowIfCancellationRequested();
-
-            // Try refresh
-
-            return AccessTokens.FirstOrDefault(x => x.Domain == domain);
-        }
-
-        /// <summary> Registers a set of tokens.</summary>
-        /// <param name="tokens"></param>
-        /// <exception cref="NotImplementedException"></exception>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public void RegisterTokens(params TokenInfo[] tokens)
-        {
-            foreach (var token in tokens)
             {
-                switch (token.Type)
+                if (token.Expiration < DateTime.Now.AddSeconds(10))
                 {
-                    case TokenType.AccessToken:
-                        RegisterAccessToken(token);
-                        break;
-                    case TokenType.RefreshToken:
-                        RegisterRefreshToken(token);
-                        break;
-                    case TokenType.IdentityToken:
-                        RegisterIdentityToken(token);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
+                    var rToken = Tokens.FirstOrDefault(t => t.Domain == domain && t.Type == TokenType.RefreshToken);
+                    if (rToken != null)
+                    {
+                        // refresh
+                    }
                 }
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.TokenData);
             }
         }
-
 
         /// <summary>
         /// Get preconfigured HttpClient with BaseAddress and AuthenticationClientHandler.

--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -67,7 +67,8 @@ namespace OpenTap.Authentication
         public IList<TokenInfo> RefreshTokens { get; set; } = new List<TokenInfo>();
         /// <summary> Identity tokens.</summary>
         public IList<TokenInfo> IdentityTokens { get; set; } = new List<TokenInfo>();
-        public string Host { get; internal set; }
+        /// <summary> Configuration which is used as BaseAddress in the GetClient() returned HttpClient.</summary>
+        public string BaseAddress { get; set; } = "http://localhost";
 
         void PrepareRequest(HttpRequestMessage request, string domain, CancellationToken cancellationToken)
         {
@@ -157,9 +158,16 @@ namespace OpenTap.Authentication
             }
         }
 
-        internal HttpClient GetClient()
+        /// <summary>
+        /// Get preconfigured HttpClient with BaseAddress and AuthenticationClientHandler.
+        /// It is up to the caller of this method to control the lifetime of the HttpClient
+        /// </summary>
+        /// <param name="domain"></param>
+        /// <param name="withRetryPolicy"></param>
+        /// <returns>HttpClient object</returns>
+        public HttpClient GetClient(string domain = null, bool withRetryPolicy = false)
         {
-            return new HttpClient(GetClientHandler()) { BaseAddress = new Uri(Host) };
+            return new HttpClient(new AuthenticationClientHandler(domain, withRetryPolicy)) { BaseAddress = new Uri(BaseAddress) };
         }
     }
 }

--- a/Engine/Authentication/TokenInfo.cs
+++ b/Engine/Authentication/TokenInfo.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using System.Xml.Serialization;
 
@@ -9,14 +7,14 @@ namespace OpenTap.Authentication
     /// <summary> Represents stored information about a token. </summary>
     public class TokenInfo
     {
-        /// <summary> Raw token string. </summary>
+        /// <summary>Raw token string. This value can be used as a Bearer token if <see cref="Type"/> is <see cref="TokenType.AccessToken"/></summary>
         public string TokenData { get; set; }
 
         static DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
         /// <summary> Expiration date of the token. </summary>
         [XmlIgnore]
-        public DateTime Expiration => unixEpoch.AddSeconds(long.Parse(this["exp"]));
+        public DateTime Expiration => unixEpoch.AddSeconds(long.Parse(GetClaim("exp")));
 
         /// <summary> The site this token belongs to. </summary>
         public string Domain { get; set; }
@@ -36,16 +34,13 @@ namespace OpenTap.Authentication
         /// <summary>
         /// Get a claim from the JWT payload
         /// </summary>
-        /// <param name="claim"></param>
-        /// <returns></returns>
-        public string this[string claim]
+        /// <param name="claim">Name of the claim, e.g. 'sub'</param>
+        /// <returns>Claim value or null if claim does not exist</returns>
+        public string GetClaim(string claim)
         {
-            get
-            {
-                if (GetPayload().RootElement.TryGetProperty(claim, out var id))
-                    return id.GetString();
-                return null;
-            }
+            if (GetPayload().RootElement.TryGetProperty(claim, out var id))
+                return id.GetString();
+            return null;
         }
 
         /// <summary>

--- a/Engine/Authentication/TokenInfo.cs
+++ b/Engine/Authentication/TokenInfo.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Xml.Serialization;
 
 namespace OpenTap.Authentication
 {
@@ -8,67 +11,63 @@ namespace OpenTap.Authentication
     {
         /// <summary> Raw token string. </summary>
         public string TokenData { get; set; }
+
+        static DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
         /// <summary> Expiration date of the token. </summary>
-        public DateTime Expiration { get; set; }
-        /// <summary> The site this token activates. </summary>
+        [XmlIgnore]
+        public DateTime Expiration => unixEpoch.AddSeconds(long.Parse(this["exp"]));
+
+        /// <summary> The site this token belongs to. </summary>
         public string Domain { get; set; }
         /// <summary> The type of token. </summary>
         public TokenType Type { get; set; }
 
-        /// <summary> Gets if the token is expired.</summary>
-        public bool Expired => Expiration < DateTime.Now;
+        JsonDocument payload;
 
-        System.Text.Json.JsonDocument payload;
-
-        System.Text.Json.JsonDocument GetPayload()
+        JsonDocument GetPayload()
         {
             if (payload != null) return payload;
             var payloadData = TokenData.Split('.')[1];
-            payload = System.Text.Json.JsonDocument.Parse(Convert.FromBase64String(payloadData));
+            payload = JsonDocument.Parse(Convert.FromBase64String(payloadData));
             return payload;
         }
-        /// <summary> Gets the client id. </summary>
-        public string GetClientId()
+
+        /// <summary>
+        /// Get a claim from the JWT payload
+        /// </summary>
+        /// <param name="claim"></param>
+        /// <returns></returns>
+        public string this[string claim]
         {
-            if (GetPayload().RootElement.TryGetProperty("azp", out var id))
-                return id.GetString();
-            return null;
+            get
+            {
+                if (GetPayload().RootElement.TryGetProperty(claim, out var id))
+                    return id.GetString();
+                return null;
+            }
         }
 
-        /// <summary> Gets the auth URL. </summary>
-        public string GetAuthority()
+        /// <summary>
+        /// Serializable constructur
+        /// </summary>
+        public TokenInfo()
         {
-            if (GetPayload().RootElement.TryGetProperty("iss", out var id))
-                return id.GetString();
-            return null;
+
         }
 
-        static readonly TimeSpan refreshSlack = TimeSpan.FromSeconds(30);
-        /// <summary> Parses tokens from oauth response string (json format). </summary>
-
-        public static List<TokenInfo> ParseTokens(string responseString, string domain)
+        /// <summary>
+        /// Default constructor from user code
+        /// </summary>
+        /// <param name="jwtString">Token Data</param>
+        /// <param name="type">Access, Refresh or ID type</param>
+        /// <param name="domain">Domain name for which this token is valid</param>
+        public TokenInfo(string jwtString, TokenType type, string domain)
         {
-            var json = System.Text.Json.JsonDocument.Parse(responseString);
-
-            //"expires_in":300,"refresh_expires_in":1800
-            var accessExp = DateTime.Now.AddSeconds(300);
-            var refreshExp = DateTime.Now.AddSeconds(1800);
-            if (json.RootElement.TryGetProperty("expires_in", out var exp1Str) && exp1Str.TryGetInt32(out var accessAdd))
-                accessExp = DateTime.Now.AddSeconds(accessAdd).Subtract(refreshSlack);
-            if (json.RootElement.TryGetProperty("refresh_expires_in", out exp1Str) && exp1Str.TryGetInt32(out var refreshAdd))
-                refreshExp = DateTime.Now.AddSeconds(refreshAdd).Subtract(refreshSlack);
-            List<TokenInfo> tokens = new List<TokenInfo>();
-
-            if (json.RootElement.TryGetProperty("access_token", out var accessTokenData))
-                tokens.Add(new TokenInfo { Domain = domain, Expiration = accessExp, Type = TokenType.AccessToken, TokenData = accessTokenData.GetString() });
-
-            if (json.RootElement.TryGetProperty("refresh_token", out var refreshTokenData))
-                tokens.Add(new TokenInfo { Domain = domain, Expiration = refreshExp, Type = TokenType.RefreshToken, TokenData = refreshTokenData.GetString() });
-
-            if(json.RootElement.TryGetProperty("id_token", out var idTokenData))
-                tokens.Add(new TokenInfo { Domain = domain, Expiration = accessExp, Type = TokenType.IdentityToken, TokenData = idTokenData.GetString() });
-
-            return tokens;
+            TokenData = jwtString;
+            Type = type;
+            Domain = domain;
         }
+
     }
 }

--- a/Package.UnitTests/PackageManagerTests.cs
+++ b/Package.UnitTests/PackageManagerTests.cs
@@ -514,6 +514,16 @@ namespace OpenTap.Package.UnitTests
             // Path with incorrect syntax
             result = PackageRepositoryHelpers.DetermineRepositoryType(@"C::\Users\steholst\Source\Repos\tap2\TapThatDoesNotExists");
             Assert.IsFalse(result is FilePackageRepository);
+
+            // Specific file entry
+            result = PackageRepositoryHelpers.DetermineRepositoryType(@"file:///C:/thisdoesnotexist");
+            Assert.IsTrue(result is FilePackageRepository);
+
+            // Specific file entry with casing
+            result = PackageRepositoryHelpers.DetermineRepositoryType(@"FILE:///C:/thisdoesnotexist");
+            Assert.IsTrue(result is FilePackageRepository);
+
+
             #endregion
 
             #region HTTP
@@ -524,6 +534,18 @@ namespace OpenTap.Package.UnitTests
             // Correct https address
             result = PackageRepositoryHelpers.DetermineRepositoryType(@"https://plugindemoapi.azurewebsites.net/");
             Assert.IsTrue(result is HttpPackageRepository, "DetermineRepositoryType - Correct https address");
+
+            // HttpRepo with casing
+            result = PackageRepositoryHelpers.DetermineRepositoryType(@"HTTP://thisdoesnotexist.io");
+            Assert.IsTrue(result is HttpPackageRepository);
+
+            // Relative PackageRepository URL
+            result = PackageRepositoryHelpers.DetermineRepositoryType(@"/thisdoesnotexist");
+            Assert.IsTrue(result is HttpPackageRepository);
+
+            // Relative PackageRepository URL
+            result = PackageRepositoryHelpers.DetermineRepositoryType(@"/packages");
+            Assert.IsTrue(result is HttpPackageRepository);
             #endregion
         }
     }

--- a/Package/IPackageRepository.cs
+++ b/Package/IPackageRepository.cs
@@ -318,13 +318,15 @@ namespace OpenTap.Package
         {
             if(registeredRepositories.TryGetValue(url, out var repo))
                 return repo;
-            if(url.Contains("http://") || url.Contains("https://"))
+            if(url.ToLower().StartsWith("http://") || url.ToLower().StartsWith("https://"))
                 return new HttpPackageRepository(url); // avoid throwing exceptions if it looks a lot like a URL.
+            if(url.ToLower().StartsWith("file:///"))
+                return new FilePackageRepository(url);
             if (Uri.IsWellFormedUriString(url, UriKind.Relative) && Directory.Exists(url))
                 return new FilePackageRepository(url);
             if (File.Exists(url))
                 return new FilePackageRepository(Path.GetDirectoryName(url));
-            if (Regex.IsMatch(url ?? "", @"^([A-Z|a-z]:)?(\\|/)"))
+            if (Regex.IsMatch(url ?? "", @"^([A-Z|a-z]:[/|\\])|(//|\\\\)"))
                 return new FilePackageRepository(url);
             else
                 return new HttpPackageRepository(url);

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -1,4 +1,5 @@
-﻿using OpenTap.Cli;
+﻿using OpenTap.Authentication;
+using OpenTap.Cli;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -27,6 +28,9 @@ namespace OpenTap.Package
         [CommandLineArgument("merge")]
         public bool Merge { get; set; }
 
+        [CommandLineArgument("baseaddress")]
+        public string BaseAddress { get; set; }
+
         /// <summary>
         /// Never prompt for user input.
         /// </summary>
@@ -41,9 +45,11 @@ namespace OpenTap.Package
             if (Force)
                 log.Warning($"Using --force does not force an image installation");
 
+            if(!string.IsNullOrEmpty(BaseAddress))
+                AuthenticationSettings.Current.BaseAddress = BaseAddress;
+
             var imageString = File.ReadAllText(ImagePath);
             var imageSpecifier = ImageSpecifier.FromString(imageString);
-
 
             try
             {

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -1,5 +1,4 @@
-﻿using OpenTap.Authentication;
-using OpenTap.Cli;
+﻿using OpenTap.Cli;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -28,9 +27,6 @@ namespace OpenTap.Package
         [CommandLineArgument("merge")]
         public bool Merge { get; set; }
 
-        [CommandLineArgument("baseaddress")]
-        public string BaseAddress { get; set; }
-
         /// <summary>
         /// Never prompt for user input.
         /// </summary>
@@ -44,9 +40,6 @@ namespace OpenTap.Package
 
             if (Force)
                 log.Warning($"Using --force does not force an image installation");
-
-            if(!string.IsNullOrEmpty(BaseAddress))
-                AuthenticationSettings.Current.BaseAddress = BaseAddress;
 
             var imageString = File.ReadAllText(ImagePath);
             var imageSpecifier = ImageSpecifier.FromString(imageString);

--- a/Package/PackageCacheHelper.cs
+++ b/Package/PackageCacheHelper.cs
@@ -17,7 +17,7 @@ namespace OpenTap.Package
         // Resolves to:
         // - Linux: /home/<USER>/.local/share/OpenTAP/PackageCache
         // - Windows: C:\Users\<USER>\AppData\Local\OpenTAP\PackageCache
-        public static string PackageCacheDirectory { get; } = new Uri(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTap", "PackageCache")).AbsoluteUri;
+        public static string PackageCacheDirectory { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTap", "PackageCache");
         readonly static TraceSource log =  Log.CreateSource("PackageCache");
 
         static PackageCacheHelper()

--- a/Package/PackageCacheHelper.cs
+++ b/Package/PackageCacheHelper.cs
@@ -17,7 +17,7 @@ namespace OpenTap.Package
         // Resolves to:
         // - Linux: /home/<USER>/.local/share/OpenTAP/PackageCache
         // - Windows: C:\Users\<USER>\AppData\Local\OpenTAP\PackageCache
-        public static string PackageCacheDirectory { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTap", "PackageCache");
+        public static string PackageCacheDirectory { get; } = new Uri(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTap", "PackageCache")).AbsoluteUri;
         readonly static TraceSource log =  Log.CreateSource("PackageCache");
 
         static PackageCacheHelper()

--- a/Package/Repositories/HttpPackageRepository.cs
+++ b/Package/Repositories/HttpPackageRepository.cs
@@ -39,7 +39,7 @@ namespace OpenTap.Package
         private HttpClient HttpClient => client ?? (client = GetHttpClient(Url));
         private static HttpClient GetHttpClient(string url)
         {
-            var httpClient = new HttpClient(Authentication.AuthenticationSettings.GetClientHandleWithRetryPolicy());
+            var httpClient = AuthenticationSettings.Current.GetClient(null, true);
             httpClient.DefaultRequestHeaders.Add("OpenTAP",
                 PluginManager.GetOpenTapAssembly().SemanticVersion.ToString());
             httpClient.DefaultRequestHeaders.Add(HttpRequestHeader.Accept.ToString(), "application/xml");

--- a/Package/Repositories/HttpPackageRepository.cs
+++ b/Package/Repositories/HttpPackageRepository.cs
@@ -30,7 +30,7 @@ namespace OpenTap.Package
     {
         // from Stream.cs: pick a value that is the largest multiple of 4096 that is still smaller than the large object heap threshold (85K).
         private const int _DefaultCopyBufferSize = 81920;
-        
+
         private static TraceSource log = Log.CreateSource("HttpPackageRepository");
         private const string ApiVersion = "3.0";
         private VersionSpecifier MinRepoVersion = new VersionSpecifier(3, 0, 0, "", "", VersionMatchBehavior.AnyPrerelease | VersionMatchBehavior.Compatible);
@@ -53,7 +53,7 @@ namespace OpenTap.Package
         private SemanticVersion _version;
 
         bool IsInError() => _version == null && nextUpdateAt > DateTime.Now;
-        
+
         /// <summary>
         /// Get or set the version of the repository
         /// </summary>
@@ -126,14 +126,14 @@ namespace OpenTap.Package
 
         async Task DoDownloadPackage(PackageDef package, FileStream fileStream, CancellationToken cancellationToken)
         {
-            
+
             try
             {
                 var hc = HttpClient;
                 {
                     HttpResponseMessage response = null;
                     hc.DefaultRequestHeaders.Add("OpenTAP", PluginManager.GetOpenTapAssembly().SemanticVersion.ToString());
-                    
+
                     var totalSize = -1L;
                     // this retry loop is to robustly to download the package even if the connection is intermittently lost
                     // to test, try
@@ -196,12 +196,12 @@ namespace OpenTap.Package
                                         ConsoleUtils.printProgress(header, pos, len);
                                         (this as IPackageDownloadProgress).OnProgressUpdate?.Invoke(header, pos, len);
                                     });
-                                
+
                             }
 
                             break;
                         }
-                        
+
                         catch (Exception ex)
                         {
                             if (ex is IOException)
@@ -216,19 +216,19 @@ namespace OpenTap.Package
                                 await Task.Delay(TimeSpan.FromSeconds(1));
                                 continue;
                             }
-                                
+
                             if (response != null)
                             {
                                 // The connection was broken while a http request was active.
                                 // If the error is transient or we got partial data we can try continuing.
-                                
+
                                 var code = response.StatusCode;
                                 bool isError = response.IsSuccessStatusCode == false;
                                 response.Dispose();
                                 response = null;
-                                
+
                                 // PartialContent usually happens when 'ex' is IOException.
-                                
+
                                 if (code == HttpStatusCode.PartialContent || (isError && HttpUtils.TransientStatusCode(code)))
                                 {
                                     await Task.Delay(TimeSpan.FromSeconds(1));
@@ -237,7 +237,7 @@ namespace OpenTap.Package
                             }
 
                             if (cancellationToken.IsCancellationRequested == false)
-                                log.Error("Failed to download package.");   
+                                log.Error("Failed to download package.");
                             throw;
                         }
                     }
@@ -263,7 +263,7 @@ namespace OpenTap.Package
                     wc.Proxy = WebRequest.GetSystemWebProxy();
                     wc.Headers.Add(HttpRequestHeader.Accept, accept ?? "application/xml");
                     wc.Headers.Add("OpenTAP", PluginManager.GetOpenTapAssembly().SemanticVersion.ToString());
-                    var token = AuthenticationSettings.Current.GetValidAccessToken(new Uri(Url).Host, TapThread.Current.AbortToken);
+                    var token = AuthenticationSettings.Current.Tokens.FirstOrDefault(s => s.Type == TokenType.AccessToken && s.Domain == new Uri(Url).Host);
                     if (token != null)
                         wc.Headers.Add("Authorization", "Bearer " + token.TokenData);
                     wc.Encoding = Encoding.UTF8;
@@ -303,7 +303,7 @@ namespace OpenTap.Package
                 {
                     var versionUrl = $"{url}/{ApiVersion}/version";
                     var response = HttpClient.GetAsync(versionUrl).Result;
-                   
+
                     // Check for http server redirects
                     url = checkServerRedirect(url, versionUrl, response);
 
@@ -364,7 +364,7 @@ namespace OpenTap.Package
 
         // The value indicates the next time at which the repo should be tried connected to.
         DateTime nextUpdateAt = DateTime.MinValue;
-        
+
         static readonly TimeSpan updateRepoVersionHoldOff = TimeSpan.FromSeconds(60);
         readonly object updateVersionLock = new object();
         private void CheckRepoApiVersion()
@@ -396,9 +396,9 @@ namespace OpenTap.Package
                     }
                     catch (HttpRequestException ex)
                     {
-                        log.Debug("HTTP Exception {0}", ex);    
+                        log.Debug("HTTP Exception {0}", ex);
                     }
-                    
+
                     if (string.IsNullOrEmpty(data))
                     {
                         // Url does not exists
@@ -665,7 +665,7 @@ namespace OpenTap.Package
         public PackageVersion[] GetPackageVersions(string packageName, CancellationToken cancellationToken, params IPackageIdentifier[] compatibleWith)
         {
             // force update version to check for errors.
-            Version?.ToString(); 
+            Version?.ToString();
             if (IsInError()) return Array.Empty<PackageVersion>();
             string response;
             string arg = string.Format("/{0}/GetPackageVersions/{1}", ApiVersion, Uri.EscapeDataString(packageName));


### PR DESCRIPTION
…reconfigured HttpClient.


I've tested using the following code in a test (however, I do not want to commit a test in CI that depends on a repository or internet connectivity)

```csharp
        [Test]
        public void RelativeUrl()
        {
            string host = REPOSITORY;
            // REST-API
            AuthenticationSettings.Current.BaseAddress = host;


            // Plugin in REST-API Process
            HttpClient client = AuthenticationSettings.Current.GetClient();
            Assert.AreEqual(host, client.BaseAddress.ToString());

            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, "/packages/3.0/GetPackageNames");
            requestMessage.Headers.Accept.Clear();
            requestMessage.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));

            var response = client.SendAsync(requestMessage).GetAwaiter().GetResult();
            List<string> packageNames = JsonConvert.DeserializeObject<List<string>>(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());   
            Assert.IsTrue(packageNames.Any());
        }
```
