### PR TITLE
701 relative url improvements

### DIFF
--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -15,7 +15,7 @@ namespace OpenTap.Authentication
     [Browsable(false)]
     public class AuthenticationSettings : ComponentSettings<AuthenticationSettings>
     {
-        private string baseAddress = "";
+        private Uri baseAddress = null;
 
         class AuthenticationClientHandler : HttpClientHandler
         {
@@ -74,14 +74,13 @@ namespace OpenTap.Authentication
         /// <summary> Configuration used as BaseAddress in HttpClients returned by <see cref="GetClient"/>.
         /// This string will be prepended to all relative urls, e.g. '/api/packages' will become '{BaseAddress}/api/packages'
         /// </summary>
-        public string BaseAddress
+        public Uri BaseAddress
         {
             get => baseAddress; set
             {
-                if (String.IsNullOrEmpty(value) || Uri.IsWellFormedUriString(value, UriKind.Absolute))
-                    baseAddress = value;
-                else
-                    throw new FormatException("BaseAddress must be a well formed absolute URI.");
+                if (value != null && !value.IsAbsoluteUri)
+                    throw new FormatException("BaseAddress must be an absolute URI.");
+                baseAddress = value;
             }
         }
 
@@ -117,8 +116,8 @@ namespace OpenTap.Authentication
         public HttpClient GetClient(string domain = null, bool withRetryPolicy = false)
         {
             var client = new HttpClient(new AuthenticationClientHandler(domain, withRetryPolicy));
-            if (!String.IsNullOrEmpty(BaseAddress))
-                client.BaseAddress = new Uri(BaseAddress, UriKind.Absolute);
+            if (BaseAddress != null)
+                client.BaseAddress = BaseAddress;
             if(userAgent == null)
             {
                 //var sw = System.Diagnostics.Stopwatch.StartNew();

--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -105,7 +105,7 @@ namespace OpenTap.Authentication
             }
         }
 
-        public static string userAgent = null;
+        private static string userAgent = null;
 
         /// <summary>
         /// Get preconfigured HttpClient with BaseAddress and AuthenticationClientHandler.

--- a/Package.UnitTests/Image/Deserialize.cs
+++ b/Package.UnitTests/Image/Deserialize.cs
@@ -56,7 +56,7 @@ namespace OpenTap.Image.Tests
             Assert.True(specifier.Packages[1].OS == "Windows");
 
             Assert.True(specifier.Repositories.Count == 3);
-            Assert.True(specifier.Repositories[0] == PackageCacheHelper.PackageCacheDirectory);
+            Assert.True(specifier.Repositories[0] == new Uri(PackageCacheHelper.PackageCacheDirectory).AbsoluteUri);
             Assert.True(specifier.Repositories[1] == "packages.opentap.io");
             Assert.True(specifier.Repositories[2] == "packages.opentap.keysight.com");
 

--- a/Package.UnitTests/Image/MockRepository.cs
+++ b/Package.UnitTests/Image/MockRepository.cs
@@ -186,7 +186,7 @@ namespace OpenTap.Image.Tests
             var list = AllPackages.Where(p => p.Name == package.Name)
                               .GroupBy(p => p.Version)
                               .OrderByDescending(g => g.Key).ToList();
-            return list.FirstOrDefault(g => package.Version.IsCompatible(g.Key)).ToArray();
+            return list.FirstOrDefault(g => package.Version.IsCompatible(g.Key))?.ToArray() ?? Array.Empty<PackageDef>();
         }
 
         public PackageVersion[] GetPackageVersions(string packageName, CancellationToken cancellationToken, params IPackageIdentifier[] compatibleWith)

--- a/Package.UnitTests/PackageManagerTests.cs
+++ b/Package.UnitTests/PackageManagerTests.cs
@@ -405,18 +405,10 @@ namespace OpenTap.Package.UnitTests
         [Test]
         public void PackageManagerTestsExecution()
         {
-            log.Info("-----------------------------DependencyChecker CheckDependencies-----------------------------");
-
             if(Directory.Exists("DownloadedPackages"))
                 Directory.Delete("DownloadedPackages", true);
 
             // Test execution
-            GetPackages();
-            DetermineRepositoryType();
-        }
-
-        void GetPackages()
-        {
             var tap = new PackageIdentifier("OpenTAP", SemanticVersion.Parse("9.0.0-Development"), CpuArchitecture.Unspecified, "Windows");
 
             // Development, don't check build version
@@ -472,36 +464,49 @@ namespace OpenTap.Package.UnitTests
             return packages;
         }
 
-        [TestCase("http://packages.opentap.io", typeof(HttpPackageRepository))] // Http
-        [TestCase("https://packages.opentap.io", typeof(HttpPackageRepository))] // Https
-        [TestCase("/api/packages", typeof(FilePackageRepository))] // Relative http from root
-        [TestCase("api/packages", typeof(FilePackageRepository))] // Relative http appended
-        [TestCase("file:///./Packages", typeof(FilePackageRepository))] // Explicit file path
-        [TestCase("file:///Packages", typeof(FilePackageRepository))] // Explicit file path
-        [TestCase("file:///C:/Packages", typeof(FilePackageRepository))] // Explicit absolute File Path
-        [TestCase("C:/Packages", typeof(FilePackageRepository))] // File Path
-        [TestCase("C:/WeirdLocation/Packages", typeof(FilePackageRepository))] // File Path
-        public void TestRepositoryType(string url, Type expectedRepositoryType)
+        [TestCase("", "http://packages.opentap.io", typeof(HttpPackageRepository))]  // Http scheme
+        [TestCase("", "https://packages.opentap.io", typeof(HttpPackageRepository))] // Https scheme
+        [TestCase("", "ftp://packages.opentap.io", typeof(NotSupportedException))]   // Unsupported scheme
+        [TestCase("", "something illigal|", typeof(ArgumentException))]              // Illigal chars
+        [TestCase("", "C:/a", typeof(FilePackageRepository))]                        // Windows absolute path
+        [TestCase("", "/a/b", typeof(FilePackageRepository))]                        // Linux absolute path
+        [TestCase("", "a/b", typeof(FilePackageRepository))]                         // Relative path
+        [TestCase("", @"a\b", typeof(FilePackageRepository))]                        // Relative file path using backslash
+        [TestCase("", "file:///./a", typeof(FilePackageRepository))]                 // Explicit file scheme
+        [TestCase("", "file:///a", typeof(FilePackageRepository))]                   // Explicit file scheme
+        [TestCase("", "file:///C:/a", typeof(FilePackageRepository))]                // Explicit absolute File Path
+        [TestCase("", @"\\a\b", typeof(FilePackageRepository))]                      // UNC path
+        [TestCase("http://opentap.io", "http://packages.opentap.io", typeof(HttpPackageRepository))]  // Http scheme
+        [TestCase("http://opentap.io", "https://packages.opentap.io", typeof(HttpPackageRepository))] // Https scheme
+        [TestCase("http://opentap.io", "C:/a", typeof(FilePackageRepository))]                        // Windows absolute path
+        [TestCase("http://opentap.io", "/a/b", typeof(HttpPackageRepository))]                        // Linux absolute path
+        [TestCase("http://opentap.io", "a/b", typeof(HttpPackageRepository))]                         // Relative path
+        [TestCase("http://opentap.io", @"a\b", typeof(HttpPackageRepository))]                        // Relative file path using backslash
+        [TestCase("http://opentap.io", "file:///./a", typeof(FilePackageRepository))]                 // Explicit file scheme
+        [TestCase("http://opentap.io", "file:///a", typeof(FilePackageRepository))]                   // Explicit file scheme
+        [TestCase("http://opentap.io", "file:///C:/a", typeof(FilePackageRepository))]                // Explicit absolute File Path
+        [TestCase("http://opentap.io", @"\\a\b", typeof(FilePackageRepository))]                      // UNC path
+        //[TestCase("http://opentap.io", @"//a/b", typeof(FilePackageRepository))]                      // UNC path using forward slash (but also scheme relative URL)
+        public void TestRepositoryType(string baseUrl, string url, Type expectedRepositoryType)
         {
-            AuthenticationSettings.Current.BaseAddress = null;
-            var result = PackageRepositoryHelpers.DetermineRepositoryType(url);
-            Assert.AreEqual(expectedRepositoryType,result.GetType());
-        }
-
-        [TestCase("http://packages.opentap.io", typeof(HttpPackageRepository))] // Http
-        [TestCase("https://packages.opentap.io", typeof(HttpPackageRepository))] // Https
-        [TestCase("/api/packages", typeof(HttpPackageRepository))] // Relative http from root
-        [TestCase("api/packages", typeof(HttpPackageRepository))] // Relative http appended
-        [TestCase("file:///./Packages", typeof(FilePackageRepository))] // Explicit file path
-        [TestCase("file:///Packages", typeof(FilePackageRepository))] // Explicit file path
-        [TestCase("file:///C:/Packages", typeof(FilePackageRepository))] // Explicit absolute File Path
-        [TestCase("C:/Packages", typeof(FilePackageRepository))] // File Path
-        [TestCase("C:/WeirdLocation/Packages", typeof(FilePackageRepository))] // File Path
-        public void TestRepositoryTypeWithBaseAddress(string url, Type expectedRepositoryType)
-        {
-            AuthenticationSettings.Current.BaseAddress = new Uri("http://opentap.io");
-            var result = PackageRepositoryHelpers.DetermineRepositoryType(url);
-            Assert.AreEqual(expectedRepositoryType, result.GetType());
+            if(String.IsNullOrEmpty(baseUrl))
+                AuthenticationSettings.Current.BaseAddress = null;
+            else
+                AuthenticationSettings.Current.BaseAddress = new Uri(baseUrl); ;
+            try
+            {
+                var result = PackageRepositoryHelpers.DetermineRepositoryType(url);
+                if (expectedRepositoryType.DescendsTo(typeof(Exception)))
+                    Assert.Fail($"Should have thrown {expectedRepositoryType.ToString()} but returned {result.GetType()}");
+                Assert.AreEqual(expectedRepositoryType, result.GetType());
+            }
+            catch (Exception ex)
+            {
+                if (expectedRepositoryType == ex.GetType())
+                    return;
+                else
+                    throw;
+            }
         }
 
         [Test]
@@ -549,69 +554,6 @@ namespace OpenTap.Package.UnitTests
                 if (File.Exists(file))
                     File.Delete(file);
             }
