### PR TITLE
739 don't include Package.Dependencies element when serializing `PackageVersion[]`

### DIFF
--- a/Engine.UnitTests/SerializerTests.cs
+++ b/Engine.UnitTests/SerializerTests.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Xml.Linq;
 using NUnit.Framework;
+using OpenTap.Package;
+using OpenTap.Plugins.BasicSteps;
 
 namespace OpenTap.Engine.UnitTests
 {
@@ -23,6 +27,43 @@ namespace OpenTap.Engine.UnitTests
             Assert.AreEqual("X Setting", xdoc.Root.Element("X").Attribute("Metadata").Value);
             Assert.AreEqual("Y", xdoc.Root.Element("Y").Attribute("Metadata").Value);
         }
-    
+
+        [Test]
+        public void TestPackageDependencySerializer()
+        {
+            var plan = new TestPlan()
+            {
+                ChildTestSteps = { new DelayStep() }
+            };
+
+            var ser = new TapSerializer();
+            { // verify that a serialized plan has package dependencies
+                var str = ser.SerializeToString(plan);   
+                CollectionAssert.IsEmpty(ser.Errors);
+                var elem = XElement.Parse(str);
+                Assert.AreEqual(1, elem.Elements("Package.Dependencies").Count());
+            }
+            { // verify that a serialized collection of plans has no package dependencies
+                var plans = new TestPlan[]
+                {
+                    plan,
+                    plan
+                };
+                var str = ser.SerializeToString(plans);
+                CollectionAssert.IsEmpty(ser.Errors);
+                var elem = XElement.Parse(str);
+                Assert.AreEqual(0, elem.Elements("Package.Dependencies").Count());            
+            }
+            { // verify that a serialized list of package versions does not have package dependencies
+                var versions = new PackageVersion[]
+                {
+                    new PackageVersion("pkg", SemanticVersion.Parse("1.0.0"), "Linux", CpuArchitecture.AnyCPU, DateTime.Now, new List<string>())
+                };
+                var str = ser.SerializeToString(versions);
+                CollectionAssert.IsEmpty(ser.Errors);
+                var elem = XElement.Parse(str);
+                Assert.AreEqual(0, elem.Elements("Package.Dependencies").Count());  
+            }
+        }
     }
 }

--- a/Engine.UnitTests/SerializerTests.cs
+++ b/Engine.UnitTests/SerializerTests.cs
@@ -43,7 +43,7 @@ namespace OpenTap.Engine.UnitTests
                 var elem = XElement.Parse(str);
                 Assert.AreEqual(1, elem.Elements("Package.Dependencies").Count());
             }
-            { // verify that a serialized collection of plans has no package dependencies
+            { // verify that a serialized collection of plans has package dependencies
                 var plans = new TestPlan[]
                 {
                     plan,
@@ -52,7 +52,7 @@ namespace OpenTap.Engine.UnitTests
                 var str = ser.SerializeToString(plans);
                 CollectionAssert.IsEmpty(ser.Errors);
                 var elem = XElement.Parse(str);
-                Assert.AreEqual(0, elem.Elements("Package.Dependencies").Count());            
+                Assert.AreEqual(1, elem.Elements("Package.Dependencies").Count());            
             }
             { // verify that a serialized list of package versions does not have package dependencies
                 var versions = new PackageVersion[]
@@ -62,7 +62,15 @@ namespace OpenTap.Engine.UnitTests
                 var str = ser.SerializeToString(versions);
                 CollectionAssert.IsEmpty(ser.Errors);
                 var elem = XElement.Parse(str);
-                Assert.AreEqual(0, elem.Elements("Package.Dependencies").Count());  
+                Assert.AreEqual(0, elem.Elements("Package.Dependencies").Count());
+
+                var deserialized = ser.DeserializeFromString(str);
+                if (deserialized is PackageVersion[] versions2)
+                {
+                    CollectionAssert.AreEqual(versions, versions2, "Deserialized versions were different from the serialized versions.");
+                }
+                else
+                    Assert.Fail($"Failed to deserialize serialized version array.");
             }
         }
     }

--- a/Engine.UnitTests/SerializerTests.cs
+++ b/Engine.UnitTests/SerializerTests.cs
@@ -27,8 +27,6 @@ namespace OpenTap.Engine.UnitTests
             Assert.AreEqual("X Setting", xdoc.Root.Element("X").Attribute("Metadata").Value);
             Assert.AreEqual("Y", xdoc.Root.Element("Y").Attribute("Metadata").Value);
         }
