### PR TITLE
808 Force Install Version Behavior: Fix

### DIFF
--- a/Package/PackageSpecifier.cs
+++ b/Package/PackageSpecifier.cs
@@ -17,8 +17,12 @@ namespace OpenTap.Package
     public class PackageSpecifier
     {
         /// <summary> Gets a readable string for this package specifier. </summary>
-        public override string ToString() => $"[{Name} ({Version})]";
-        
+        public override string ToString()
+        {
+            var versionString = Version == VersionSpecifier.AnyRelease ? "Any Release" : Version.ToString();
+            return $"[{Name} ({versionString})]";
+        }
+
         /// <summary>
         /// Search for parameters that specifies a range of packages in the OpenTAP package system. Unset parameters will be treated as 'any'.
         /// </summary>
@@ -194,7 +198,7 @@ namespace OpenTap.Package
             if (this == VersionSpecifier.Any)
                 return "Any";
             if (this == VersionSpecifier.AnyRelease)
-                return "Any Release";
+                return "";
 
             var formatter = versionFormatter.Value;
             formatter.Clear();

--- a/Package/Repositories/HttpPackageRepository.cs
+++ b/Package/Repositories/HttpPackageRepository.cs
@@ -621,7 +621,7 @@ namespace OpenTap.Package
 
             if (!string.IsNullOrWhiteSpace(package.Name)) endpoint = "/GetPackage/" + Uri.EscapeDataString(package.Name);
 
-            if (!string.IsNullOrEmpty(package.Version.ToString()))
+            if (package.Version != VersionSpecifier.AnyRelease)
                 reqs.Add(string.Format("version={0}", Uri.EscapeDataString(package.Version.ToString())));
             if (!string.IsNullOrWhiteSpace(package.OS))
                 reqs.Add(string.Format("os={0}", Uri.EscapeDataString(package.OS)));


### PR DESCRIPTION
- Reverted so that AnyRelease.ToString() => "". Previously an empty version meant AnyRelease and some code might still use this convension.
- Also Made a more explicit check for 'AnyRelease in HttpPackageRepository'

Close #808