### PR TITLE
742 fix deserialized packageversion licenses

### DIFF
--- a/Engine.UnitTests/SerializerTests.cs
+++ b/Engine.UnitTests/SerializerTests.cs
@@ -35,6 +35,23 @@ namespace OpenTap.Engine.UnitTests
                 
             }
         }
+
+        [Test]
+        public void TestPackageVersionLicenseSerializer()
+        {
+            var packageVersion = new PackageVersion("pkg", SemanticVersion.Parse("1.0.0"), "Linux", CpuArchitecture.AnyCPU, DateTime.Now, 
+                new List<string>()
+                {
+                    "License 1",
+                    "License 2"
+                });
+            var ser = new TapSerializer();
+            var str = ser.SerializeToString(packageVersion);
+            var des = ser.DeserializeFromString(str);
+            
+            Assert.AreEqual(packageVersion, des);
+            CollectionAssert.AreEqual(packageVersion.Licenses, ((des as PackageVersion)!).Licenses);
+        }
         
         [Test]
         public void TestPackageDependencySerializer()

--- a/Package/IPackageRepository.cs
+++ b/Package/IPackageRepository.cs
@@ -6,11 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
 using OpenTap.Authentication;
 
@@ -106,114 +104,6 @@ namespace OpenTap.Package
         public bool Equals(PackageVersion other)
         {
             return (this as PackageIdentifier).Equals(other);
-        }
-    }
-
-    internal class PackageVersionSerializerPlugin : TapSerializerPlugin
-    {
-        public override double Order { get { return 5; } }
-
-        public override bool Deserialize(XElement node, ITypeData t, Action<object> setter)
-        {
-            if (t.IsA(typeof(PackageVersion[])))
-            {
-                var list = new List<PackageVersion>();
-                foreach (var element in node.Elements())
-                    list.Add(DeserializePackageVersion(element));
-
-                setter(list.ToArray());
-                return true;
-            }
-            if (t.IsA(typeof(PackageVersion)))
-            {
-                setter(DeserializePackageVersion(node));
-                return true;
-            }
-            return false;
-        }
-
-        public override bool Serialize(XElement node, object obj, ITypeData expectedType)
-        {
-            if (expectedType.IsA(typeof(PackageVersion)) == false)
-                return false;
-
-            // We want to disable dependency writing either if:
-            // 1: we are serializing a single PackageVersion
-            // 2: we are serializing a single collection of PackageVersions
-            // In any other case, we do want to write package dependencies.
-            bool shouldDisableDependencyWriter()
-            {
-                if (node.Parent == null)
-                    return true;
-                if (node.Parent.Name.LocalName == "ArrayOfPackageVersion" ||
-                    node.Parent.Name.LocalName == "ListOfPackageVersion")
-                    return node.Parent.Parent == null;
-                return false;
-            }
-
-            if (shouldDisableDependencyWriter() == false)
-                return false;
-
-            // ask the TestPlanPackageDependency serializer (the one that writes the 
-            // <Package.Dependencies> tag in the bottom of e.g. TestPlan files) to
-            // not write the tag for this file.
-            var depSerializer = Serializer.GetSerializer<TestPlanPackageDependencySerializer>();
-            if (depSerializer != null)
-                depSerializer.WritePackageDependencies = false;
-            
-            // The serialization of this element should be handled by a generic serializer
-            return false;
-        }
-
-        PackageVersion DeserializePackageVersion(XElement node)
-        {
-            var version = new PackageVersion();
-            var elements = node.Elements().ToList();
-            var attributes = node.Attributes().ToList();
-            foreach (var element in elements)
-            {
-                if (element.IsEmpty) continue;
-                setProp(element.Name.LocalName, element.Value);
-            }
-            foreach (var attribute in attributes)
-            {
-                setProp(attribute.Name.LocalName, attribute.Value);
-            }
-
-            return version;
-
-            void setProp(string propertyName, string value)
-            {
-                if (propertyName == "CPU") // CPU was removed in OpenTAP 9.0. This is to support packages created by TAP 8x
-                    propertyName = "Architecture";
-
-                var prop = typeof(PackageVersion).GetProperty(propertyName);
-                if (prop == null) return;
-                if (prop.PropertyType.IsEnum)
-                    prop.SetValue(version, Enum.Parse(prop.PropertyType, value));
-                else if (prop.PropertyType.HasInterface<IList<string>>())
-                {
-                    var list = new List<string>();
-                    list.Add(value);
-                    prop.SetValue(version, list);
-                }
-                else if (prop.PropertyType == typeof(SemanticVersion))
-                {
-                    if (SemanticVersion.TryParse(value, out var semver))
-                        prop.SetValue(version, semver);
-                    else
-                        Log.Warning($"Cannot parse version '{value}' of package '{version.Name ?? "Unknown"}'.");
-                }
-                else if (prop.PropertyType == typeof(DateTime))
-                {
-                    if (DateTime.TryParse(value, out var date))
-                        prop.SetValue(version, date);
-                }
-                else
-                {
-                    prop.SetValue(version, value);
-                }
-            }
         }
     }
 

