### PR TITLE
781 Scpi Instrument Not Supported on ubuntu 2204: Fix

### DIFF
--- a/Engine/LibDl.cs
+++ b/Engine/LibDl.cs
@@ -1,0 +1,114 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+static class LibDl
+{
+    static IntPtr load(string name) => libdl.dlopen(name, rtld_now);
+    static void close(IntPtr ptr) => libdl.dlclose(ptr);
+
+    public static string GetError()
+    {
+        var error = libdl.dlerror();
+        if (IntPtr.Zero == error) return null;
+        return Marshal.PtrToStringAuto(error);
+
+    }
+    
+    static void checkError()
+    {
+        var error = libdl.dlerror();
+        if (error != IntPtr.Zero)
+            throw new Exception("Unable to load python: " + error.ToString());
+    }
+
+    static void clearError() => libdl.dlerror();
+
+    const int rtld_now = 2;
+
+    interface ILibDL
+    {
+        IntPtr dlopen(string filename, int flags);
+        int dlclose(IntPtr handle);
+        IntPtr dlerror();
+        IntPtr dlsym(IntPtr handle, string symbol);
+    }
+
+    class libdl1 : ILibDL
+    {
+        [DllImport("libdl.so")]
+        static extern IntPtr dlopen(string fileName, int flags);
+
+        [DllImport("libdl.so")]
+        static extern int dlclose(IntPtr handle);
+
+        [DllImport("libdl.so")]
+        static extern IntPtr dlerror();
+        
+        [DllImport("libdl.so.2")]
+        static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+
+        IntPtr ILibDL.dlopen(string fileName, int flags) => dlopen(fileName, flags);
+        int ILibDL.dlclose(IntPtr handle) => dlclose(handle);
+        IntPtr ILibDL.dlerror() => dlerror();
+        IntPtr ILibDL.dlsym(IntPtr handle, string symbol) => dlsym(handle, symbol);
+
+    }
+
+    class libdl2 : ILibDL
+    {
+        [DllImport("libdl.so.2")]
+        static extern IntPtr dlopen(string fileName, int flags);
+        
+        [DllImport("libdl.so.2")]
+        static extern int dlclose(IntPtr handle);
+
+        [DllImport("libdl.so.2")]
+        static extern IntPtr dlerror();
+        
+        [DllImport("libdl.so.2")]
+        static extern IntPtr dlsym(IntPtr handle, string symbol);
+        
+        
+        IntPtr ILibDL.dlopen(string fileName, int flags) => dlopen(fileName, flags);
+        int ILibDL.dlclose(IntPtr handle) => dlclose(handle);
+        IntPtr ILibDL.dlerror() => dlerror();
+
+        IntPtr ILibDL.dlsym(IntPtr handle, string symbol) => dlsym(handle, symbol);
+    }
+
+    static readonly ILibDL libdl;
+
+    static LibDl()
+    {
+        try
+        {
+            libdl = new libdl2();
+            // call dlerror to ensure library is resolved
+            libdl.dlerror();
+        }
+        catch (DllNotFoundException)
+        {
+            libdl = new libdl1();
+        }
+    }
+
+    public static IntPtr Sym(IntPtr lib, string name) => libdl.dlsym(lib, name);
+
+    public static IntPtr Load(string name)
+    {
+        clearError();
+        IntPtr p = load(name);
+        if (p == IntPtr.Zero)
+            return IntPtr.Zero;
+        return p;
+    }
+
+    public static void Unload(IntPtr lib)
+    {
+        if (lib == IntPtr.Zero)
+            throw new NullReferenceException();
+        close(lib);
+    }
+}

--- a/Engine/Visa.cs
+++ b/Engine/Visa.cs
@@ -77,14 +77,6 @@ internal static class Visa
     [DllImport("kernel32.dll")]
     static extern IntPtr GetProcAddress(IntPtr hModule, string procname);
 
-    [DllImport("libdl.so")]
-    static extern IntPtr dlopen(string filename, int flags);
-
-    [DllImport("libdl.so")]
-    static extern IntPtr dlsym(IntPtr handle, string symbol);
-
-    const int RTLD_NOW = 2; // for dlopen's flags 
-
     static T GetSymbol<T>(IntPtr s)
     {
         return Marshal.GetDelegateForFunctionPointer<T>(s);
@@ -107,10 +99,9 @@ internal static class Visa
             LoadLib = () =>
             {
                 string[] paths = {"./libvisa32.so", "./libvisa.so", "libvisa32.so", "libvisa.so", "libiovisa.so", "./libiovisa.so"};
-                return paths.Select(x => dlopen(x, flags: RTLD_NOW))
-                    .FirstOrDefault(x => x != IntPtr.Zero);
+                return paths.Select(LibDl.Load) .FirstOrDefault(x => x != IntPtr.Zero);
             };
-            LoadSym = (lib_handle, name, ord) => dlsym(lib_handle, name);
+            LoadSym = (lib_handle, name, ord) => LibDl.Sym(lib_handle, name);
         }
 
         var lib = LoadLib();


### PR DESCRIPTION
- Added support for loading libdl.so.2 when using Visa.

This was manually tested to work on SCPI enabled instruments on Ubuntu 2204.

Close #781