### PR TITLE
838 AllowAsChildAttributes Break Change Fix

### DIFF
--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 9.19.0
+version = 9.19.1
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.

--- a/Engine.UnitTests/AllowChildTest.cs
+++ b/Engine.UnitTests/AllowChildTest.cs
@@ -1,0 +1,81 @@
+using NUnit.Framework;
+using OpenTap.Plugins.BasicSteps;
+
+namespace OpenTap.Engine.UnitTests
+{
+    [TestFixture]
+    public class AllowChildTest
+    {
+        
+        private class BaseAutomationStep : TestStep
+        {
+            public override void Run()
+            {
+            }
+        }
+
+        [AllowAsChildIn(typeof(BaseAutomationStep))]
+        private class AutomationStep : BaseAutomationStep
+        {
+        }
+
+        [AllowAsChildIn(typeof(BaseAutomationStep))]
+        [AllowAnyChild]
+        private class LoopStep : BaseAutomationStep
+        {
+        }
+
+        [Test]
+        public void TestAllowChildren()
+        {
+            LoopStep step = new LoopStep();
+            step.ChildTestSteps.Add(new AutomationStep());
+        }
+
+        [Test]
+        public void TestGuid()
+        {
+            var a = new DelayStep();
+            var b = new DelayStep();
+            Assert.AreNotEqual(a.Id, b.Id);
+        }
+
+        public interface IBaseParentStep : ITestStep
+        {
+            
+        }
+        
+        [AllowChildrenOfType(typeof(DelayStep))]
+        private class BaseParentStep : TestStep, IBaseParentStep
+        {
+            public override void Run() {  }
+        }
+
+        class InheritedParentStep : BaseParentStep
+        {
+            
+        }
+        
+        [AllowAsChildIn(typeof(IBaseParentStep))]
+        
+        public class InsideInterfaceStep : TestStep
+        {
+            public override void Run() { }
+        }
+        public class InsideInterfaceStep2 : InsideInterfaceStep
+        {
+            
+        }
+
+        [Test]
+        public void TestInterfaceParentStep()
+        {
+            var parent = new InheritedParentStep();
+            var child = new InsideInterfaceStep2();
+            
+            // this should not throw exceptions:
+            parent.ChildTestSteps.Add(child);
+            parent.ChildTestSteps.Add(new DelayStep());
+        }
+    }
+}

--- a/Engine.UnitTests/Tap.Engine.UnitTests.csproj
+++ b/Engine.UnitTests/Tap.Engine.UnitTests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Engine.UnitTests/TestStepTest.cs
+++ b/Engine.UnitTests/TestStepTest.cs
@@ -459,44 +459,6 @@ namespace OpenTap.Engine.UnitTests
     }
 
     [TestFixture]
-    public class AllowChildTest
-    {
-        
-        private class BaseAutomationStep : TestStep
-        {
-            public override void Run()
-            {
-            }
-        }
-
-        [AllowAsChildIn(typeof(BaseAutomationStep))]
-        private class AutomationStep : BaseAutomationStep
-        {
-        }
-
-        [AllowAsChildIn(typeof(BaseAutomationStep))]
-        [AllowAnyChild]
-        private class LoopStep : BaseAutomationStep
-        {
-        }
-
-        [Test]
-        public void TestAllowChildren()
-        {
-            LoopStep step = new LoopStep();
-            step.ChildTestSteps.Add(new AutomationStep());
-        }
-
-        [Test]
-        public void TestGuid()
-        {
-            var a = new DelayStep();
-            var b = new DelayStep();
-            Assert.AreNotEqual(a.Id, b.Id);
-        }
-    }
-
-    [TestFixture]
     public class BasicTestStepTests
     {
         public class FunkyArrayStep : TestStep

--- a/Engine/Reflection/ReflectionDataExtensions.cs
+++ b/Engine/Reflection/ReflectionDataExtensions.cs
@@ -56,6 +56,46 @@ namespace OpenTap
             return false;
         }
 
+        internal static bool HasAttributeInherited<T>(this IReflectionData mem) where T : class
+        {
+            if (mem is ITypeData td)
+            {
+                while (td != null)
+                {
+                    if (td.HasAttribute<T>()) return true;
+                    td = td.BaseType;
+                }
+
+                return false;
+            }
+
+            throw new ArgumentException("Inherited attributes can only be read from type data instances.");
+        }
+        
+        internal static IEnumerable<T> GetAttributesInherited<T>(this IReflectionData mem) where T : class
+        {
+            if (mem is ITypeData td)
+            {
+                IEnumerable<T> result = null;
+                while (td != null)
+                {
+                    var r = td.Attributes?.OfType<T>();
+                    if (r?.Any() == true)
+                    {
+                        if(result != null)
+                            result = result.Concat(r);
+                        else result = r;
+                    }
+
+                    td = td.BaseType;
+                }
+
+                return result ?? Array.Empty<T>();
+            }
+
+            throw new ArgumentException("Inherited attributes can only be read from type data instances.");
+        }
+
         /// <summary>
         /// Returns true if a reflection ifno has an attribute of type T.
         /// </summary>

--- a/Engine/TestStepList.cs
+++ b/Engine/TestStepList.cs
@@ -182,8 +182,8 @@ namespace OpenTap
             if (childType == null)
                 throw new ArgumentNullException(nameof(childType));
             // if the parent is a TestPlan or the parent specifies "AllowAnyChild", then OK
-            bool parentAllowsAnyChild = parentType.HasAttribute<AllowAnyChildAttribute>();
-            bool isChildIn = childType.HasAttribute<AllowAsChildInAttribute>();
+            bool parentAllowsAnyChild = parentType.HasAttributeInherited<AllowAnyChildAttribute>();
+            bool isChildIn = childType.HasAttributeInherited<AllowAsChildInAttribute>();
             if (parentAllowsAnyChild)
             {
                 if (!isChildIn)
@@ -195,7 +195,7 @@ namespace OpenTap
             if (isChildIn)
             {
                 // if the child specifies the parent type or the parent ancestor type in a "AllowAsChildIn" attribute, then OK
-                var childIn = childType.GetAttributes<AllowAsChildInAttribute>();
+                var childIn = childType.GetAttributesInherited<AllowAsChildInAttribute>();
                 foreach (AllowAsChildInAttribute attribute in childIn)
                 {
                     if (parentType.DescendsTo(attribute.ParentStepType))
@@ -204,7 +204,7 @@ namespace OpenTap
             }
 
             // if the parent specifies the childType or a base type of childType in an "AllowChildrenOfType" attribute, then OK
-            var child = parentType.GetAttributes<AllowChildrenOfTypeAttribute>();
+            var child = parentType.GetAttributesInherited<AllowChildrenOfTypeAttribute>();
             foreach (AllowChildrenOfTypeAttribute attribute in child)
             {
                 if (childType.DescendsTo(attribute.RequiredInterface))


### PR DESCRIPTION
- Moved AllowChildTest to a separate file and added new tests verifying the fix.
- Added explicitly pulling inherited attributes to TEstPlanList.AllowAsChild.

Close #838 