### PR TITLE
858 improve error message for invalid version specs

### DIFF
--- a/Package/PackageActions/Create.cs
+++ b/Package/PackageActions/Create.cs
@@ -106,6 +106,12 @@ namespace OpenTap.Package
                 {
                     var fullpath = Path.GetFullPath(PackageXmlFile);
                     pkg = PackageDefExt.FromInputXml(fullpath, ProjectDir);
+                    if (pkg.Version == null)
+                    {
+                        log.Error(
+                            $"The specified version '{pkg.RawVersion}' is not a valid semantic version. See https://semver.org");
+                        return (int)PackageExitCodes.InvalidPackageDefinition;
+                    }
 
                     // Check if package name has invalid characters or is not a valid path
                     var illegalCharacter = pkg.Name.IndexOfAny(IllegalPackageNameChars);


### PR DESCRIPTION
When a package has an invalid version specifier, we now fail immediately after parsing during package create.

Closes #858