### PR TITLE
751 dont open resources when runmonitors throw

### DIFF
--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -760,20 +760,16 @@ namespace OpenTap
         private void OpenInternal(TestPlanRun run, bool isOpen, List<ITestStep> steps)
         {
             monitors = TestPlanRunMonitors.GetCurrent();
-            try
-            {
-                // Enter monitors
-                foreach (var item in monitors)
-                    item.EnterTestPlanRun(run);
-            }
-            finally   // We need to make sure OpenAllAsync is always called (even when CheckResources throws an exception). 
-            {         // Otherwise we risk that e.g. ResourceManager.WaitUntilAllResourcesOpened() will hang forever.
-                run.ResourceManager.EnabledSteps = steps;
-                run.ResourceManager.StaticResources = run.ResultListeners.ToArray();
-                run.ResultListenersSealed = true;
-                if (!isOpen)
-                    run.ResourceManager.BeginStep(run, this, TestPlanExecutionStage.Open, TapThread.Current.AbortToken);
-            }
+
+            // Enter monitors
+            foreach (var item in monitors)
+                item.EnterTestPlanRun(run);
+            
+            run.ResourceManager.EnabledSteps = steps;
+            run.ResourceManager.StaticResources = run.ResultListeners.ToArray();
+            run.ResultListenersSealed = true;
+            if (!isOpen)
+                run.ResourceManager.BeginStep(run, this, TestPlanExecutionStage.Open, TapThread.Current.AbortToken);
         }
 
         /// <summary>


### PR DESCRIPTION
This removes a try {} finally {} clause that would cause resources to be opened when TestPlanRunMonitors throw (which causes the plan to fail to start anyway)

There was a comment warning about why this was required which may or may not be relevant today. The workaround was added in the "first source code drop" commit from 9.0. I tracked the commit back to 2015 where I'm sure it fixed some relevant issue, but a lot has changed since then.

After reviewing the code with @AsgerIversen, we agreed that it is probably not necessary anymore, and we have a unittest that verifies the behavior with all OpenTAP resource managers at least.

Closes #751 