### PR TITLE
734 remove --quiet shortname

### DIFF
--- a/Cli/TapEntry.cs
+++ b/Cli/TapEntry.cs
@@ -173,7 +173,7 @@ namespace OpenTap.Cli
             {
                 var args = Environment.GetCommandLineArgs();
                 bool isVerbose = args.Contains("--verbose") || args.Contains("-v");
-                bool isQuiet = args.Contains("--quiet") || args.Contains("-q");
+                bool isQuiet = args.Contains("--quiet");
                 ConsoleTraceListener.SetStartupTime(start);
                 var cliTraceListener = new ConsoleTraceListener(isVerbose, isQuiet, IsColor());
                 Log.AddListener(cliTraceListener);

--- a/Cli/TapEntry.cs
+++ b/Cli/TapEntry.cs
@@ -173,7 +173,7 @@ namespace OpenTap.Cli
             {
                 var args = Environment.GetCommandLineArgs();
                 bool isVerbose = args.Contains("--verbose") || args.Contains("-v");
-                bool isQuiet = args.Contains("--quiet");
+                bool isQuiet = args.Contains("--quiet") || args.Contains("-q");
                 ConsoleTraceListener.SetStartupTime(start);
                 var cliTraceListener = new ConsoleTraceListener(isVerbose, isQuiet, IsColor());
                 Log.AddListener(cliTraceListener);

--- a/Shared/ICliActionExtensions.cs
+++ b/Shared/ICliActionExtensions.cs
@@ -36,7 +36,7 @@ namespace OpenTap.Cli
             ap.AllOptions.Add("help", 'h', false, "Write help information.");
             ap.AllOptions.Add("verbose", 'v', false, "Show verbose/debug-level log messages.");
             ap.AllOptions.Add("color", 'c', false, "Color messages according to their severity.");
-            ap.AllOptions.Add("quiet", 'q', false, "Quiet console logging.");
+            ap.AllOptions.Add("quiet", needsArgument: false, description: "Quiet console logging.");
             ap.AllOptions.Add("log", description: "Specify log file location. Default is ./SessionLogs.");
 
             var argToProp = new Dictionary<string, IMemberData>();


### PR DESCRIPTION
This removes the '-q' shortname option for 'quiet'. I prefer this to adding the '-q' shortname since it is likely to lead to collisions that are hard to avoid since '-q' is specially handled.

Closes #734 