### PR TITLE
797 Result Table optimizer Type Bug: Unit test

### DIFF
--- a/Engine.UnitTests/ResultProxyTests.cs
+++ b/Engine.UnitTests/ResultProxyTests.cs
@@ -419,5 +419,22 @@ namespace OpenTap.Engine.UnitTests
                 Assert.IsTrue(ResultTableOptimizer.CanMerge(rt1, rt2) == false);
             }
         }
+        
+        // an issue inside ResultTableOptimizer caused it to
+        // think that two tables were 'mergable' even though they had different
+        // column types. In this test, one is bool and the other is int.
+        [Test]
+        public void TestResultTableMergeBug()
+        {
+            var boolColumnTable = new ResultTable("X", new[] {new ResultColumn("A", new bool[1])});
+            var boolColumnTable2 = new ResultTable("X", new[] {new ResultColumn("A", new bool[1])});
+            var intColumnTable = new ResultTable("X", new[] {new ResultColumn("A", new int[1])});
+            var intColumnTable2 = new ResultTable("X", new[] {new ResultColumn("A", new int[1])});
+            Assert.IsTrue(ResultTableOptimizer.CanMerge(intColumnTable, intColumnTable2), "These columns should be mergeable.");
+            Assert.IsTrue(ResultTableOptimizer.CanMerge(boolColumnTable, boolColumnTable2), "These columns should be mergeable.");
+            Assert.IsFalse(ResultTableOptimizer.CanMerge(boolColumnTable, intColumnTable), "It should not be possible to merge an int column and bool column.");
+            
+            
+        }
     }
 }

--- a/Engine/ResultTableOptimizer.cs
+++ b/Engine/ResultTableOptimizer.cs
@@ -23,6 +23,8 @@ namespace OpenTap
                 var c2 = table2.Columns[columnIdx];
                 if (c1.Name != c2.Name || c1.ObjectType != c2.ObjectType)
                     return false;
+                if (c1.TypeCode != c2.TypeCode)
+                    return false;
                 if (!c1.Parameters.SequenceEqual(c2.Parameters))
                     return false;
             }


### PR DESCRIPTION
Fixed the issue by checking the ResultColumn TypeCode. The problem was probably caused by confusion about the ObjectType and the TypeCode, for which only the TypeCode says anything about which data type the column values has.

Added a unit test to show the issue.

Examples of how to reproduce the issue under normal conditions can be seen in issue #797 

Close #797 