### PR TITLE
Always set the PackageSource when resolving a package

### DIFF
--- a/Package/Repositories/HttpPackageRepository.cs
+++ b/Package/Repositories/HttpPackageRepository.cs
@@ -354,11 +354,10 @@ namespace OpenTap.Package
                     var packages = PackageDef.ManyFromXml(stream).ToArray();
                     packages.ForEach(p =>
                     {
-                        if (p.PackageSource == null)
-                            p.PackageSource = new HttpRepositoryPackageDefSource
-                            {
-                                RepositoryUrl = Url
-                            };
+                        p.PackageSource = new HttpRepositoryPackageDefSource
+                        {
+                            RepositoryUrl = Url
+                        };
                     });
 
                     return packages;


### PR DESCRIPTION
We know where we just resolved the package from. The repo does not necessarily know it's correct location, if e.g. behind a proxy.