### PR TITLE
Make process isolation Linux compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,8 @@ jobs:
           dotnet-version: '6.0.x'
       - name: Build
         run: dotnet publish -c Release OpenTAP.sln
+      - name: Copy Debug Package 
+        run: cp ./bin/Release/OpenTap.Debug.TapPackage ./bin/Release/publish
       - name: Upload binaries
         uses: actions/upload-artifact@v2
         with:
@@ -250,6 +252,8 @@ jobs:
           dotnet-version: '6.0.x'
       - name: Build
         run: dotnet publish -c Release OpenTAP.sln
+      - name: Copy Debug Package 
+        run: cp ./bin/Release/OpenTap.Debug.TapPackage ./bin/Release/publish
       - name: Upload binaries
         uses: actions/upload-artifact@v2
         with:
@@ -359,6 +363,7 @@ jobs:
       - name: Test
         run: |
           chmod +x bin/Release/tap
+          ./bin/Release/tap package install ./bin/Release/OpenTap.Debug.TapPackage -f
           bin/Release/tap run tests/regression.TapPlan --verbose --color
 
   TestMacPlan:
@@ -379,6 +384,7 @@ jobs:
       - name: Test
         run: |
           chmod +x bin/Release/tap
+          ./bin/Release/tap package install ./bin/Release/OpenTap.Debug.TapPackage -f
           bin/Release/tap run tests/regression.TapPlan --verbose --color
 
   ###############

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Build
         run: dotnet publish -c Release OpenTAP.sln
       - name: Copy Debug Package 
-        run: cp ./bin/Release/OpenTap.Debug.TapPackage ./bin/Release/publish
+        run: cp ./bin/Release/OpenTap.Debug.TapPackage ./bin/Release/publish/dbg.zip
       - name: Upload binaries
         uses: actions/upload-artifact@v2
         with:
@@ -253,7 +253,7 @@ jobs:
       - name: Build
         run: dotnet publish -c Release OpenTAP.sln
       - name: Copy Debug Package 
-        run: cp ./bin/Release/OpenTap.Debug.TapPackage ./bin/Release/publish
+        run: cp ./bin/Release/OpenTap.Debug.TapPackage ./bin/Release/publish/dbg.zip
       - name: Upload binaries
         uses: actions/upload-artifact@v2
         with:
@@ -363,7 +363,7 @@ jobs:
       - name: Test
         run: |
           chmod +x bin/Release/tap
-          ./bin/Release/tap package install ./bin/Release/OpenTap.Debug.TapPackage -f
+          ./bin/Release/tap package install ./bin/Release/dbg.zip -f
           bin/Release/tap run tests/regression.TapPlan --verbose --color
 
   TestMacPlan:
@@ -384,7 +384,7 @@ jobs:
       - name: Test
         run: |
           chmod +x bin/Release/tap
-          ./bin/Release/tap package install ./bin/Release/OpenTap.Debug.TapPackage -f
+          ./bin/Release/tap package install ./bin/Release/dbg.zip -f
           bin/Release/tap run tests/regression.TapPlan --verbose --color
 
   ###############

--- a/Cli/TapEntry.cs
+++ b/Cli/TapEntry.cs
@@ -84,7 +84,8 @@ namespace OpenTap.Cli
 
             string arguments = new CommandLineSplit(Environment.CommandLine).Args;
             string message = null;
