### PR TITLE
Redefined the meaning of VersionSpecifier.Any and

### DIFF
--- a/Package/Image/PackageDependencyGraph.cs
+++ b/Package/Image/PackageDependencyGraph.cs
@@ -163,9 +163,18 @@ namespace OpenTap.Package
         readonly Dictionary<string, string> currentPreReleases = new Dictionary<string, string>();
         public IEnumerable<SemanticVersion> PackagesSatisfying(PackageSpecifier packageSpecifier)
         {
-            if (!string.IsNullOrWhiteSpace(packageSpecifier.Version.PreRelease))
+            if (!string.IsNullOrWhiteSpace(packageSpecifier.Version.PreRelease) || packageSpecifier.Version.MatchBehavior.HasFlag(VersionMatchBehavior.AnyPrerelease))
             {
-                var newPreRelease = packageSpecifier.Version.PreRelease.Split('.')[0];
+                string newPreRelease;
+                if (packageSpecifier.Version.MatchBehavior.HasFlag(VersionMatchBehavior.AnyPrerelease))
+                {
+                    newPreRelease = "alpha";
+                }
+                else
+                {
+                    newPreRelease = packageSpecifier.Version.PreRelease.Split('.')[0];
+                }
+
                 if (!currentPreReleases.TryGetValue(packageSpecifier.Name, out var currentPrerelease) || newPreRelease.CompareTo(currentPrerelease) > 0 )
                 {
                     currentPreReleases[packageSpecifier.Name] = newPreRelease;

--- a/Package/PackageSpecifier.cs
+++ b/Package/PackageSpecifier.cs
@@ -68,12 +68,12 @@ namespace OpenTap.Package
         /// <summary>
         /// The VersionSpecifier that will match any version. VersionSpecifier.Any.IsCompatible always returns true.
         /// </summary>
-        public static readonly VersionSpecifier Any = new VersionSpecifier(null, null, null, null, null, VersionMatchBehavior.Compatible | VersionMatchBehavior.AnyPrerelease);
+        public static readonly VersionSpecifier Any = new VersionSpecifier(null, null, null, null, null,  VersionMatchBehavior.Exact | VersionMatchBehavior.AnyPrerelease);
 
         /// <summary>
         /// The VersionSpecifier that will match any version. VersionSpecifier.Any.IsCompatible always returns true.
         /// </summary>
-        public static readonly VersionSpecifier AnyRelease = new VersionSpecifier(null, null, null, null, null, VersionMatchBehavior.Compatible);
+        public static readonly VersionSpecifier AnyRelease = new VersionSpecifier(null, null, null, null, null, VersionMatchBehavior.Exact);
 
         
         /// <summary>


### PR DESCRIPTION
VersionSpecifier.AnyRelease

Now the version match behavior is Exact, which means it will map to any version, but always the newest

Closes #824
Closes #825