### PR TITLE
864 mimic pre-9.19 URI behavior when BaseAddress is not set

### DIFF
--- a/Package.UnitTests/PackageManagerTests.cs
+++ b/Package.UnitTests/PackageManagerTests.cs
@@ -493,7 +493,7 @@ namespace OpenTap.Package.UnitTests
         [TestCase("", "http://packages.opentap.io", typeof(HttpPackageRepository))]  // Http scheme
         [TestCase("", "https://packages.opentap.io", typeof(HttpPackageRepository))] // Https scheme
         [TestCase("", "ftp://packages.opentap.io", typeof(NotSupportedException))]   // Unsupported scheme
-        [TestCase("", "something illigal|", typeof(ArgumentException))]              // Illigal chars
+        [TestCase("", "something illegal|", typeof(NotSupportedException))]          // Illegal chars
         [TestCase("", "C:/a", typeof(FilePackageRepository))]                        // Windows absolute path
         [TestCase("", "/a/b", typeof(FilePackageRepository))]                        // Linux absolute path
         [TestCase("", "a/b", typeof(FilePackageRepository))]                         // Relative path
@@ -502,6 +502,9 @@ namespace OpenTap.Package.UnitTests
         [TestCase("", "file:///a", typeof(FilePackageRepository))]                   // Explicit file scheme
         [TestCase("", "file:///C:/a", typeof(FilePackageRepository))]                // Explicit absolute File Path
         [TestCase("", @"\\a\b", typeof(FilePackageRepository))]                      // UNC path
+        [TestCase("", "packages.opentap.io", typeof(HttpPackageRepository))]         // No scheme, top level domain
+        [TestCase("", "my-repo.com", typeof(HttpPackageRepository))]                 // No scheme, top level domain
+        [TestCase("", ".my.file.repo.", typeof(FilePackageRepository))]              // File path with periods
         [TestCase("http://opentap.io", "http://packages.opentap.io", typeof(HttpPackageRepository))]  // Http scheme
         [TestCase("http://opentap.io", "https://packages.opentap.io", typeof(HttpPackageRepository))] // Https scheme
         [TestCase("http://opentap.io", "C:/a", typeof(FilePackageRepository))]                        // Windows absolute path
@@ -527,8 +530,7 @@ namespace OpenTap.Package.UnitTests
             {
                 if (expectedRepositoryType == ex.GetType())
                     return;
-                else
-                    throw;
+                throw;
             }
         }
 

--- a/Package/IPackageRepository.cs
+++ b/Package/IPackageRepository.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -262,16 +263,45 @@ namespace OpenTap.Package
                             throw new NotSupportedException($"Scheme {uri.Scheme} is not supported as a package repository ({url}).");
                     }
                 }
-                else
+
+                if (AuthenticationSettings.Current.BaseAddress != null)
+                    return DetermineRepositoryType(new Uri(new Uri(AuthenticationSettings.Current.BaseAddress), url).AbsoluteUri);
+                    
+                // This is a relative URI, and it's scheme cannot be determined. The best we can do is guess.
+                // If the path contains any invalid path chars, it cannot be a file repository
+                // Trailing slashes don't matter. Simplify the logic by stripping them
+                url = url.TrimEnd('/');
+                var canBeFile = Path.GetInvalidPathChars().Any(url.Contains) == false;
+                if (canBeFile)
                 {
-                    if (AuthenticationSettings.Current.BaseAddress != null)
-                        return DetermineRepositoryType(new Uri(new Uri(AuthenticationSettings.Current.BaseAddress), url).AbsoluteUri);
-                    else
-                        return new FilePackageRepository(Path.GetFullPath(url)); // GetFullPath throws ArgumentException if url contains illigal path chars
+                    try
+                    {
+                        // GetFullPath detects issues not detected by GetInvalidPathChars
+                        _ = Path.GetFullPath(url);
+                    }
+                    catch
+                    {
+                        canBeFile = false;
+                    }
                 }
+
+                var canBeUrl = Uri.IsWellFormedUriString("https://" + url, UriKind.Absolute);
+                if (canBeFile && canBeUrl)
+                {
+                    // The URI is ambiguous. Assume it is a http repository if it ends with something that looks like a top-level domain
+                    var segments = url.Split('.');
+                    var topLevel = segments.LastOrDefault();
+                    if (segments.Count() > 1 && !string.IsNullOrWhiteSpace(topLevel))
+                    {
+                        canBeFile = false;
+                    }
+                }
+                
+                if (canBeFile) return new FilePackageRepository(Path.GetFullPath(url));
+                if (canBeUrl) return new HttpPackageRepository("http://" + url);
             }
-            else
-                throw new NotSupportedException($"Unable to determine repository type of '{url}'. Try specifying a scheme using 'http://' or 'file:///'.");
+
+            throw new NotSupportedException($"Unable to determine repository type of '{url}'. Try specifying a scheme using 'http://' or 'file:///'.");
         }
 
         static Dictionary<string, IPackageRepository> registeredRepositories = new Dictionary<string, IPackageRepository>();

--- a/Package/IPackageRepository.cs
+++ b/Package/IPackageRepository.cs
@@ -296,6 +296,8 @@ namespace OpenTap.Package
                         canBeFile = false;
                     }
                 }
+
+                log.Warning($"Repository '{url}' is ambiguous. It will be interpreted as a {(canBeFile ? "directory" : "http repository")}. Please specify a URI scheme if this is not correct.");
                 
                 if (canBeFile) return new FilePackageRepository(Path.GetFullPath(url));
                 if (canBeUrl) return new HttpPackageRepository("http://" + url);


### PR DESCRIPTION
This fixes some behavior changes introduced by 9.19, such as not being able to list packages using `tap package list -r packages.opentap.io` due to the way relative URIs are resolved.

Closes #864