### PR TITLE
Make valuetypes constructable

### DIFF
--- a/Engine.UnitTests/TypeDataTest.cs
+++ b/Engine.UnitTests/TypeDataTest.cs
@@ -1,5 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -36,6 +38,28 @@ namespace OpenTap.UnitTests
             // PropertyInfo.SetValue(xx, null) does not throw an exception for value types.
             // https://docs.microsoft.com/de-de/dotnet/api/system.reflection.propertyinfo.setvalue
             Assert.DoesNotThrow(() => memberData.SetValue(obj, null));
+        }
+
+        
+        [Test]
+        public void ValueTypeCanCreateInstanceTest()
+        {
+            var types = new[]
+            {
+                typeof(int),
+                typeof(double),
+                typeof(DateTime),
+                typeof(TimeSpan),
+                typeof(KeyValuePair<string, string>),
+            };
+            
+            foreach (var type in types)
+            {
+                var td = TypeData.FromType(type);
+                Assert.AreEqual(type.IsValueType, td.IsValueType);
+                Assert.IsTrue(td.CanCreateInstance, $"Expected type {type.FullName} to be constructable.");
+                Assert.AreEqual(Activator.CreateInstance(type), td.CreateInstance());
+            }
         }
 
         [Test]

--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -507,35 +507,63 @@ namespace OpenTap
                 return tp;
             return null; // This is not a type that we care about (not defined in any of the files the searcher is given)
         }
