### PR TITLE
Better documentation of format of TokenInfo.Domain

### DIFF
--- a/Engine.UnitTests/AuthenticationTests.cs
+++ b/Engine.UnitTests/AuthenticationTests.cs
@@ -24,7 +24,7 @@ namespace OpenTap.UnitTests
     ""session_state"": ""05d7a6f2-70dd-48e3-806b-dc9ccb5e7f3e"",
     ""scope"": ""openid profile email""
 }";
-            var ti = TokenInfo.FromResponse(response, "http://packages.opentap.io");
+            var ti = TokenInfo.FromResponse(response, "packages.opentap.io");
             Assert.IsNotNull(ti.RefreshToken);
 
 
@@ -38,7 +38,7 @@ namespace OpenTap.UnitTests
     ""session_state"": ""05d7a6f2-70dd-48e3-806b-dc9ccb5e7f3e"",
     ""scope"": ""openid profile email""
 }";
-            ti = TokenInfo.FromResponse(response, "http://packages.opentap.io");
+            ti = TokenInfo.FromResponse(response, "packages.opentap.io");
             Assert.IsNotNull(ti.RefreshToken);
 
             response = @"{
@@ -49,7 +49,7 @@ namespace OpenTap.UnitTests
     ""session_state"": ""05d7a6f2-70dd-48e3-806b-dc9ccb5e7f3e"",
     ""scope"": ""openid profile email""
 }";
-            ti = TokenInfo.FromResponse(response, "http://packages.opentap.io");
+            ti = TokenInfo.FromResponse(response, "packages.opentap.io");
             Assert.IsNull(ti.RefreshToken);
         }
 
@@ -69,7 +69,7 @@ namespace OpenTap.UnitTests
     ""scope"": ""openid profile email""
 }";
 
-            var ti = TokenInfo.FromResponse(response, "http://packages.opentap.io");
+            var ti = TokenInfo.FromResponse(response, "packages.opentap.io");
             DateTime dateTime = new DateTime(2022, 7, 5, 11, 02, 56);
             TimeSpan timeSpan = ti.Expiration - dateTime;
             Console.WriteLine(dateTime.ToString());

--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -113,15 +113,17 @@ namespace OpenTap.Authentication
         private static string userAgent = null;
 
         /// <summary>
-        /// Get preconfigured HttpClient with BaseAddress and AuthenticationClientHandler.
+        /// Get a HttpClient with a preconfigued BaseAddress and preconfigured authentication using a Bearer token from <see cref="Tokens"/>.
         /// It is up to the caller of this method to control the lifetime of the HttpClient
         /// </summary>
-        /// <param name="domain">An access token will attempt to be included which are valid against this domain.</param>
+        /// <param name="domain">This value is compared to <see cref="TokenInfo.Domain"/> to find the token from <see cref="Tokens"/> to use as Bearer token for requests. If unspecified, the host part of the request URI is used.</param>
         /// <param name="withRetryPolicy">If the request should be retried in case of transient errors.</param>
-        /// <param name="baseAddress">The base address used in the returned client. A relative URL given here will be relative to <see cref="BaseAddress"/>. Default is <see cref="BaseAddress"/>.  </param>
-        /// <returns>HttpClient object</returns>
+        /// <param name="baseAddress">The base address used in the returned client. A relative URL given here will be relative to <see cref="BaseAddress"/>. Default is <see cref="BaseAddress"/>.</param>
+        /// <returns>A preconfigued HttpClient object</returns>
         public HttpClient GetClient(string domain = null, bool withRetryPolicy = false, string baseAddress = null)
         {
+            if (Uri.IsWellFormedUriString(domain, UriKind.Absolute))
+                throw new ArgumentException("Domain should only be the host part of a URI and not a full absolute URI.", "domain");
             var client = new HttpClient(new AuthenticationClientHandler(domain, withRetryPolicy));
             if (baseAddress != null)
             {

--- a/Engine/Authentication/TokenInfo.cs
+++ b/Engine/Authentication/TokenInfo.cs
@@ -27,12 +27,22 @@ namespace OpenTap.Authentication
         /// </summary>
         public string RefreshToken { get; set; }
 
+        private string domain;
         /// <summary> 
-        /// The site this token is intended for. Used by the HttpClient 
+        /// The hostname or IP address this token is intended for. Used by the HttpClient 
         /// returned from <see cref="AuthenticationSettings.GetClient"/> to determine which TokenInfo
         /// in the <see cref="AuthenticationSettings.Tokens"/> list to use for a given request.
         /// </summary>
-        public string Domain { get; set; }
+        public string Domain 
+        { 
+            get => domain; 
+            set
+            {
+                if (Uri.IsWellFormedUriString(value, UriKind.Absolute))
+                    throw new ArgumentException("Domain should only be the host part of a URI and not a full absolute URI.");
+                domain = value;
+            }
+        }
 
         private Dictionary<string, string> _Claims;
         /// <summary>
@@ -42,7 +52,7 @@ namespace OpenTap.Authentication
         {
             get
             {
-                if(_Claims == null)
+                if (_Claims == null)
                     _Claims = GetPayload().RootElement.EnumerateObject().ToDictionary(c => c.Name, c => c.Value.ToString());
                 return _Claims;
             }


### PR DESCRIPTION
Better documentation and ArgumentExceptions to avoid the mistake of using a full URI (e.g. BaseAddress) as the TokenInfo.Domain