-        }
-
-        void DetermineRepositoryType()
-        {
-            #region Path
-            // Correct path
-            var result = PackageRepositoryHelpers.DetermineRepositoryType(Path.Combine(Directory.GetCurrentDirectory(), "TapPackages"));
-            Assert.IsTrue(result is FilePackageRepository, "DetermineRepositoryType - Correct path");
-
-            // Correct network path
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"\\Tap\Tap.PackageManager.UnitTests\TapPlugins");
-            Assert.IsTrue(result is FilePackageRepository, "DetermineRepositoryType - Correct network path");
-
-            // Incorrect path
-            Assert.Catch(() =>
-            {
-                result = PackageRepositoryHelpers.DetermineRepositoryType(@"Tap\Tap.PackageManager.UnitTests\TapPlugins"); 
-            }, "DetermineRepositoryType - Incorrect path");
-
-            // Path that does not exists
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"C:\Users\steholst\Source\Repos\tap2\TapThatDoesNotExists");
-            Assert.IsTrue(result is FilePackageRepository, "DetermineRepositoryType - Path that does not exists");
-
-            // Illegal path
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"C:\Users\steholst\Source\Repos\tap2\Tap?");
-            Assert.IsTrue(result is FilePackageRepository, "DetermineRepositoryType - Illegal path");
-
-            // Specific file entry
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"file:///C:/thisdoesnotexist");
-            Assert.IsTrue(result is FilePackageRepository);
-
-            // Specific file entry with casing
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"FILE:///C:/thisdoesnotexist");
-            Assert.IsTrue(result is FilePackageRepository);
-
-
-            #endregion
-
-            #region HTTP
-            // Correct http address
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"http://plugindemoapi.azurewebsites.net/");
-            Assert.IsTrue(result is HttpPackageRepository, "DetermineRepositoryType - Correct http address");
-
-            // Correct https address
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"https://plugindemoapi.azurewebsites.net/");
-            Assert.IsTrue(result is HttpPackageRepository, "DetermineRepositoryType - Correct https address");
-
-            // HttpRepo with casing
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"HTTP://thisdoesnotexist.io");
-            Assert.IsTrue(result is HttpPackageRepository);
-
-            // Relative PackageRepository URL
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"/thisdoesnotexist");
-            Assert.IsTrue(result is HttpPackageRepository);
-
-            // Relative PackageRepository URL
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"thisdoesnotexist/packages");
-            Assert.IsTrue(result is HttpPackageRepository);
-
-            // Relative PackageRepository URL
-            result = PackageRepositoryHelpers.DetermineRepositoryType(@"/packages");
-            Assert.IsTrue(result is HttpPackageRepository);
-            #endregion
         }
     }
 }

