### PR TITLE
Added a series of test plan run related performance improvements.

### DIFF
--- a/Engine/Invokable/Invokable.cs
+++ b/Engine/Invokable/Invokable.cs
@@ -4,7 +4,7 @@ namespace OpenTap
 {
     /// <summary> Action(T) IInvokable. </summary>
     /// <typeparam name="T"></typeparam>
-    class Invokable<T> : IInvokable<T>
+    readonly struct Invokable<T> : IInvokable<T>
     {
         readonly Action<T> action;
         public Invokable(Action<T> action) => this.action = action;
@@ -14,12 +14,13 @@ namespace OpenTap
         /// <summary> Add an ignored argument. </summary>
         public Invokable<T, T2> AddArg<T2>()
         {
-            return new Invokable<T, T2>((a1, a2) => action(a1));
+            var act = action;
+            return new Invokable<T, T2>((a1, a2) => act(a1));
         }
     }
     
     /// <summary> Action(T) IInvokable. </summary>
-    class Invokable<T, T2> : IInvokable<T,T2>
+    readonly struct Invokable<T, T2> : IInvokable<T,T2>
     {
         readonly Action<T,T2> action;
         public Invokable(Action<T,T2> action) => this.action = action;

--- a/Engine/Log.cs
+++ b/Engine/Log.cs
@@ -449,7 +449,7 @@ namespace OpenTap
             var timespan = ShortTimeSpan.FromSeconds(elapsed.TotalSeconds);
 
             if (sb == null)
-                sb = new StringBuilder();
+                sb = StringBuilderCache.GetStringBuilder();
             sb.Clear();
             if (args.Length == 0)
             {
@@ -841,6 +841,19 @@ namespace OpenTap
                 ex.Rethrow();
             else
                 (ex.InnerException ?? ex).Rethrow();
+        }
+    }
+
+    static class StringBuilderCache
+    {
+        [ThreadStatic]
+        static StringBuilder sb;
+
+        public static StringBuilder GetStringBuilder()
+        {
+            var sb2 = sb ?? (sb = new StringBuilder());
+            sb2.Clear();
+            return sb2;   
         }
     }
 }

--- a/Engine/NumberParser.cs
+++ b/Engine/NumberParser.cs
@@ -766,15 +766,6 @@ namespace OpenTap
             return false;
         }
 
-        [ThreadStatic] static StringBuilder stringBuilder;
-
-        StringBuilder getStringBuilder()
-        {
-            var sb =stringBuilder ?? (stringBuilder = new StringBuilder());
-            sb.Clear();
-            return sb;
-        }
-        
         /// <summary>
         /// Parses a sequence of numbers back into a string.
         /// </summary>
