### PR TITLE
Now that we support multiple .gitversion files, we should not rewind …

### DIFF
--- a/Package/CreatePackage/GitVersionAction.cs
+++ b/Package/CreatePackage/GitVersionAction.cs
@@ -77,7 +77,6 @@ namespace OpenTap.Package
                     return (int)ExitCodes.ArgumentError;
                 }
             }
-            RepoPath = repositoryDir;
 
             if (FieldCount < 1 || FieldCount > 5)
             {

--- a/Package/CreatePackage/GitVersionAction.cs
+++ b/Package/CreatePackage/GitVersionAction.cs
@@ -67,17 +67,6 @@ namespace OpenTap.Package
         /// <returns>Returns 0 to indicate success.</returns>
         public int Execute(CancellationToken cancellationToken)
         {
-            string repositoryDir = RepoPath;
-            while (!Directory.Exists(Path.Combine(repositoryDir, ".git")))
-            {
-                repositoryDir = Path.GetDirectoryName(repositoryDir);
-                if (repositoryDir == null)
-                {
-                    log.Error("Directory {0} is not a git repository.", RepoPath);
-                    return (int)ExitCodes.ArgumentError;
-                }
-            }
-
             if (FieldCount < 1 || FieldCount > 5)
             {
                 log.Error("The argument for --fields ({0}) must be an integer between 1 and 5.", FieldCount);


### PR DESCRIPTION
…to root directory when we start to calculate gitversion.