### PR TITLE
Add the Release Notes for OpenTAP 9.17 to the Table of Contents

### DIFF
--- a/doc/.vuepress/config.js
+++ b/doc/.vuepress/config.js
@@ -61,6 +61,7 @@ module.exports = {
             {
                 title: 'Release Notes',
                 children: [
+                    ['/Release Notes/ReleaseNote_OpenTAP9.17.md', "Release Notes - OpenTAP 9.17"],
                     ['/Release Notes/ReleaseNote_OpenTAP9.16.md', "Release Notes - OpenTAP 9.16"],
                     ['/Release Notes/ReleaseNote_OpenTAP9.15.md', "Release Notes - OpenTAP 9.15"],
                     ['/Release Notes/ReleaseNote_OpenTAP9.14.md', "Release Notes - OpenTAP 9.14"],

--- a/doc/Release Notes/Readme.md
+++ b/doc/Release Notes/Readme.md
@@ -1,6 +1,7 @@
 Table of Contents
 =================
 
+- [Release Note - OpenTAP 9.17](ReleaseNote_OpenTAP9.17.md)
 - [Release Note - OpenTAP 9.16](ReleaseNote_OpenTAP9.16.md)
 - [Release Note - OpenTAP 9.15](ReleaseNote_OpenTAP9.15.md)
 - [Release Note - OpenTAP 9.14](ReleaseNote_OpenTAP9.14.md)


### PR DESCRIPTION
Resolves #730 

I've just noticed that PR #432 contains: 
* a draft version of [doc/Release Notes/ReleaseNote_OpenTAP9.17.md](https://github.com/opentap/opentap/blob/c6d4a72039042aaadde2d46736857d926ebecb92/doc/Release%20Notes/ReleaseNote_OpenTAP9.17.md) superseded by PR #579,
* an update to the Table of Contents in [doc/Release Notes/Readme.md](https://github.com/opentap/opentap/pull/432/commits/274b878f488c7e2f75c142201e1fd86997a7c698).

I think that PR #432 can now be safely closed, merging this PR to update both the Markdown and the VuePress Table of Contents.