@@ -789,7 +780,7 @@ namespace OpenTap
                 var seqs = values as _ICombinedNumberSequence;
                 if (seqs != null)
                 {
-                    StringBuilder sb = getStringBuilder();
+                    StringBuilder sb = StringBuilderCache.GetStringBuilder();
                     foreach (var subseq in seqs.Sequences)
                     {
                         var range = subseq as Range;
@@ -814,7 +805,7 @@ namespace OpenTap
             }
             if (UseRanges)
             { // Parse the slow way.
-                StringBuilder sb = getStringBuilder();
+                StringBuilder sb = StringBuilderCache.GetStringBuilder();
                 List<BigFloat> sequence = new List<BigFloat>();
                 BigFloat seq_step = 0;
                 foreach (var _val in values)
@@ -855,7 +846,7 @@ namespace OpenTap
             if (!UsePrefix)
             {
                 // this ca be done really fast since we dont have to use BigFloat.
-                var sb = getStringBuilder();
+                var sb =StringBuilderCache.GetStringBuilder();
                 foreach (var _val in values)
                 {
                     if (sb.Length != 0)
@@ -887,7 +878,7 @@ namespace OpenTap
             }
             
             {
-                StringBuilder sb = getStringBuilder();
+                StringBuilder sb = StringBuilderCache.GetStringBuilder();
                 foreach (var _val in values)
                 {
                     var val = BigFloat.Convert(_val);

--- a/Engine/Reflection/TypeDataProviderStack.cs
+++ b/Engine/Reflection/TypeDataProviderStack.cs
@@ -121,8 +121,8 @@ namespace OpenTap
             var providers1 = TypeData.FromType(typeof(IStackedTypeDataProvider)).DerivedTypes;
             var providers2 = TypeData.FromType(typeof(ITypeDataProvider)).DerivedTypes;
 
-            int l1 = providers1.Count();
-            int l2 = providers2.Count();
+            int l1 = providers1 is ICollection<TypeData> x1 ? x1.Count : providers1.Count();
+            int l2 = providers2 is ICollection<TypeData> x2 ? x2.Count : providers2.Count();
 
             if (lastCount == l1 + l2) return providersCache;
 

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -15,7 +15,7 @@ namespace OpenTap
 {
     partial class TestPlan
     {
-        bool runPrePlanRunMethods(IEnumerable<ITestStep> steps, TestPlanRun planRun)
+        bool runPrePlanRunMethods(IList<ITestStep> steps, TestPlanRun planRun)
         {
             Stopwatch preTimer = Stopwatch.StartNew(); // try to avoid calling Stopwatch.StartNew too often.
             TimeSpan elaps = preTimer.Elapsed;
@@ -485,7 +485,8 @@ namespace OpenTap
         /// <returns>TestPlanRun results, no StepResults.</returns>
         public TestPlanRun Execute(IEnumerable<IResultListener> resultListeners, IEnumerable<ResultParameter> metaDataParameters = null, HashSet<ITestStep> stepsOverride = null)
         {
-            return executeInContext( resultListeners, metaDataParameters, stepsOverride);
+            using(TypeData.WithTypeDataCache())
+                return executeInContext( resultListeners, metaDataParameters, stepsOverride);
         }
 
         TestPlanRun executeInContext(IEnumerable<IResultListener> resultListeners,

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -964,7 +964,7 @@ namespace OpenTap
                     {
                         if (Step is TestStep _step)
                             _step.Results = new ResultSource(stepRun, Step.PlanRun);
-                        //TestPlan.Log.Info("{0} started.", stepRun.TestStepPath);
+                        TestPlan.Log.Info("{0} started.", stepRun.TestStepPath);
                         stepRun.StartStepRun(); // set verdict to running, set Timestamp.
                         parentRun.ChildStarted(stepRun);
                         planRun.AddTestStepRunStart(stepRun);
@@ -1055,11 +1055,11 @@ namespace OpenTap
                         stepRun.CompleteStepRun(planRun, Step, time);
                         if (Step.Verdict == Verdict.NotSet)
                         {
-                            //TestPlan.Log.Info(time, "{0} completed.", stepRun.TestStepPath);
+                            TestPlan.Log.Info(time, "{0} completed.", stepRun.TestStepPath);
                         }
                         else
                         {
-                            //TestPlan.Log.Info(time, "{0} completed with verdict '{1}'.", stepRun.TestStepPath, Step.Verdict);
+                            TestPlan.Log.Info(time, "{0} completed with verdict '{1}'.", stepRun.TestStepPath, Step.Verdict);
                         }
 
                         planRun.AddTestStepRunCompleted(stepRun);

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -884,7 +884,7 @@ namespace OpenTap
         {
             var name = Step.GetFormattedName();
 
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = StringBuilderCache.GetStringBuilder();
             sb.Append('"');
 
             void getParentNames(ITestStep step)
@@ -939,7 +939,7 @@ namespace OpenTap
 
             var previouslyExecutingTestStep = currentlyExecutingTestStep;
             currentlyExecutingTestStep = Step;
-            var stepPath = stepRun.TestStepPath;
+            
             //Raise an event prior to starting the actual run of the TestStep. 
             Step.OfferBreak(stepRun, true);
             if (stepRun.SuggestedNextStep != null) {
@@ -964,7 +964,7 @@ namespace OpenTap
                     {
                         if (Step is TestStep _step)
                             _step.Results = new ResultSource(stepRun, Step.PlanRun);
-                        TestPlan.Log.Info("{0} started.", stepRun.TestStepPath);
+                        //TestPlan.Log.Info("{0} started.", stepRun.TestStepPath);
                         stepRun.StartStepRun(); // set verdict to running, set Timestamp.
                         parentRun.ChildStarted(stepRun);
                         planRun.AddTestStepRunStart(stepRun);
@@ -1055,11 +1055,11 @@ namespace OpenTap
                         stepRun.CompleteStepRun(planRun, Step, time);
                         if (Step.Verdict == Verdict.NotSet)
                         {
-                            TestPlan.Log.Info(time, "{0} completed.", stepRun.TestStepPath);
+                            //TestPlan.Log.Info(time, "{0} completed.", stepRun.TestStepPath);
                         }
                         else
                         {
-                            TestPlan.Log.Info(time, "{0} completed with verdict '{1}'.", stepRun.TestStepPath, Step.Verdict);
+                            //TestPlan.Log.Info(time, "{0} completed with verdict '{1}'.", stepRun.TestStepPath, Step.Verdict);
                         }
 
                         planRun.AddTestStepRunCompleted(stepRun);


### PR DESCRIPTION
Performance testing using `tap benchmark test-plan --quiet --iterations 10000`

- main branch: Time spent per iteration: 5.16 ms (σ: 0.59 ms)
- With logging: Time spent per iteration: 3.85 ms (σ: 0.05 ms)
- Without logging: Time spent per iteration: 2.69 ms (σ: 0.06 ms)

Without logging: see commented out log messages in TestStep.cs

Main branch high variance seems to suggest that a significant improvement has been made with regards to generating garbage.
