### PR TITLE
Fix bug causing small packages to have incorrect hashes

### DIFF
--- a/Package.UnitTests/Image/Cache.cs
+++ b/Package.UnitTests/Image/Cache.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using OpenTap.Package;
 using System.Collections.Generic;
 using System.IO;
@@ -32,6 +33,27 @@ namespace OpenTap.Image.Tests
             {
                 PackageCacheHelper.ClearCache();
             }
+        }
+
+        [Test]
+        public void TestImageIds()
+        {
+            var opentap = new PackageDef()
+            {
+                Name = "OpenTAP",
+                Version = SemanticVersion.Parse("1.2.3"),
+                Architecture = CpuArchitecture.AnyCPU,
+                OS = "Windows"
+            };
+            
+            var spec1 = new ImageIdentifier(new PackageDef[] { opentap }, Array.Empty<string>());
+            var id1 = spec1.Id;
+            
+            opentap.Version = SemanticVersion.Parse("4.5.6");
+            var spec2 = new ImageIdentifier(new PackageDef[] { opentap }, Array.Empty<string>());
+            var id2 = spec2.Id;
+
+            Assert.AreNotEqual(id1, id2);
         }
     }
 }

--- a/Package/Image/ImageIdentifier.cs
+++ b/Package/Image/ImageIdentifier.cs
@@ -93,7 +93,7 @@ namespace OpenTap.Package
             }
 
 
-            HashAlgorithm algorithm = SHA1.Create();
+            using var algorithm = SHA1.Create();
             var bytes = algorithm.ComputeHash(Encoding.UTF8.GetBytes(string.Join(",", packageHashes)));
             return BitConverter.ToString(bytes).Replace("-", "");
         }

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -103,6 +103,7 @@ namespace OpenTap.Package
                 }
 
                 log.Debug(sw, "Resolution done");
+                log.Debug("Image hash: {0}", image.Id);
                 if (DryRun)
                 {
                     log.Info("Resolved packages:");

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -833,7 +833,7 @@ namespace OpenTap.Package
         public string ComputeHash()
         {
             using MemoryStream str = new MemoryStream();
-            using (TextWriter wtr = new StreamWriter(str))
+            using (TextWriter wtr = new StreamWriter(str, Encoding.Default, 4096, true))
             {
                 wtr.Write(this.Name);
                 wtr.Write(this.Version);

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -313,7 +313,7 @@ namespace OpenTap.Package
                     hashVerified = true;
                     if (loadedHash.Length == oldHashLength)
                     {
-                        var hash2 = ComputeHash(quick: true);
+                        var hash2 = ComputeHash();
                         if (hash2 != null)
                             loadedHash = hash2;
                     }
@@ -860,13 +860,7 @@ namespace OpenTap.Package
         /// This method relies on hashes of each file. If those are not already part of the definition (they are normally computed when the package is created), this method will try to compute them based on files on the disk.
         /// </summary>
         /// <returns>A base64 encoded SHA1 hash of relevant fields in the package definition</returns>
-        public string ComputeHash() => ComputeHash(false);
-        /// <summary>
-        /// Computes the hash/signature of the package based on its definition. 
-        /// This method relies on hashes of each file. If those are not already part of the definition (they are normally computed when the package is created), this method will try to compute them based on files on the disk.
-        /// </summary>
-        /// <returns>A base64 encoded SHA1 hash of relevant fields in the package definition</returns>
-        public string ComputeHash(bool quick)
+        public string ComputeHash()
         {
             using MemoryStream str = new MemoryStream();
             using (TextWriter wtr = new StreamWriter(str, Encoding.Default, 4096, true))
@@ -883,17 +877,9 @@ namespace OpenTap.Package
                     FileHashPackageAction.Hash fileHash =
                         file.CustomData.OfType<FileHashPackageAction.Hash>().FirstOrDefault();
                     if (fileHash != null)
-                    {
                         wtr.Write(fileHash.Value);
-                    }
-                    else if (quick) 
-                        return null; // dont start hashing files when in 'quick' mode.
-                    else if (File.Exists(file.FileName))
-                    {
-                        wtr.Write(Convert.ToBase64String(FileHashPackageAction.hashFile(file.FileName)));
-                    }
                     else
-                        throw new Exception($"Missing hash of payload file {file.FileName} (file does not exist).");
+                        wtr.Write(file.FileName);
                 }
             }
 

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -315,14 +315,7 @@ namespace OpenTap.Package
                     {
                         var hash2 = ComputeHash(quick: true);
                         if (hash2 != null)
-                        {
-                            if (hash2 != loadedHash)
-                            {
-                                log.Warning("Bad hash detected.");
-                            }
-
                             loadedHash = hash2;
-                        }
                     }
                 }
                 

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -292,12 +292,49 @@ namespace OpenTap.Package
         /// Holds additional metadata for a package
         /// </summary>
         public Dictionary<string, string> MetaData { get; } = new Dictionary<string, string>();
-        
+
+        string loadedHash;
+        bool hashVerified;
+        const int oldHashLength = 40;
         /// <summary>
         /// The hash of the package. This is based on hashes of each payload file as well as metadata in the package definition.
         /// </summary>
         [DefaultValue(null)]
-        public string Hash { get; set; }
+        public string Hash
+        {
+            get
+            {
+                // in OpenTAP 9.18 and earlier weak / invalid hash values were calculated.
+                // in 9.19, its fixed, but to distinguish a different length of hashes are used.
+                // the previous hash length was always 40.
+                
+                if (!hashVerified && loadedHash != null)
+                {
+                    hashVerified = true;
+                    if (loadedHash.Length == oldHashLength)
+                    {
+                        var hash2 = ComputeHash(quick: true);
+                        if (hash2 != null)
+                        {
+                            if (hash2 != loadedHash)
+                            {
+                                log.Warning("Bad hash detected.");
+                            }
+
+                            loadedHash = hash2;
+                        }
+                    }
+                }
+                
+                return loadedHash;
+            }
+            set
+            {
+                if (loadedHash == value) return;
+                loadedHash = value;
+                hashVerified = loadedHash?.Length != oldHashLength;
+            }
+        }
 
         /// <summary>
         /// A description of this package.
@@ -830,7 +867,13 @@ namespace OpenTap.Package
         /// This method relies on hashes of each file. If those are not already part of the definition (they are normally computed when the package is created), this method will try to compute them based on files on the disk.
         /// </summary>
         /// <returns>A base64 encoded SHA1 hash of relevant fields in the package definition</returns>
-        public string ComputeHash()
+        public string ComputeHash() => ComputeHash(false);
+        /// <summary>
+        /// Computes the hash/signature of the package based on its definition. 
+        /// This method relies on hashes of each file. If those are not already part of the definition (they are normally computed when the package is created), this method will try to compute them based on files on the disk.
+        /// </summary>
+        /// <returns>A base64 encoded SHA1 hash of relevant fields in the package definition</returns>
+        public string ComputeHash(bool quick)
         {
             using MemoryStream str = new MemoryStream();
             using (TextWriter wtr = new StreamWriter(str, Encoding.Default, 4096, true))
@@ -844,11 +887,14 @@ namespace OpenTap.Package
                 wtr.Write(string.Join("", this.Dependencies.OrderBy(d => d.Name).Select(d => d.Name + d.Version)));
                 foreach (PackageFile file in this.Files.OrderBy(f => f.FileName))
                 {
-                    FileHashPackageAction.Hash fileHash = file.CustomData.OfType<FileHashPackageAction.Hash>().FirstOrDefault();
+                    FileHashPackageAction.Hash fileHash =
+                        file.CustomData.OfType<FileHashPackageAction.Hash>().FirstOrDefault();
                     if (fileHash != null)
                     {
                         wtr.Write(fileHash.Value);
                     }
+                    else if (quick) 
+                        return null; // dont start hashing files when in 'quick' mode.
                     else if (File.Exists(file.FileName))
                     {
                         wtr.Write(Convert.ToBase64String(FileHashPackageAction.hashFile(file.FileName)));
@@ -857,15 +903,17 @@ namespace OpenTap.Package
                         throw new Exception($"Missing hash of payload file {file.FileName} (file does not exist).");
                 }
             }
+
             str.Seek(0, SeekOrigin.Begin);
             using var algorithm = SHA1.Create();
             var bytes = algorithm.ComputeHash(str);
-            return BitConverter.ToString(bytes).Replace("-", "");
+            return Utils.Base64UrlEncode(bytes);
         }
 
         internal PackageSpecifier GetSpecifier() => new PackageSpecifier(Name, Version.AsExactSpecifier(), Architecture, OS);
     }
 