-            using (ExecutorSubProcess subproc = ExecutorSubProcess.Create("tap.exe", arguments))
+            
+            using (ExecutorSubProcess subproc = ExecutorSubProcess.Create("tap", arguments))
             {
                 subproc.MessageReceived += (s, msg) =>
                 {

--- a/Package/Installation.cs
+++ b/Package/Installation.cs
@@ -40,7 +40,7 @@ namespace OpenTap.Package
         /// <summary>
         /// Get the installation of the currently running tap process
         /// </summary>
-        public static Installation Current => _current ?? (_current = new Installation(ExecutorClient.ExeDir));
+        public static Installation Current => _current ??= new Installation(ExecutorClient.ExeDir);
 
         /// <summary> Target installation architecture. This could be anything as 32-bit is supported on 64bit systems.</summary>
         internal CpuArchitecture Architecture => GetOpenTapPackage()?.Architecture ?? ArchitectureHelper.GuessBaseArchitecture;

--- a/Shared/ExecutorInterop.cs
+++ b/Shared/ExecutorInterop.cs
@@ -105,7 +105,7 @@ namespace OpenTap
             string pipename = pipeName = Guid.NewGuid().ToString().Replace("-", "");
             try
             {
-                return new NamedPipeServerStream(pipename, PipeDirection.In, 10, PipeTransmissionMode.Message, PipeOptions.WriteThrough);
+                return new NamedPipeServerStream(pipename, PipeDirection.In, 10);
             }
             catch (UnauthorizedAccessException)
             {

--- a/tests/regression.TapPlan
+++ b/tests/regression.TapPlan
@@ -4,6 +4,10 @@
     <TestStep type="OpenTap.Plugins.BasicSteps.SequenceStep" Id="d032668a-7a5e-4300-b927-a8ff0b6f91fd" OpenTap.Visibility="Visible">
       <Name Metadata="Step Name">Sequence</Name>
       <ChildTestSteps>
+        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Id="76447d35-9a8e-4b78-b04b-bfeef98d2a83">
+          <Filepath>../../tests/test-install-package.TapPlan</Filepath>
+          <Name Metadata="Step Name">Test Plan {Referenced Plan}</Name>
+        </TestStep>
         <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Id="1e18241d-7317-4cf0-9d1e-e6b920256386">
           <Filepath>../../tests/show-tags.TapPlan</Filepath>
           <StepMapping />
@@ -103,10 +107,6 @@
         </TestStep>
         <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Id="65337d35-9a8e-4b78-b04b-bfeef98d2a83">
           <Filepath>../../tests/test-cli-load-plan-with-error.TapPlan</Filepath>
-          <Name Metadata="Step Name">Test Plan {Referenced Plan}</Name>
-        </TestStep>
-        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Id="76447d35-9a8e-4b78-b04b-bfeef98d2a83">
-          <Filepath>../../tests/test-install-package.TapPlan</Filepath>
           <Name Metadata="Step Name">Test Plan {Referenced Plan}</Name>
         </TestStep>
       </ChildTestSteps>

--- a/tests/regression.TapPlan
+++ b/tests/regression.TapPlan
@@ -105,6 +105,10 @@
           <Filepath>../../tests/test-cli-load-plan-with-error.TapPlan</Filepath>
           <Name Metadata="Step Name">Test Plan {Referenced Plan}</Name>
         </TestStep>
+        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Id="76447d35-9a8e-4b78-b04b-bfeef98d2a83">
+          <Filepath>../../tests/test-install-package.TapPlan</Filepath>
+          <Name Metadata="Step Name">Test Plan {Referenced Plan}</Name>
+        </TestStep>
       </ChildTestSteps>
     </TestStep>
   </Steps>

--- a/tests/test-install-package.TapPlan
+++ b/tests/test-install-package.TapPlan
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestPlan type="OpenTap.TestPlan">
+  <Steps>
+    <TestStep type="OpenTap.Plugins.BasicSteps.ProcessStep" Id="aa23442b-dc13-419d-9cf7-3e47864543fc">
+      <Application>tap</Application>
+      <Arguments>package install Demonstration</Arguments>
+      <WorkingDirectory></WorkingDirectory>
+      <EnvironmentVariables />
+      <Timeout>0</Timeout>
+      <AddToLog>true</AddToLog>
+      <CheckExitCode>true</CheckExitCode>
+      <RegularExpressionPattern>
+        <Value>(.*)</Value>
+        <IsEnabled>false</IsEnabled>
+      </RegularExpressionPattern>
+      <VerdictOnMatch>Pass</VerdictOnMatch>
+      <VerdictOnNoMatch>Fail</VerdictOnNoMatch>
+      <ResultRegularExpressionPattern>
+        <Value>(.*)</Value>
+        <IsEnabled>false</IsEnabled>
+      </ResultRegularExpressionPattern>
+      <ResultName>Regex Result</ResultName>
+      <Behavior>GroupsAsDimensions</Behavior>
+      <DimensionTitles></DimensionTitles>
+      <Name Metadata="Step Name">Install Demonstration</Name>
+    </TestStep>
+  </Steps>
+  <OpenTap.Description>This tests the very basic capability of being able to install a package</OpenTap.Description>
+</TestPlan>


### PR DESCRIPTION
This adds a regression test for verifying that packages can actually be installed on all platforms, and it makes the process isolation logic use cross-platform flags when creating named pipes.

Closes #801