### PR TITLE
835 Compatible sort bug fix 2:

### DIFF
--- a/Package.UnitTests/Image/DependencyGraphTest.cs
+++ b/Package.UnitTests/Image/DependencyGraphTest.cs
@@ -102,6 +102,7 @@ namespace OpenTap.Image.Tests
             yield return ("OpenTAP; TUI, beta", "OpenTAP, 9.18.4;TUI, 0.1.0-beta.145+6c192a43");
             yield return ("OpenTAP; REST-API; CSV", "CSV, 9.11.0+98498e58;Keysight Licensing, 1.1.1+7a2a1fe3;OpenTAP, 9.18.4+7dec4717;REST-API, 2.9.1+e5319b91");
             yield return ("TEST-A", "TEST-A, 1.0.0; TEST-B,1.0.0;TEST-C,1.0.0");
+            yield return ("OpenTAP, ^9.14", "OpenTAP, 9.14.0");
             // requesting a bet, but the newest is actually a release. The release versions should then be resolved.
             yield return ("Developer's System, beta", "CSV, 9.11.0+98498e58;Developer's System, 9.17.2-beta.12+a3f06537;" +
                                                       "Editor, 9.17.2-beta.12+a3f06537;Keysight Licensing, 1.1.0-rc.3+fc48665d;" +

--- a/Package/Image/PackageDependencyCache.cs
+++ b/Package/Image/PackageDependencyCache.cs
@@ -89,7 +89,9 @@ namespace OpenTap.Package
                     var sw = Stopwatch.StartNew();
                     var graph = new PackageDependencyGraph();
                     var packages = fpkg.GetAllPackages(TapThread.Current.AbortToken);
-                    graph.LoadFromPackageDefs(packages.Where(x => x.IsPlatformCompatible(deploymentInstallationArchitecture, os)));
+                    graph.LoadFromPackageDefs(packages.Where(x => x.IsPlatformCompatible(
+                        deploymentInstallationArchitecture,
+                        os)));
                     
                     log.Debug(sw, "Read {1} packages from {0}", repo, packages.Length);
                     

--- a/Package/PackageDefinitionSerializerPlugin.cs
+++ b/Package/PackageDefinitionSerializerPlugin.cs
@@ -237,7 +237,7 @@ namespace OpenTap.Package
                     semver.Patch,
                     semver.PreRelease,
                     semver.BuildMetadata, 
-                    VersionMatchBehavior.Compatible | VersionMatchBehavior.AnyPrerelease);
+                    VersionMatchBehavior.Compatible);
             }
             // For compatability (pre 9.0 packages may not have correctly formatted version numbers)
             var plugins = PluginManager.GetPlugins<IVersionTryConverter>().Concat(PluginManager.GetPlugins<IVersionConverter>());


### PR DESCRIPTION
Tried to fix the issue by not loading compatible specifiers ad AnyPreRelease.