### PR TITLE
760 FileRepository PackageManager Supporting Uri: Fix

### DIFF
--- a/Package/IPackageRepository.cs
+++ b/Package/IPackageRepository.cs
@@ -257,7 +257,7 @@ namespace OpenTap.Package
                         case "https":
                             return new HttpPackageRepository(url);
                         case "file":
-                            return new FilePackageRepository(uri.AbsolutePath);
+                            return new FilePackageRepository(url);
                         default:
                             throw new NotSupportedException($"Scheme {uri.Scheme} is not supported as a package repository ({url}).");
                     }

--- a/Package/Repositories/FilePackageRepository.cs
+++ b/Package/Repositories/FilePackageRepository.cs
@@ -53,6 +53,7 @@ namespace OpenTap.Package
                     AbsolutePath = Path.GetFullPath(Path.GetDirectoryName(absolutePath)).TrimEnd('/', '\\');
                 else
                     AbsolutePath = Path.GetFullPath(absolutePath).TrimEnd('/', '\\');
+                AbsolutePath = Uri.UnescapeDataString(AbsolutePath);
 
                 Url = new Uri(AbsolutePath).AbsoluteUri;
             }


### PR DESCRIPTION
- Fixed the issue by unescaping the absolute path.
Close #760 