-        
-        private bool IsValueType(TypeDefinition typeDef)
-        {
-            try
-            {
-                var name = CurrentReader.GetString(typeDef.Name);
-                if (name == nameof(ValueType)) return true;
 
-                var baseType = typeDef.BaseType;
-                switch (baseType.Kind)
+        private static readonly Dictionary<string, bool> ValueTypeMap = new Dictionary<string, bool>(); 
+        private bool IsValueType(TypeDefinition typeDef, string typeName = null)
+        {
+            bool helper(string s)
+            {
+                try
                 {
-                    case HandleKind.TypeReference:
-                        var tr = (TypeReferenceHandle)baseType;
-                        var r = CurrentReader.GetTypeReference(tr);
-                        return CurrentReader.GetString(r.Name) == nameof(ValueType);
-                    case HandleKind.TypeDefinition:
-                        var td = (TypeDefinitionHandle)baseType;
-                        var d = CurrentReader.GetTypeDefinition(td);
-                        return IsValueType(d);
-                    default:
-                        return false;
+                    if (s == typeof(ValueType).FullName) return true;
+
+                    var baseType = typeDef.BaseType;
+                    switch (baseType.Kind)
+                    {
+                        case HandleKind.TypeReference:
+                            var tr = (TypeReferenceHandle)baseType;
+                            var r = CurrentReader.GetTypeReference(tr);
+                            return CurrentReader.GetString(r.Name) == "ValueType";
+                        case HandleKind.TypeDefinition:
+                            var td = (TypeDefinitionHandle)baseType;
+                            var d = CurrentReader.GetTypeDefinition(td);
+                            return IsValueType(d);
+                        default:
+                            return false;
+                    }
+                }
+                catch
+                {
+                    // This should be rare, and if the reader can't resolve some base type we can't do anything about it.
+                    // Just assume it isn't a valuetype and move on.
+                    return false;
                 }
             }
-            catch
+
+            typeName ??= GetTypeName(typeDef);
+            return ValueTypeMap.GetOrCreateValue(typeName, helper);
+        }
+
+        private string GetTypeName(TypeDefinition td)
+        {
+            string typeName;
+
+            TypeDefinitionHandle declaringTypeHandle = td.GetDeclaringType();
+            if (declaringTypeHandle.IsNil)
             {
-                // This should be rare, and if the reader can't resolve some base type we can't do anything about it.
-                // Just assume it isn't a valuetype and move on.
-                return false;
+                typeName = string.Format("{0}.{1}", CurrentReader.GetString(td.Namespace),
+                    CurrentReader.GetString(td.Name));
             }
+            else
+            {
+                // This is a nested type
+                TypeData declaringType = PluginFromTypeDefRecursive(declaringTypeHandle);
+                if (declaringType == null)
+                    return null;
+                typeName = string.Format("{0}+{1}", declaringType.Name, CurrentReader.GetString(td.Name));
+            }
+
+            return typeName;
         }
 
         private TypeData PluginFromTypeDefRecursive(TypeDefinitionHandle handle)
@@ -559,21 +587,8 @@ namespace OpenTap
                     return null;
             }
 
-            string typeName;
-            
-            TypeDefinitionHandle declaringTypeHandle = typeDef.GetDeclaringType();
-            if (declaringTypeHandle.IsNil)
-            {
-                typeName = string.Format("{0}.{1}", CurrentReader.GetString(typeDef.Namespace), CurrentReader.GetString(typeDef.Name));
-            }
-            else
-            {
-                // This is a nested type
-                TypeData declaringType = PluginFromTypeDefRecursive(declaringTypeHandle);
-                if (declaringType == null)
-                    return null;
-                typeName = string.Format("{0}+{1}", declaringType.Name, CurrentReader.GetString(typeDef.Name));
-            }
+            var typeName = GetTypeName(typeDef);
+
             if (AllTypes.TryGetValue(typeName, out var existingPlugin))
             {
                 if (existingPlugin.Assembly.Name == CurrentAsm.Name)
@@ -686,14 +701,18 @@ namespace OpenTap
                 {
                     plugin.CanCreateInstance = false;
                 }
-                else if (IsValueType(typeDef))
+                // It is not possible to instantiate types if they have unresolved generic parameters.
+                // Since we are currently reflecing an unloaded assembly, it is impossible for generic parameters
+                // to be resolved. If there are generic parameters, this typedata must therefore be unconstroctable.
+                // Once the type is actually loaded, whether an instance can be created for resolved instances
+                // of this type will be computed differently in the TypeData implementation.
+                else if (typeDef.GetGenericParameters().Count != 0)
                 {
-                    // It is not possible to instantiate types if they have unresolved generic parameters.
-                    // Since we are currently reflecing an unloaded assembly, it is impossible for generic parameters
-                    // to be resolved. If there are generic parameters, this typedata must therefore be unconstroctable.
-                    // Once the type is actually loaded, whether an instance can be created for resolved instances
-                    // of this type will be computed differently in the TypeData implementation.
-                    plugin.CanCreateInstance = typeDef.GetGenericParameters().Count == 0;
+                    plugin.CanCreateInstance = false;
+                }
+                else if (IsValueType(typeDef, typeName))
+                {
+                    plugin.CanCreateInstance = true;
                 }
                 else
                 {

--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -508,14 +508,16 @@ namespace OpenTap
             return null; // This is not a type that we care about (not defined in any of the files the searcher is given)
         }
 
+        private static string valueTypeName = typeof(ValueType).FullName;
         private static readonly Dictionary<string, bool> ValueTypeMap = new Dictionary<string, bool>(); 
         private bool IsValueType(TypeDefinition typeDef, string typeName = null)
         {
+            
             bool helper(string s)
             {
                 try
                 {
-                    if (s == typeof(ValueType).FullName) return true;
+                    if (s == valueTypeName) return true;
 
                     var baseType = typeDef.BaseType;
                     switch (baseType.Kind)
@@ -526,6 +528,7 @@ namespace OpenTap
                             return CurrentReader.GetString(r.Name) == "ValueType";
                         case HandleKind.TypeDefinition:
                             var td = (TypeDefinitionHandle)baseType;
+                            if (td.IsNil) return false;
                             var d = CurrentReader.GetTypeDefinition(td);
                             return IsValueType(d);
                         default:
@@ -588,7 +591,7 @@ namespace OpenTap
             }
 
             var typeName = GetTypeName(typeDef);
-
+            if (typeName == null) return null;
             if (AllTypes.TryGetValue(typeName, out var existingPlugin))
             {
                 if (existingPlugin.Assembly.Name == CurrentAsm.Name)

--- a/Engine/TypeData.cs
+++ b/Engine/TypeData.cs
@@ -175,7 +175,8 @@ namespace OpenTap
                 if (Load() is Type t)
                 {
                     type = t;
-                    canCreateInstance = type.IsAbstract == false && type.IsInterface == false &&
+                    canCreateInstance = type.IsValueType ||
+                                        type.IsAbstract == false && type.IsInterface == false &&
                                         type.ContainsGenericParameters == false &&
                                         type.GetConstructor(Array.Empty<Type>()) != null;
                     return canCreateInstance.Value;


### PR DESCRIPTION
Mark valuetypes as constructable in the plugin searcher
Make typedata treat valuetypes as constructable
Add unittest to verify the fix
CLoses #610