-
-
         public class PackageVersionTestStep : TestStep
         {
             public PackageVersion[] PackageVersion { get; set; }
@@ -37,7 +35,7 @@ namespace OpenTap.Engine.UnitTests
                 
             }
         }
-
+        
         [Test]
         public void TestPackageDependencySerializer()
         {
@@ -45,13 +43,7 @@ namespace OpenTap.Engine.UnitTests
             {
                 ChildTestSteps = { new DelayStep() }
             };
-            var packageVersion = new PackageVersion("pkg", SemanticVersion.Parse("1.0.0"), "Linux",
-                CpuArchitecture.AnyCPU, DateTime.Now,
-                new List<string>()
-                {
-                    "Lic1",
-                    "Lic2"
-                });
+            var packageVersion = new PackageVersion("pkg", SemanticVersion.Parse("1.0.0"), "Linux", CpuArchitecture.AnyCPU, DateTime.Now, new List<string>());
 
             { // verify that a serialized plan has package dependencies
                 var ser = new TapSerializer();
@@ -81,7 +73,6 @@ namespace OpenTap.Engine.UnitTests
 
                 var deserialized = ser.DeserializeFromString(str);
                 Assert.AreEqual(packageVersion, deserialized);
-                CollectionAssert.AreEqual(packageVersion.Licenses, ((deserialized as PackageVersion)!).Licenses);
             }
             { // verify that a serialized list of package versions does not have package dependencies
                 var ser = new TapSerializer();
@@ -96,7 +87,6 @@ namespace OpenTap.Engine.UnitTests
                 {
                     Assert.AreEqual(1, versions2.Count());
                     CollectionAssert.AreEqual(versions, versions2, "Deserialized versions were different from the serialized versions.");
-                    CollectionAssert.AreEqual(versions[0].Licenses, versions2[0].Licenses);
                 }
                 else
                 {

--- a/Engine.UnitTests/SerializerTests.cs
+++ b/Engine.UnitTests/SerializerTests.cs
@@ -57,7 +57,12 @@ namespace OpenTap.Engine.UnitTests
             { // verify that a serialized list of package versions does not have package dependencies
                 var versions = new PackageVersion[]
                 {
-                    new PackageVersion("pkg", SemanticVersion.Parse("1.0.0"), "Linux", CpuArchitecture.AnyCPU, DateTime.Now, new List<string>())
+                    new PackageVersion("pkg", SemanticVersion.Parse("1.0.0"), "Linux", CpuArchitecture.AnyCPU, DateTime.Now, 
+                        new List<string>()
+                        {
+                            "Lic1",
+                            "Lic2"
+                        })
                 };
                 var str = ser.SerializeToString(versions);
                 CollectionAssert.IsEmpty(ser.Errors);
@@ -67,7 +72,9 @@ namespace OpenTap.Engine.UnitTests
                 var deserialized = ser.DeserializeFromString(str);
                 if (deserialized is PackageVersion[] versions2)
                 {
+                    Assert.AreEqual(1, versions2.Count());
                     CollectionAssert.AreEqual(versions, versions2, "Deserialized versions were different from the serialized versions.");
+                    CollectionAssert.AreEqual(versions[0].Licenses, versions2[0].Licenses);
                 }
                 else
                     Assert.Fail($"Failed to deserialize serialized version array.");

--- a/Engine/SerializerPlugins/CollectionSerializer.cs
+++ b/Engine/SerializerPlugins/CollectionSerializer.cs
@@ -261,6 +261,10 @@ namespace OpenTap.Plugins
                 foreach (object obj in sourceEnumerable)
                 {
                     var step = new XElement(Element);
+                    // We need to add the step to the document immediately so each serializer call 
+                    // has access to the element's parents.
+                    elem.Add(step);
+
                     if (obj != null)
                     {
                         type = obj.GetType();
@@ -271,6 +275,12 @@ namespace OpenTap.Plugins
                         {
                             Serializer.Serialize(step, obj, expectedType: TypeData.FromType(genericTypeArg));
                         }
+                        catch
+                        {
+                            // Remove the element from the document in case serialization fails
+                            step.Remove();
+                            throw;
+                        }
                         finally
                         {
                             if (isComponentSettings)
@@ -278,7 +288,6 @@ namespace OpenTap.Plugins
                         }
                     }
 
-                    elem.Add(step);
                 }
             }
             finally

--- a/Package/PackageDefinitionSerializerPlugin.cs
+++ b/Package/PackageDefinitionSerializerPlugin.cs
@@ -97,7 +97,9 @@ namespace OpenTap.Package
         }
 
         /// <summary>
-        /// Called as part for the serialization chain. Returns false if it cannot serialize the XML element.  
+        /// Called as part for the serialization chain. Returns false if it cannot serialize the XML element.
+        /// Disables the 'WritePackageDependencies' feature of the <see cref="TestPlanPackageDependencySerializer"/>
+        /// further up the chain when it runs.
         /// </summary>
         public override bool Serialize(XElement node, object obj, ITypeData expectedType)
         {

--- a/Package/PackageDefinitionSerializerPlugin.cs
+++ b/Package/PackageDefinitionSerializerPlugin.cs
@@ -170,7 +170,7 @@ namespace OpenTap.Package
             // ask the TestPlanPackageDependency serializer (the one that writes the 
             // <Package.Dependencies> tag in the bottom of e.g. TestPlan files) to
             // not write the tag for this file.
-            var depSerializer = Serializer.GetSerializer<TestPlanPackageDependency>();
+            var depSerializer = Serializer.GetSerializer<TestPlanPackageDependencySerializer>();
             if (depSerializer != null)
                 depSerializer.WritePackageDependencies = false;
 

--- a/Package/PackageDefinitionSerializerPlugin.cs
+++ b/Package/PackageDefinitionSerializerPlugin.cs
@@ -101,7 +101,9 @@ namespace OpenTap.Package
         /// </summary>
         public override bool Serialize(XElement node, object obj, ITypeData expectedType)
         {
-            if (expectedType.DescendsTo(typeof(IPackageIdentifier)) == false)
+            if (expectedType.IsA(typeof(PackageDef)) == false 
+                && expectedType.IsA(typeof(PackageIdentifier)) == false
+                && expectedType.IsA(typeof(PackageVersion)) == false)
                 return false;
             XNamespace ns = "http://opentap.io/schemas/package";
             node.Name = ns + (expectedType.IsA(typeof(PackageIdentifier)) ? nameof(PackageIdentifier) : "Package");

--- a/Package/PackageDefinitionSerializerPlugin.cs
+++ b/Package/PackageDefinitionSerializerPlugin.cs
@@ -103,9 +103,7 @@ namespace OpenTap.Package
         /// </summary>
         public override bool Serialize(XElement node, object obj, ITypeData expectedType)
         {
-            if (expectedType.IsA(typeof(PackageDef)) == false 
-                && expectedType.IsA(typeof(PackageIdentifier)) == false
-                && expectedType.IsA(typeof(PackageVersion)) == false)
+            if (expectedType.IsA(typeof(PackageDef)) == false && expectedType.IsA(typeof(PackageIdentifier)) == false)
                 return false;
             XNamespace ns = "http://opentap.io/schemas/package";
             node.Name = ns + (expectedType.IsA(typeof(PackageIdentifier)) ? nameof(PackageIdentifier) : "Package");

--- a/Package/PackageDefinitionSerializerPlugin.cs
+++ b/Package/PackageDefinitionSerializerPlugin.cs
@@ -101,7 +101,7 @@ namespace OpenTap.Package
         /// </summary>
         public override bool Serialize(XElement node, object obj, ITypeData expectedType)
         {
-            if (expectedType.IsA(typeof(PackageDef)) == false && expectedType.IsA(typeof(PackageIdentifier)) == false)
+            if (expectedType.DescendsTo(typeof(IPackageIdentifier)) == false)
                 return false;
             XNamespace ns = "http://opentap.io/schemas/package";
             node.Name = ns + (expectedType.IsA(typeof(PackageIdentifier)) ? nameof(PackageIdentifier) : "Package");

--- a/Package/TestPlanPackageDependencySerializer.cs
+++ b/Package/TestPlanPackageDependencySerializer.cs
@@ -15,7 +15,7 @@ using System.Xml.Linq;
 namespace OpenTap.Package
 {
     [Display("Test Plan Package Dependencies", Description: "Serializer plugin that inserts package dependencies for a test plan in the test plan itself.")]
-    internal class TestPlanPackageDependency : TapSerializerPlugin
+    internal class TestPlanPackageDependencySerializer : TapSerializerPlugin
     {
         static readonly XName PackageDependenciesName = "Package.Dependencies";
         static readonly XName PackageDependencyName = "Package";


### PR DESCRIPTION
Update the PackageVersion serializer to disable writing `Package.Dependencies` when serializing either a single `PackageVersion`, or a single collection of `PackageVersion`s.

Closes #739 