--- a/Package/PackageVersionSerializerPlugin.cs
+++ b/Package/PackageVersionSerializerPlugin.cs
@@ -11,21 +11,64 @@ namespace OpenTap.Package
 
         public override bool Deserialize(XElement node, ITypeData t, Action<object> setter)
         {
-            if (t.IsA(typeof(PackageVersion[])))
-            {
-                var list = new List<PackageVersion>();
-                foreach (var element in node.Elements())
-                    list.Add(DeserializePackageVersion(element));
+            if (t.IsA(typeof(PackageVersion)) == false) return false;
 
-                setter(list.ToArray());
-                return true;
-            }
-            if (t.IsA(typeof(PackageVersion)))
+            var version = new PackageVersion();
+
+            void setProp(string propertyName, XObject obj)
             {
-                setter(DeserializePackageVersion(node));
-                return true;
+                // CPU was removed in OpenTAP 9.0. This is to support packages created by TAP 8x
+                if (propertyName == "CPU") 
+                    propertyName = "Architecture";
+
+                var prop = typeof(PackageVersion).GetProperty(propertyName);
+                if (prop == null) return;
+                
+                // Deserialize using a default serializer when possible
+                if (obj is XElement elem)
+                {
+                    Serializer.Deserialize(elem, o => prop.SetValue(version, o), prop.PropertyType);
+                    return;
+                }
+
+                // Obj is always either an XElement or an XAttribute
+                var value = (obj as XAttribute)!.Value;
+                if (prop.PropertyType.IsEnum)
+                    prop.SetValue(version, Enum.Parse(prop.PropertyType, value));
+                else if (prop.PropertyType == typeof(SemanticVersion))
+                {
+                    if (SemanticVersion.TryParse(value, out var semver))
+                        prop.SetValue(version, semver);
+                    else
+                        Log.Warning($"Cannot parse version '{value}' of package '{version.Name ?? "Unknown"}'.");
+                }
+                else if (prop.PropertyType == typeof(DateTime))
+                {
+                    if (DateTime.TryParse(value, out var date))
+                        prop.SetValue(version, date);
+                }
+                else
+                {
+                    prop.SetValue(version, value);
+                }
             }
-            return false;
+
+            var elements = node.Elements().ToList();
+            var attributes = node.Attributes().ToList();
+
+            foreach (var element in elements)
+            {
+                if (element.IsEmpty) continue;
+                setProp(element.Name.LocalName, element);
+            }
+
+            foreach (var attribute in attributes)
+            {
+                setProp(attribute.Name.LocalName, attribute);
+            }
+
+            setter(version);
+            return true;
         }
 
         public override bool Serialize(XElement node, object obj, ITypeData expectedType)
@@ -59,57 +102,6 @@ namespace OpenTap.Package
             
             // The serialization of this element should be handled by a generic serializer
             return false;
-        }
-
-        PackageVersion DeserializePackageVersion(XElement node)
-        {
-            var version = new PackageVersion();
-            var elements = node.Elements().ToList();
-            var attributes = node.Attributes().ToList();
-            foreach (var element in elements)
-            {
-                if (element.IsEmpty) continue;
-                setProp(element.Name.LocalName, element.Value);
-            }
-            foreach (var attribute in attributes)
-            {
-                setProp(attribute.Name.LocalName, attribute.Value);
-            }
-
-            return version;
-
-            void setProp(string propertyName, string value)
-            {
-                if (propertyName == "CPU") // CPU was removed in OpenTAP 9.0. This is to support packages created by TAP 8x
-                    propertyName = "Architecture";
-
-                var prop = typeof(PackageVersion).GetProperty(propertyName);
-                if (prop == null) return;
-                if (prop.PropertyType.IsEnum)
-                    prop.SetValue(version, Enum.Parse(prop.PropertyType, value));
-                else if (prop.PropertyType.HasInterface<IList<string>>())
-                {
-                    var list = new List<string>();
-                    list.Add(value);
-                    prop.SetValue(version, list);
-                }
-                else if (prop.PropertyType == typeof(SemanticVersion))
-                {
-                    if (SemanticVersion.TryParse(value, out var semver))
-                        prop.SetValue(version, semver);
-                    else
-                        Log.Warning($"Cannot parse version '{value}' of package '{version.Name ?? "Unknown"}'.");
-                }
-                else if (prop.PropertyType == typeof(DateTime))
-                {
-                    if (DateTime.TryParse(value, out var date))
-                        prop.SetValue(version, date);
-                }
-                else
-                {
-                    prop.SetValue(version, value);
-                }
-            }
         }
     }
 }

