### PR TITLE
Align targetFramework for Tap.Upgrader to avoid shipping netstandard.dll

### DIFF
--- a/Tap.Upgrader/Tap.Upgrader.csproj
+++ b/Tap.Upgrader/Tap.Upgrader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>$(OpenTapAppTargetFramework)</TargetFramework>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/package.xml
+++ b/package.xml
@@ -91,8 +91,6 @@
               SourcePath="libgit2sharp.license.md"/>
         <File Path="Dependencies/Mono.Cecil.0.10.1.0/LICENSE.txt"
               SourcePath="Mono.Cecil.License.txt"/>
-        <File Path="Dependencies/netstandard.2.0.0.0/LICENSE.txt"
-              SourcePath="dotnet_mit_license.txt"/>
         <File Path="Dependencies/System.Reflection.Metadata.1.4.3.0/LICENSE.txt"
               SourcePath="dotnet_mit_license.txt"/>
         <File Path="Dependencies/System.Collections.Immutable.1.2.3.0/LICENSE.txt"
@@ -101,15 +99,8 @@
               SourcePath="dotnet_mit_license.txt"/>
         <File Path="Dependencies/System.ValueTuple.4.0.3.0/LICENSE.txt"
               SourcePath="dotnet_mit_license.txt"/>
-        <File Path="Dependencies/System.Runtime.4.1.2.0/LICENSE.txt"
-              SourcePath="dotnet_library_license.txt"/>
-        <File Path="Dependencies/System.Collections.4.0.11.0/LICENSE.txt"
-              SourcePath="dotnet_library_license.txt"/>
-        <File Path="Dependencies/System.IO.4.1.2.0/LICENSE.txt"
-              SourcePath="dotnet_library_license.txt"/>
-        <File Path="Dependencies/System.Runtime.Extensions.4.1.2.0/LICENSE.txt"
-              SourcePath="dotnet_library_license.txt"/>
-        <File Path="Dependencies/System.Linq.4.1.2.0/LICENSE.txt"
+
+        <File Path="Dependencies/System.Linq.4.1.0.0/LICENSE.txt"
               SourcePath="dotnet_library_license.txt"/>
         <File Path="Dependencies/DotNet.Glob.3.0.1.0/LICENSE.txt"
               SourcePath="Dotnet.Glob.License.txt"/>


### PR DESCRIPTION
Alternative to #690 

Close #689 