+    
     // helper class to ignore namespaces when de-serializing
     internal class NamespaceIgnorantXmlTextReader : XmlTextReader
     {

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -832,7 +832,7 @@ namespace OpenTap.Package
         /// <returns>A base64 encoded SHA1 hash of relevant fields in the package definition</returns>
         public string ComputeHash()
         {
-            using (MemoryStream str = new MemoryStream())
+            using MemoryStream str = new MemoryStream();
             using (TextWriter wtr = new StreamWriter(str))
             {
                 wtr.Write(this.Name);
@@ -856,12 +856,11 @@ namespace OpenTap.Package
                     else
                         throw new Exception($"Missing hash of payload file {file.FileName} (file does not exist).");
                 }
-
-                str.Seek(0, 0);
-                HashAlgorithm algorithm = SHA1.Create();
-                var bytes = algorithm.ComputeHash(str);
-                return BitConverter.ToString(bytes).Replace("-", "");
             }
+            str.Seek(0, SeekOrigin.Begin);
+            using var algorithm = SHA1.Create();
+            var bytes = algorithm.ComputeHash(str);
+            return BitConverter.ToString(bytes).Replace("-", "");
         }
 
         internal PackageSpecifier GetSpecifier() => new PackageSpecifier(Name, Version.AsExactSpecifier(), Architecture, OS);

--- a/Shared/ReflectionHelper.cs
+++ b/Shared/ReflectionHelper.cs
@@ -843,6 +843,13 @@ namespace OpenTap
     
     static class Utils
     {
+        static readonly char[] padding = { '=' };
+        public static string Base64UrlEncode(byte[] bytes)
+        {
+            return Convert.ToBase64String(bytes)
+                .TrimEnd(padding).Replace('+', '-')
+                .Replace('/', '_');
+        }
         public static IEnumerable<(int, T)> WithIndex<T>(this IEnumerable<T> collection)
         {
             return collection.Select((ele, index) => (index, ele));


### PR DESCRIPTION
Because we didn't flush our writer, we never calculated correct hashes. This became apparent for smaller packages which got identical hashes because the memory stream would be empty, but for larger packages we likely also calculated the hash from incomplete data.