--- a/Package/PackageVersionSerializerPlugin.cs
+++ b/Package/PackageVersionSerializerPlugin.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace OpenTap.Package
+{
+    internal class PackageVersionSerializerPlugin : TapSerializerPlugin
+    {
+        public override double Order { get { return 5; } }
+
+        public override bool Deserialize(XElement node, ITypeData t, Action<object> setter)
+        {
+            if (t.IsA(typeof(PackageVersion[])))
+            {
+                var list = new List<PackageVersion>();
+                foreach (var element in node.Elements())
+                    list.Add(DeserializePackageVersion(element));
+
+                setter(list.ToArray());
+                return true;
+            }
+            if (t.IsA(typeof(PackageVersion)))
+            {
+                setter(DeserializePackageVersion(node));
+                return true;
+            }
+            return false;
+        }
+
+        public override bool Serialize(XElement node, object obj, ITypeData expectedType)
+        {
+            if (expectedType.IsA(typeof(PackageVersion)) == false)
+                return false;
+
+            // We want to disable dependency writing either if:
+            // 1: we are serializing a single PackageVersion
+            // 2: we are serializing a single collection of PackageVersions
+            // In any other case, we do want to write package dependencies.
+            bool shouldDisableDependencyWriter()
+            {
+                if (node.Parent == null)
+                    return true;
+                if (node.Parent.Name.LocalName == "ArrayOfPackageVersion" ||
+                    node.Parent.Name.LocalName == "ListOfPackageVersion")
+                    return node.Parent.Parent == null;
+                return false;
+            }
+
+            if (shouldDisableDependencyWriter() == false)
+                return false;
+
+            // ask the TestPlanPackageDependency serializer (the one that writes the 
+            // <Package.Dependencies> tag in the bottom of e.g. TestPlan files) to
+            // not write the tag for this file.
+            var depSerializer = Serializer.GetSerializer<TestPlanPackageDependencySerializer>();
+            if (depSerializer != null)
+                depSerializer.WritePackageDependencies = false;
+            
+            // The serialization of this element should be handled by a generic serializer
+            return false;
+        }
+
+        PackageVersion DeserializePackageVersion(XElement node)
+        {
+            var version = new PackageVersion();
+            var elements = node.Elements().ToList();
+            var attributes = node.Attributes().ToList();
+            foreach (var element in elements)
+            {
+                if (element.IsEmpty) continue;
+                setProp(element.Name.LocalName, element.Value);
+            }
+            foreach (var attribute in attributes)
+            {
+                setProp(attribute.Name.LocalName, attribute.Value);
+            }
+
+            return version;
+
+            void setProp(string propertyName, string value)
+            {
+                if (propertyName == "CPU") // CPU was removed in OpenTAP 9.0. This is to support packages created by TAP 8x
+                    propertyName = "Architecture";
+
+                var prop = typeof(PackageVersion).GetProperty(propertyName);
+                if (prop == null) return;
+                if (prop.PropertyType.IsEnum)
+                    prop.SetValue(version, Enum.Parse(prop.PropertyType, value));
+                else if (prop.PropertyType.HasInterface<IList<string>>())
+                {
+                    var list = new List<string>();
+                    list.Add(value);
+                    prop.SetValue(version, list);
+                }
+                else if (prop.PropertyType == typeof(SemanticVersion))
+                {
+                    if (SemanticVersion.TryParse(value, out var semver))
+                        prop.SetValue(version, semver);
+                    else
+                        Log.Warning($"Cannot parse version '{value}' of package '{version.Name ?? "Unknown"}'.");
+                }
+                else if (prop.PropertyType == typeof(DateTime))
+                {
+                    if (DateTime.TryParse(value, out var date))
+                        prop.SetValue(version, date);
+                }
+                else
+                {
+                    prop.SetValue(version, value);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This refactors the PackageVersionSerializerPlugin

The plugin was moved into a separate file

The deserializer was simplified a bit to use a default deserializer when possible.
Unfortunately we still need to implement the deserialization of its `XAttributes`,
but this is relatively simple.

Closes #742 