### PR TITLE
Check whether a property is browsable when determining if it should be visible

### DIFF
--- a/Engine.UnitTests/RunCliActionTest.cs
+++ b/Engine.UnitTests/RunCliActionTest.cs
@@ -10,22 +10,23 @@ namespace OpenTap.Engine.UnitTests
     public class RunCliActionTest
     {
         const string planFile = "list-external-parameters.TapPlan";
+
         [Test]
         public void ListExternalParameters()
         {
-var runcli = new RunCliAction
+            var runcli = new RunCliAction
             {
-                ListExternal = true, 
+                ListExternal = true,
                 TestPlanPath = planFile,
                 NonInteractive = true
             };
-            
+
             var plan = new TestPlan();
             var step = new ProcessStep()
             {
                 LogHeader = null, // test that the log header is a null string.
                 Application = "tap.exe" // test that application is a non-null string.
-            }; 
+            };
             plan.ChildTestSteps.Add(step);
             var stepType = TypeData.GetTypeData(step);
             stepType.GetMember(nameof(step.LogHeader)).Parameterize(plan, step, "log-header");

--- a/Engine.UnitTests/TestPlanRunnerTests.cs
+++ b/Engine.UnitTests/TestPlanRunnerTests.cs
@@ -51,6 +51,16 @@ namespace OpenTap.Engine.UnitTests
             proc.WaitForEnd();
             Assert.AreEqual(0, proc.TapProcess.ExitCode);
         }
+        
+        
+        [Test]
+        public void TestUnbrowsableCliActionsHidden()
+        {
+            var proc = TapProcessContainer.StartFromArgs("package check-updates -h");
+            proc.WaitForEnd();
+            // The --startup option is unbrowsable and should not show up in the help text
+            StringAssert.DoesNotContain("--startup", proc.ConsoleOutput);
+        }
 
         [Test]
         public void TestProcessContainer()

--- a/Engine/Cli/CommandLineArgumentAttribute.cs
+++ b/Engine/Cli/CommandLineArgumentAttribute.cs
@@ -30,10 +30,12 @@ namespace OpenTap.Cli
         /// Human readable description of the argument.
         /// </summary>
         public string Description { get; set; }
+
         /// <summary>
         /// Indicates whether this will be shown when writing CLI usage information.
         /// </summary>
-        public bool Visible { get; set; }
+        [Obsolete("Please use the 'Browsable' attribute.")]
+        public bool Visible { get; set; } = true;
 
         /// <summary>
         /// Primary constructor.
@@ -44,7 +46,6 @@ namespace OpenTap.Cli
             this.Name = name;
             ShortName = null;
             Description = null;
-            Visible = true;
         }
     }
 

--- a/Engine/Cli/RunCliAction.cs
+++ b/Engine/Cli/RunCliAction.cs
@@ -5,6 +5,7 @@
 using OpenTap.Package;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -35,7 +36,8 @@ namespace OpenTap.Cli
         /// <summary>
         /// Additional directories to be searched for plugins. This option may be used multiple times, e.g., --search dir1 --search dir2.
         /// </summary>
-        [CommandLineArgument("search", Description = "Additional directories to be searched for plugins.\nThis option may be used multiple times, e.g., --search dir1 --search dir2.", Visible = false)]
+        [CommandLineArgument("search", Description = "Additional directories to be searched for plugins.\nThis option may be used multiple times, e.g., --search dir1 --search dir2.")]
+        [Browsable(false)]
         public string[] Search { get; set; } = new string[0];
 
         /// <summary>

--- a/Package/PackageActions/Create.cs
+++ b/Package/PackageActions/Create.cs
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Text.RegularExpressions;
 using OpenTap.Cli;
@@ -54,7 +55,8 @@ namespace OpenTap.Package
         /// <summary>
         /// Obsolete, use Install property instead.
         /// </summary>
-        [CommandLineArgument("fake-install", Visible = false, Description = "Install the created package. It will not overwrite files \nalready in the target installation (e.g. debug binaries).")]
+        [CommandLineArgument("fake-install", Description = "Install the created package. It will not overwrite files \nalready in the target installation (e.g. debug binaries).")]
+        [Browsable(false)]
         public bool FakeInstall { get; set; } = false;
 
         /// <summary>

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -55,7 +55,8 @@ namespace OpenTap.Package
         public bool CheckOnly { get; set; }
 
         [Obsolete("Interactive is the default. Use --non-interactive to disable.")]
-        [CommandLineArgument("interactive", Description = "More user responsive.",Visible = false)]
+        [CommandLineArgument("interactive", Description = "More user responsive.")]
+        [Browsable(false)]
         public bool Interactive { get; set; }
 
         /// <summary>

--- a/Shared/ICliActionExtensions.cs
+++ b/Shared/ICliActionExtensions.cs
@@ -6,6 +6,7 @@
 using OpenTap.Package;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -92,7 +93,7 @@ namespace OpenTap.Cli
                 }
 
                 var arg = ap.AllOptions.Add(attr.Name, attr.ShortName?.FirstOrDefault() ?? '\0', needsArg, description);
-                arg.IsVisible = attr.Visible;
+                arg.IsVisible = attr.Visible && (prop.GetAttribute<BrowsableAttribute>()?.Browsable ?? true);
                 argToProp.Add(arg.LongName, prop);
             }
 

--- a/Shared/ICliActionExtensions.cs
+++ b/Shared/ICliActionExtensions.cs
@@ -93,7 +93,10 @@ namespace OpenTap.Cli
                 }
 
                 var arg = ap.AllOptions.Add(attr.Name, attr.ShortName?.FirstOrDefault() ?? '\0', needsArg, description);
+                // attr.Visible has been obsoleted but is still considered for backward compatibility.
+#pragma warning disable CS0618
                 arg.IsVisible = attr.Visible && (prop.GetAttribute<BrowsableAttribute>()?.Browsable ?? true);
+#pragma warning restore CS0618
                 argToProp.Add(arg.LongName, prop);
             }
 


### PR DESCRIPTION
Check whether a property is browsable when determining if it should be visible
Cleanup formatting in unrelated unittest.

Also obsoletes `CommandLineArgumentAttribute.Visible`

Closes #755
Closes #764