### PR TITLE
625 ignoring dependencies aborts installation

### DIFF
--- a/Package/PackageActionHelpers.cs
+++ b/Package/PackageActionHelpers.cs
@@ -209,7 +209,8 @@ namespace OpenTap.Package
             log.Debug("Resolving dependencies.");
             var resolver = new DependencyResolver(installation, gatheredPackages, repositories);
 
-            var actualMissingDependencies = resolver.MissingDependencies.Where(s => !gatheredPackages.Any(p => s.Name == p.Name));
+            var actualMissingDependencies = resolver.MissingDependencies
+                .Where(s => gatheredPackages.All(p => s.Name != p.Name)).ToArray();
 
             if (resolver.UnknownDependencies.Any())
             {
@@ -243,9 +244,14 @@ namespace OpenTap.Package
 
                     foreach (var package in actualMissingDependencies)
                     {
-                        // Handle each package at a time.
-                        DepRequest req = null;
-                        pkgs.Add(req = new DepRequest { PackageName = package.Name, message = string.Format("Add dependency {0} {1} ?", package.Name, package.Version), Response = DepResponse.Add });
+                        // Handle one dependency at a time.
+                        var req = new DepRequest
+                        {
+                            PackageName = package.Name,
+                            message = $"Add dependency '{package.Name} version {package.Version}'?",
+                            Response = DepResponse.Add
+                        };
+                        pkgs.Add(req);
                         UserInput.Request(req, true);
                     }
 

--- a/Package/PackageActionHelpers.cs
+++ b/Package/PackageActionHelpers.cs
@@ -2,7 +2,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
-using OpenTap.Cli;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -99,6 +99,11 @@ namespace OpenTap.Package
         {
             if (Target == null)
                 Target = FileSystemHelper.GetCurrentInstallationDirectory();
+            if (IgnoreDependencies && InstallDependencies)
+            {
+                log.Error($"'--dependencies' and '--no-dependencies' are mutually exclusive.");
+                return (int)ExitCodes.ArgumentError;
+            }
             var targetInstallation = new Installation(Target);
 
             if (NoCache) PackageManagerSettings.Current.UseLocalPackageCache = false;
@@ -190,7 +195,8 @@ namespace OpenTap.Package
                     log.Warning("Overwriting files. (--{0} option specified).", Overwrite ? "overwrite" : "force");
 
                 RaiseProgressUpdate(10, "Gathering dependencies.");
-                bool checkDependencies = (!IgnoreDependencies && !Force) || CheckOnly;
+                // If 'askToInstallDependencies' is true, then the user already manually decided for each missing dependency.
+                bool checkDependencies = askToInstallDependencies == false && ((!IgnoreDependencies && !Force) || CheckOnly);
                 var issue = DependencyChecker.CheckDependencies(installationPackages, packagesToInstall,
                     IgnoreDependencies ? LogEventType.Information : checkDependencies ? LogEventType.Error : LogEventType.Warning);
                 if (checkDependencies)


### PR DESCRIPTION
Minor code cleanup. Skip dependency checks if the user was already manually prompted for dependencies.

Closes #625