### PR TITLE
856 Disallow Parameterizing Swept Property: Fix

### DIFF
--- a/BasicSteps/SweepParameterStepBase.cs
+++ b/BasicSteps/SweepParameterStepBase.cs
@@ -41,6 +41,7 @@ namespace OpenTap.Plugins.BasicSteps
     {
         internal IEnumerable<ParameterMemberData> SweepProperties => TypeData.GetTypeData(this)
             .GetMembers().OfType<ParameterMemberData>()
+            .Where(p =>  p.IsParameterized(this) == false)
             .Where(x => x.HasAttribute<UnsweepableAttribute>() == false && x.Writable && x.Readable);
 
         internal IEnumerable<ParameterMemberData> SelectedMembers =>

--- a/Engine.UnitTests/ScopeParametersTest.cs
+++ b/Engine.UnitTests/ScopeParametersTest.cs
@@ -326,6 +326,12 @@ namespace OpenTap.UnitTests
                 parameterize = icons[name].First();
                 Assert.IsFalse(parameterize.GetAll<IEnabledAnnotation>().Any(x => x.IsEnabled == false));
             }
+
+            // Now parameterize it (sweep -> sequence step).
+            icons[IconNames.ParameterizeOnParent].First().Get<IMethodAnnotation>().Invoke();
+            
+            // It should not be possible to select a parameterized property to be swept.
+            Assert.IsTrue(!sweep.AvailableParameters.Any());
         }
 
         [Test]

--- a/Engine.UnitTests/ScopeParametersTest.cs
+++ b/Engine.UnitTests/ScopeParametersTest.cs
@@ -287,6 +287,46 @@ namespace OpenTap.UnitTests
                 Assert.AreEqual(20, param.Value);
             }
         }
+        
+        [Test]
+        public void SweepLoopRange4Test()
+        {
+            var plan = new TestPlan();
+            var sweep = new SweepParameterRangeStep();
+            var seq = new SequenceStep();
+            var delay = new DelayStep();
+            plan.ChildTestSteps.Add(seq);
+            seq.ChildTestSteps.Add(sweep);
+            sweep.ChildTestSteps.Add(delay);
+            
+            var a = AnnotationCollection.Annotate(delay).GetMember(nameof(delay.DelaySecs));
+            var menu = a.Get<MenuAnnotation>();
+            var icons = menu.MenuItems.ToLookup(x => x.Get<IIconAnnotation>()?.IconName ?? "");
+            var parameterize = icons[IconNames.ParameterizeOnParent].First();
+            parameterize.Get<IMethodAnnotation>().Invoke();
+            
+            a = AnnotationCollection.Annotate(sweep).GetMember("Parameters \\ Time Delay");
+            menu = a.Get<MenuAnnotation>();
+            icons = menu.MenuItems.ToLookup(x => x.Get<IIconAnnotation>()?.IconName ?? "");
+            
+            // It should not be possible to parameterize (parameterized) properties which are selected for sweeping.
+            var names = new [] {IconNames.ParameterizeOnTestPlan, IconNames.Parameterize, IconNames.ParameterizeOnParent };
+            foreach (var name in names)
+            {
+                parameterize = icons[name].First();
+                Assert.IsTrue(parameterize.GetAll<IEnabledAnnotation>().Any(x => x.IsEnabled == false));
+            }
+
+            sweep.SelectedParameters.Clear();
+            a.Read();
+            
+            // It should be possible to parameterize (parameterized) properties which are not selected for sweeping.
+            foreach (var name in names)
+            {
+                parameterize = icons[name].First();
+                Assert.IsFalse(parameterize.GetAll<IEnabledAnnotation>().Any(x => x.IsEnabled == false));
+            }
+        }
 
         [Test]
         public void SweepLoop2Test()

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -65,6 +65,10 @@ namespace OpenTap
             }
             return null;
         }
+
+        /// <summary> Returns true if a member is parameters </summary>
+        public static bool IsParameterized(this IMemberData member, object source) =>
+            DynamicMember.IsParameterized(member, source);
     }
 
     /// <summary>

--- a/Engine/MenuAnnotation.cs
+++ b/Engine/MenuAnnotation.cs
@@ -153,9 +153,12 @@ namespace OpenTap
         bool Enabled { get; }
     }
 
-    internal interface ITestStepMenuModel
+    /// <summary> Menu models for test step properties. </summary>
+    public interface ITestStepMenuModel
     {
+        /// <summary> The selected test steps. </summary>
         ITestStepParent[] Source { get; }
+        /// <summary> Selected Member </summary>
         IMemberData Member { get; }
     }
 


### PR DESCRIPTION
- Fixed the issue by adding an (IEnabledAnnotation) annotation when the correct pattern is detected.
- Added a unit test to verify the behavior.


![image](https://user-images.githubusercontent.com/24250062/193557695-e220e819-2105-48f5-8f32-686ee572decd.png)