--- a/Package.UnitTests/PackageManagerTests.cs
+++ b/Package.UnitTests/PackageManagerTests.cs
@@ -489,10 +489,7 @@ namespace OpenTap.Package.UnitTests
         //[TestCase("http://opentap.io", @"//a/b", typeof(FilePackageRepository))]                      // UNC path using forward slash (but also scheme relative URL)
         public void TestRepositoryType(string baseUrl, string url, Type expectedRepositoryType)
         {
-            if(String.IsNullOrEmpty(baseUrl))
-                AuthenticationSettings.Current.BaseAddress = null;
-            else
-                AuthenticationSettings.Current.BaseAddress = new Uri(baseUrl); ;
+            AuthenticationSettings.Current.BaseAddress = baseUrl;
             try
             {
                 var result = PackageRepositoryHelpers.DetermineRepositoryType(url);

--- a/Package.UnitTests/PackageManagerTests.cs
+++ b/Package.UnitTests/PackageManagerTests.cs
@@ -345,7 +345,7 @@ namespace OpenTap.Package.UnitTests
         public void TestDependencyPatchVersion()
         {
             // Verify that the resolver bumps from installed "9.12.0" because "^9.12.1" is required
-            var repo = "packages.opentap.io";
+            var repo = "http://packages.opentap.io";
 
             var installedOpenTap = new PackageDef() {Version = SemanticVersion.Parse("9.12.0"), Name = "OpenTAP", Architecture = CpuArchitecture.x64};
 

--- a/Package/IPackageRepository.cs
+++ b/Package/IPackageRepository.cs
@@ -347,7 +347,7 @@ namespace OpenTap.Package
                 else
                 {
                     if (AuthenticationSettings.Current.BaseAddress != null)
-                        return DetermineRepositoryType(new Uri(AuthenticationSettings.Current.BaseAddress, url).AbsoluteUri);
+                        return DetermineRepositoryType(new Uri(new Uri(AuthenticationSettings.Current.BaseAddress), url).AbsoluteUri);
                     else
                         return new FilePackageRepository(Path.GetFullPath(url)); // GetFullPath throws ArgumentException if url contains illigal path chars
                 }

--- a/Package/Image/ImageSpecifier.cs
+++ b/Package/Image/ImageSpecifier.cs
@@ -23,9 +23,10 @@ namespace OpenTap.Package
 
         /// <summary>
         /// OpenTAP repositories to fetch the desired packages from
+        /// These should be well formed URIs and will be interpreted relative to the BaseAddress set in AuthenticationSettings.
         /// </summary>
         public List<string> Repositories { get; set; } =
-            new List<string>() { PackageCacheHelper.PackageCacheDirectory };
+            new List<string>() { new Uri(PackageCacheHelper.PackageCacheDirectory).AbsoluteUri };
 
         /// <summary>
         /// Resolve the desired packages from the specified repositories. This will check if the packages are available, compatible and can successfully be deployed as an OpenTAP installation

--- a/Package/PackageActionHelpers.cs
+++ b/Package/PackageActionHelpers.cs
@@ -346,7 +346,7 @@ namespace OpenTap.Package
                                 rm = new FilePackageRepository(System.IO.Path.GetDirectoryName(fileSource.PackageFilePath));
                                 break;
                             default:
-                                throw new Exception("Unable to determine package source.");
+                                throw new Exception($"Unable to determine repositoy type for package source {pkg.PackageSource.GetType()}.");
                         }
                         if (rm is IPackageDownloadProgress r)
                         {

--- a/Package/PackageManagerSettings.cs
+++ b/Package/PackageManagerSettings.cs
@@ -84,11 +84,23 @@ namespace OpenTap.Package
         {
             var repositories = new List<IPackageRepository>();
             if (PackageManagerSettings.Current.UseLocalPackageCache)
-                repositories.Add(PackageRepositoryHelpers.DetermineRepositoryType(PackageCacheHelper.PackageCacheDirectory));
+                repositories.Add(PackageRepositoryHelpers.DetermineRepositoryType(new Uri(PackageCacheHelper.PackageCacheDirectory).AbsoluteUri));
             if (cliSpecifiedRepoUrls == null)
                 repositories.AddRange(PackageManagerSettings.Current.Repositories.Where(p => p.IsEnabled && p.Manager != null).Select(s => s.Manager).ToList());
             else
-                repositories.AddRange(cliSpecifiedRepoUrls.Select(s => PackageRepositoryHelpers.DetermineRepositoryType(s)));
+            {
+                var log = Log.CreateSource("PackageAction");
+                foreach (var repo in  cliSpecifiedRepoUrls)
+                {
+                    if (Uri.IsWellFormedUriString(repo, UriKind.Relative) && !Directory.Exists(repo))
+                    {
+                        log.Info($"Package directory '{repo}' not found. Trying using HTTP scheme.");
+                        repositories.Add(PackageRepositoryHelpers.DetermineRepositoryType("http://" + repo));
+                    }
+                    else
+                        repositories.Add(PackageRepositoryHelpers.DetermineRepositoryType(repo));
+                }
+            }
             return repositories;
         }
     }

--- a/Package/PackageManagerSettings.cs
+++ b/Package/PackageManagerSettings.cs
@@ -27,7 +27,7 @@ namespace OpenTap.Package
         public PackageManagerSettings()
         {
             Repositories = new List<RepositorySettingEntry>();
-            Repositories.Add(new RepositorySettingEntry { IsEnabled = true, Url = ExecutorClient.ExeDir });
+            Repositories.Add(new RepositorySettingEntry { IsEnabled = true, Url = new Uri(ExecutorClient.ExeDir).AbsoluteUri });
             Repositories.Add(new RepositorySettingEntry { IsEnabled = true, Url = "https://packages.opentap.io" });
             UseLocalPackageCache = true;
         }

--- a/Package/Repositories/HttpPackageRepository.cs
+++ b/Package/Repositories/HttpPackageRepository.cs
@@ -325,6 +325,15 @@ namespace OpenTap.Package
                     {
                         data = tryDownload($"{Url}/{ApiVersion}/version");
                     }
+                    catch (InvalidOperationException) // if user specified "packages.opentap.io", it looks like a relative url, so we only prepend "http://" when we are sure that it actually isnt a relative url
+                    {
+                        if (!Url.StartsWith("http://"))
+                        {
+                            Url = $"http://{Url}";
+                            data = tryDownload($"{Url}/{ApiVersion}/version");
+                        }
+                        else throw;
+                    }
                     catch (HttpRequestException ex)
                     {
                         log.Debug("HTTP Exception {0}", ex);

--- a/Package/Repositories/HttpPackageRepository.cs
+++ b/Package/Repositories/HttpPackageRepository.cs
@@ -191,15 +191,6 @@ namespace OpenTap.Package
 
                             break;
                         }
-                        catch (InvalidOperationException) // if user specified "packages.opentap.io", it looks like a relative url, so we only prepend "http://" when we are sure that it actually isnt a relative url
-                        {
-                            if (!Url.StartsWith("http://"))
-                            {
-                                Url = $"http://{Url}";
-                                DoDownloadPackage(package, fileStream, cancellationToken).Wait(cancellationToken);
-                            }
-                            else throw;
-                        }
                         catch (Exception ex)
                         {
                             if (ex is IOException)
@@ -267,15 +258,6 @@ namespace OpenTap.Package
                 var response = HttpClient.SendAsync(httpRequestMessage).GetAwaiter().GetResult();
                 xmlText = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             }
-            catch (InvalidOperationException) // if user specified "packages.opentap.io", it looks like a relative url, so we only prepend "http://" when we are sure that it actually isnt a relative url
-            {
-                if (!Url.StartsWith("http://"))
-                {
-                    Url = $"http://{Url}";
-                    xmlText = downloadPackagesString(args, data, contentType, accept);
-                }
-                else throw;
-            }
             catch (Exception ex)
             {
                 if (ex is WebException)
@@ -324,15 +306,6 @@ namespace OpenTap.Package
                     try
                     {
                         data = tryDownload($"{Url}/{ApiVersion}/version");
-                    }
-                    catch (InvalidOperationException) // if user specified "packages.opentap.io", it looks like a relative url, so we only prepend "http://" when we are sure that it actually isnt a relative url
-                    {
-                        if (!Url.StartsWith("http://"))
-                        {
-                            Url = $"http://{Url}";
-                            data = tryDownload($"{Url}/{ApiVersion}/version");
-                        }
-                        else throw;
                     }
                     catch (HttpRequestException ex)
                     {


### PR DESCRIPTION
* [Better error message when PackageSource has unexpected type](https://github.com/opentap/opentap/pull/705/commits/72e88c63bea398945764d111d26663c09a55ff21)
* [User-Agent header now also includes the name/version of the process/CliAction that loaded OpenTAP](https://github.com/opentap/opentap/pull/705/commits/fb33a5f91520c4bf9b9d3ef3a453a33acc4c27de)
* [Format of BaseAddress is now checked earlier (in the setter)](https://github.com/opentap/opentap/pull/705/commits/fb33a5f91520c4bf9b9d3ef3a453a33acc4c27de)
* [Fixed error/regression when using "tap package list -r packages.opentap.io](https://github.com/opentap/opentap/pull/705/commits/6aa0cc094f2dda2b2f529e82e2ef68e947711656)