### PR TITLE
Store SessionLogs in OpenTAP folder instead of /var/log/SessionLogs

### DIFF
--- a/LinuxInstall/package/Debian/create-deb
+++ b/LinuxInstall/package/Debian/create-deb
@@ -7,20 +7,19 @@ pushd "$GIT_ROOT/LinuxInstall/package/Debian"
 
 # Build Deb package
 
+TAP_DIR="opentap/usr/share/opentap"
 mkdir -p opentap/DEBIAN
 mkdir -p opentap/usr/bin
-mkdir -p opentap/usr/share/opentap
+mkdir -p $TAP_DIR
 mkdir -p opentap/usr/share/doc/opentap
-mkdir -p opentap/var/log/SessionLogs
 
 cp "$GIT_ROOT/LICENSE.txt" opentap/usr/share/doc/opentap/copyright
 
 echo "Extracting opentap"
-unzip -q ../OpenTAP.TapPackage -d opentap/usr/share/opentap
+unzip -q ../OpenTAP.TapPackage -d $TAP_DIR
 
-pushd opentap/usr/share/opentap
+pushd $TAP_DIR
 chmod +x tap
-ln -s ../../../var/log/SessionLogs
 popd
 pushd opentap/usr/bin
 ln -s ../share/opentap/tap
@@ -37,7 +36,7 @@ cp postinst.in opentap/DEBIAN/postinst
 chmod 0555 opentap/DEBIAN/postinst
 chmod +x opentap/DEBIAN/postinst
 
-VERSION="$(./opentap/usr/share/opentap/tap sdk gitversion)"
+VERSION="$(./$TAP_DIR/tap sdk gitversion)"
 # The last character in the version specifier cannot be a '-'
 while [ "${VERSION: -1}" = "-" ]; do
     VERSION="${VERSION::-1}"
@@ -46,7 +45,7 @@ done
 sed control.in -e "s/\$(GitVersion)/$VERSION/g" -e "s/@SIZE_KB@/$SIZE_KB/g" > opentap/DEBIAN/control
 
 # Don't package log file generated from gitversion
-rm -rf ./opentap/var/log/SessionLogs/*
+rm -rf ./$TAP_DIR/SessionLogs/*
 
 chmod 755 opentap/DEBIAN
 

--- a/package.xml
+++ b/package.xml
@@ -117,7 +117,17 @@
               SourcePath="newtonsoft_mit_license.txt"/>
     </Files>
     <PackageActionExtensions Condition="$(Platform) != Windows">
-        <ActionStep ActionName="install" ExeFile="chmod" Arguments="+x tap"  />
+      <!-- An exit code of '1' means we failed to set the permission.
+        This happens when the user has read/write/execute permissions,
+        but doesn't actually own the file. This is the case for the Debian package 
+        because the user doesn't own the installation, but belongs to a group that does.
+        This is usually fine because the file is already executable.
+
+        The alternative to suppressing this error is a broken installation, so even in the case
+        where 'tap' is not executable after an upgrade, this behavior where the user can fix
+        it with 'chmod +X' is still the preferable alternative.
+      -->
+        <ActionStep ActionName="install" ExeFile="chmod" Arguments="+x tap" ExpectedExitCodes="0,1" />
     </PackageActionExtensions>
     <PackageActionExtensions Condition="$(Platform) == Windows">
         <ActionStep ActionName="install" ExeFile="Packages/OpenTAP/Tap.Upgrader.exe" />


### PR DESCRIPTION
This fixes a permission issue that prevents REST from starting, and I don't think it made a whole lot of sense to symlink logfiles to a different location anyway.

Closes #717 