### PR TITLE
835 Compatible Sort Bug: fix

### DIFF
--- a/Package/Image/ImageResolver.cs
+++ b/Package/Image/ImageResolver.cs
@@ -193,6 +193,8 @@ namespace OpenTap.Package
             for (int i = 0; i < allVersions.Count; i++)
             {
                 var pkg = packages[i];
+                // skip the following if there is less than two versions.
+                if (allVersions[i].Length <= 1) continue;
                 var versions = allVersions[i].ToList();
                 
                 if (pkg.Version == VersionSpecifier.Any)

--- a/Package/PackageSpecifier.cs
+++ b/Package/PackageSpecifier.cs
@@ -422,6 +422,13 @@ namespace OpenTap.Package
             
             public int Compare(SemanticVersion a, SemanticVersion b)
             {
+                // If pre-releases are not wanted, put them at the very last.
+                if (pkg.PreRelease == null && (a.PreRelease != null || b.PreRelease != null))
+                {
+                    if (a.PreRelease == null && b.PreRelease != null) return -1;
+                    if (a.PreRelease != null && b.PreRelease == null) return 1;
+                }
+                
                 if (pkg.Major.HasValue)
                 {
                     var m = a.Major.CompareTo(b.Major);
@@ -432,12 +439,13 @@ namespace OpenTap.Package
                     var m = a.Minor.CompareTo(b.Minor);
                     if (m != 0) return m;
                 }
+                
                 if (pkg.Patch.HasValue)
                 {
                     var m = a.Patch.CompareTo(b.Patch);
                     if (m != 0) return m;
                 }
-                
+
                 if (a.PreRelease == b.PreRelease) return 0;
                 if (a.PreRelease == null && b.PreRelease != null) return 1;
                 if (a.PreRelease != null && b.PreRelease == null) return -1;


### PR DESCRIPTION
Fixed the problem by changing the sort order for compatible but not-prerelease version specifiers.

Close #835 