### PR TITLE
performance improvements 2

### DIFF
--- a/Engine.UnitTests/TestStepTest.cs
+++ b/Engine.UnitTests/TestStepTest.cs
@@ -390,7 +390,7 @@ namespace OpenTap.Engine.UnitTests
         {
 
             Param1 = 5;
-            var param = ResultParameters.GetParams(this);
+            var param = ResultParameters.GetParams(this, null);
             var dict = param.ToDictionary();
             Assert.IsTrue((double)dict["Param1"] == Param1);
             Assert.IsTrue(dict.ContainsKey("sub/Index"));

--- a/Engine/ComponentSettingsContext.cs
+++ b/Engine/ComponentSettingsContext.cs
@@ -22,7 +22,7 @@ namespace OpenTap
 
         public ComponentSettingsContext()
         {
-            objectCache = new Memorizer<Type, ComponentSettings>(Load);
+            objectCache = new Memorizer<Type, ComponentSettings>(Load, false);
         }
 
         string settingsDirectoryRoot = Path.Combine(ExecutorClient.ExeDir, "Settings");

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -559,13 +559,19 @@ namespace OpenTap
 
                 return dynamicMembers ?? EmptyDictionary<string, IMemberData>.Instance;
             }
-            
+
+            IMemberData[] members;
             public IEnumerable<IMemberData> GetMembers()
             {
                 var dynamicMembers = getDynamicMembers();
                 var members = BaseType.GetMembers();
                 if (dynamicMembers.Count > 0)
-                    members = members.Concat(dynamicMembers.Values);
+                {
+                    if(this.members?.Length != dynamicMembers.Count + members.Count())
+                        this.members = members.Concat(dynamicMembers.Values).ToArray();
+                    members = this.members;
+                }
+
                 return members;
             }
 

--- a/Engine/EngineSettings.cs
+++ b/Engine/EngineSettings.cs
@@ -131,6 +131,10 @@ namespace OpenTap
             get { return Environment.GetEnvironmentVariable("STARTUP_DIR"); }
             set { Environment.SetEnvironmentVariable("STARTUP_DIR", value); }
         }
+        ///<summary> Reduces some of the most occurring logging when running a test plan. </summary>
+        [Display("Reduce Logging", Group: "Optimization",
+            Description: "Reduces some of the most occurring logging when running a test plan.")]
+        public bool ReduceLogging { get; set; }
 
         /// <summary>
         /// 

--- a/Engine/IStringConvertProvider.cs
+++ b/Engine/IStringConvertProvider.cs
@@ -53,7 +53,10 @@ namespace OpenTap
             {
                 var derivedTypes = TypeData.GetDerivedTypes<T>();
 
-                int count = derivedTypes.Count(x => x.CanCreateInstance);
+                int count = 0;
+                foreach(var x in derivedTypes)
+                    if (x.CanCreateInstance)
+                        count++;
                 
                 if (count != saveTypes.Count)
                 {

--- a/Engine/Invokable/Invokable.cs
+++ b/Engine/Invokable/Invokable.cs
@@ -4,7 +4,7 @@ namespace OpenTap
 {
     /// <summary> Action(T) IInvokable. </summary>
     /// <typeparam name="T"></typeparam>
-    class Invokable<T> : IInvokable<T>
+    readonly struct Invokable<T> : IInvokable<T>
     {
         readonly Action<T> action;
         public Invokable(Action<T> action) => this.action = action;
@@ -14,12 +14,13 @@ namespace OpenTap
         /// <summary> Add an ignored argument. </summary>
         public Invokable<T, T2> AddArg<T2>()
         {
-            return new Invokable<T, T2>((a1, a2) => action(a1));
+            var action2 = action;
+            return new Invokable<T, T2>((a1, a2) => action2(a1));
         }
     }
     
     /// <summary> Action(T) IInvokable. </summary>
-    class Invokable<T, T2> : IInvokable<T,T2>
+    readonly struct Invokable<T, T2> : IInvokable<T,T2>
     {
         readonly Action<T,T2> action;
         public Invokable(Action<T,T2> action) => this.action = action;

--- a/Engine/NumberParser.cs
+++ b/Engine/NumberParser.cs
@@ -766,15 +766,6 @@ namespace OpenTap
             return false;
         }
 
-        [ThreadStatic] static StringBuilder stringBuilder;
-
-        StringBuilder getStringBuilder()
-        {
-            var sb =stringBuilder ?? (stringBuilder = new StringBuilder());
-            sb.Clear();
-            return sb;
-        }
-        
         /// <summary>
         /// Parses a sequence of numbers back into a string.
         /// </summary>
@@ -789,7 +780,7 @@ namespace OpenTap
                 var seqs = values as _ICombinedNumberSequence;
                 if (seqs != null)
                 {
-                    StringBuilder sb = getStringBuilder();
+                    StringBuilder sb = StringBuilderCache.GetStringBuilder();
                     foreach (var subseq in seqs.Sequences)
                     {
                         var range = subseq as Range;
@@ -814,7 +805,7 @@ namespace OpenTap
             }
             if (UseRanges)
             { // Parse the slow way.
-                StringBuilder sb = getStringBuilder();
+                StringBuilder sb = StringBuilderCache.GetStringBuilder();
                 List<BigFloat> sequence = new List<BigFloat>();
                 BigFloat seq_step = 0;
                 foreach (var _val in values)
@@ -855,7 +846,7 @@ namespace OpenTap
             if (!UsePrefix)
             {
                 // this ca be done really fast since we dont have to use BigFloat.
-                var sb = getStringBuilder();
+                var sb = StringBuilderCache.GetStringBuilder();
                 foreach (var _val in values)
                 {
                     if (sb.Length != 0)
@@ -887,7 +878,7 @@ namespace OpenTap
             }
             
             {
-                StringBuilder sb = getStringBuilder();
+                StringBuilder sb = StringBuilderCache.GetStringBuilder();
                 foreach (var _val in values)
                 {
                     var val = BigFloat.Convert(_val);
@@ -897,6 +888,17 @@ namespace OpenTap
                     parseBackNumber(val, sb);
                 }
                 return sb.ToString();
+            }
+        }
+        class StringBuilderCache
+        {
+            [ThreadStatic] static StringBuilder stringBuilder;
+
+            static public StringBuilder GetStringBuilder()
+            {
+                var sb = stringBuilder ?? (stringBuilder = new StringBuilder());
+                sb.Clear();
+                return sb;
             }
         }
     }

--- a/Engine/Reflection/TypeDataProviderStack.cs
+++ b/Engine/Reflection/TypeDataProviderStack.cs
@@ -122,8 +122,9 @@ namespace OpenTap
             var providers1 = TypeData.FromType(typeof(IStackedTypeDataProvider)).DerivedTypes;
             var providers2 = TypeData.FromType(typeof(ITypeDataProvider)).DerivedTypes;
 
-            int l1 = providers1.Count();
-            int l2 = providers2.Count();
+            
+            int l1 = providers1 is ICollection<TypeData> _p1 ? _p1.Count : providers1.Count();
+            int l2 = providers2 is ICollection<TypeData> _p2 ? _p2.Count : providers2.Count();
 
             if (lastCount == l1 + l2) return providersCache;
 

--- a/Engine/ResourceDependencyAnalyzer.cs
+++ b/Engine/ResourceDependencyAnalyzer.cs
@@ -100,9 +100,9 @@ namespace OpenTap
             return new ResourceDep(behavior, o, pi);
         }
 
-        ResourceDep[] getManyResources<T>(T[] steps)
+        ResourceDep[] getManyResources<T>(ICollection<T> steps)
         {
-            if (steps.Length == 0)
+            if (steps.Count == 0)
                 return Array.Empty<ResourceDep>();
 
             var result = new HashSet<ResourceDep>();
@@ -261,7 +261,7 @@ namespace OpenTap
         /// Finds all IResource properties on a list of references. The references can be any class derived from ITapPlugin, such as ITestStep or IResource.
         /// If a reference supplied in the <paramref name="references"/> list is a IResource itself it will be added to the resulting list.
         /// </summary>
-        internal List<ResourceNode> GetAllResources(object[] references, out bool errorDetected)
+        internal List<ResourceNode> GetAllResources(ICollection<object> references, out bool errorDetected)
         {
             errorDetected = false;
 
@@ -334,11 +334,13 @@ namespace OpenTap
                     if (nodeRepresentingResource != null)
                         nodeRepresentingResource.References.Add(new ResourceReference(r, prop));
                     return nodeRepresentingResource;
-                }, new HashSet<ResourceNode>());
+                }, new HashSet<ResourceNode>(), targetType: _resourceType ??= TypeData.FromType(typeof(IResource)));
             }
 
             return tree;
         }
+
+        TypeData _resourceType;
     }
 }
 

--- a/Engine/ResultListener.cs
+++ b/Engine/ResultListener.cs
@@ -546,11 +546,11 @@ namespace OpenTap
             return lst.ToArray();
         }
         
-        private static void GetPropertiesFromObject(object obj, ICollection<ResultParameter> output, string namePrefix = "", bool metadataOnly = false)
+        private static void GetPropertiesFromObject(object obj, ICollection<ResultParameter> output, string namePrefix = "", bool metadataOnly = false, ITypeData type = null)
         {
             if (obj == null)
                 return;
-            var type = TypeData.GetTypeData(obj);
+            type ??= TypeData.GetTypeData(obj);
             foreach (var (prop, group, name, metadata) in GetParametersMap(type))
             {
                 if (metadataOnly && metadata == null) continue;
@@ -561,11 +561,11 @@ namespace OpenTap
             }
         }
 
-        internal static void UpdateParams(ResultParameters parameters, object obj, string namePrefix = "")
+        internal static void UpdateParams(ResultParameters parameters, object obj, string namePrefix = "", ITypeData type = null)
         {
             if (obj == null)
                 return;
-            var type = TypeData.GetTypeData(obj);
+            type ??= TypeData.GetTypeData(obj);
             var p = GetParametersMap(type);
             foreach (var (prop, group, _name, metadata) in p)
             {
@@ -590,19 +590,21 @@ namespace OpenTap
 
         internal void Overwrite(string name, IConvertible value, string group, MetaDataAttribute metadata)
         {
-           Add(group, name, value, metadata);
+            if (object.Equals(Find(name, group)?.Value, value))
+                return;
+            Add(group, name, value, metadata);
         }
 
         /// <summary>
         /// Returns a <see cref="ResultParameters"/> list with one entry for every setting of the inputted 
         /// TestStep.
         /// </summary>
-        internal static ResultParameters GetParams(ITestStep step)
+        internal static ResultParameters GetParams(ITestStep step, ITypeData stepType)
         {
             if (step == null)
                 throw new ArgumentNullException(nameof(step));
             var parameters = new List<ResultParameter>(5);
-            GetPropertiesFromObject(step, parameters);
+            GetPropertiesFromObject(step, parameters, type: stepType);
             
             if (parameters.Count == 0)
                 return new ResultParameters();

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -15,7 +15,7 @@ namespace OpenTap
 {
     partial class TestPlan
     {
-        bool runPrePlanRunMethods(IEnumerable<ITestStep> steps, TestPlanRun planRun)
+        bool runPrePlanRunMethods(IList<ITestStep> steps, TestPlanRun planRun)
         {
             Stopwatch preTimer = Stopwatch.StartNew(); // try to avoid calling Stopwatch.StartNew too often.
             TimeSpan elaps = preTimer.Elapsed;

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -540,7 +540,11 @@ namespace OpenTap
 
             var allSteps = Utils.FlattenHeirarchy(steps, step => step.ChildTestSteps);
             var allEnabledSteps = Utils.FlattenHeirarchy(steps.Where(x => x.Enabled), step => step.GetEnabledChildSteps());
-
+            foreach (var step in allEnabledSteps)
+            {
+                if (step is ITestPlanRunCache cache)
+                    cache.Load();
+            }
             var enabledSinks = new HashSet<IResultSink>();
             TestStepExtensions.GetObjectSettings<IResultSink, ITestStep, IResultSink>(allEnabledSteps, true, null, enabledSinks);
             if(enabledSinks.Count > 0)
@@ -674,7 +678,11 @@ namespace OpenTap
 
                 // Clean all test steps StepRun, otherwise the next test plan execution will be stuck at TestStep.DoRun at steps that does not have a cleared StepRun.
                 foreach (var step in allSteps)
+                {
                     step.StepRun = null;
+                    if (step is ITestPlanRunCache cache)
+                        cache.Clear();
+                }
 
                 executingPlanRun.LocalValue = prevExecutingPlanRun;
                 CurrentRun = prevExecutingPlanRun;

--- a/Engine/TypeData.cs
+++ b/Engine/TypeData.cs
@@ -480,9 +480,12 @@ namespace OpenTap
         public static ITypeData GetTypeData(object obj)
         {
             if (obj == null) return NullTypeData.Instance;
+            if (obj is ITestPlanRunCache c && c.Type is { } td2)
+                return td2;
             var cache = TypeDataCache.Current;
             if (cache != null && cache.TryGetValue(obj, out var cachedValue))
                 return cachedValue;
+            
             checkCacheValidity();
             var resolver = new TypeDataProviderStack();
             var result = resolver.GetTypeData(obj);


### PR DESCRIPTION
Mostly these are focused around reducing GC overhead.

- Added option to reduce logging using EngineSettings
- Invokabe class turned into struct
- Made TestStep.Results lazy, so that it is only created if the step actually needs result processing.
- TestStepRun now keeps a field with the step type to avoid getting it later.

Measurements:

Two images installed into each folders:
```
tap.exe image install -t ./test "OpenTAP:9.19.1,OpenTap.Benchmark:beta"
tap.exe image install -t ./test2 "OpenTAP:9.19.1-alpha.6.1+de732a16.pull-874-merge,OpenTap.Benchmark:beta"
```
Without optimizations: 
```
Time spent per iteration: 4.59 ms (σ: 0.69 ms)
Benchmark completed 1000 iterations in 00:00:05.1020834
Time spent per iteration: 4.57 ms (σ: 0.66 ms)
Benchmark completed 1000 iterations in 00:00:04.9561905
Time spent per iteration: 4.55 ms (σ: 0.59 ms)
Benchmark completed 1000 iterations in 00:00:04.9333377
```

With Optimizations and logging

```
Time spent per iteration: 4.2 ms (σ: 0.45 ms)
Benchmark completed 1000 iterations in 00:00:04.5623400

Time spent per iteration: 4.35 ms (σ: 0.45 ms)
Benchmark completed 1000 iterations in 00:00:04.6975976

Time spent per iteration: 4.23 ms (σ: 0.44 ms)
Benchmark completed 1000 iterations in 00:00:04.6370493
```

With reduced logging:

```
Time spent per iteration: 3.1 ms (σ: 0.33 ms)
Benchmark completed 1000 iterations in 00:00:03.2975280
Time spent per iteration: 3.14 ms (σ: 0.33 ms)
Benchmark completed 1000 iterations in 00:00:03.3215842
Time spent per iteration: 3.09 ms (σ: 0.31 ms)
```

Update 2: After further improvements (commit 2)
```
Time spent per iteration: 2.24 ms (σ: 0.26 ms)
Benchmark completed 1000 iterations in 00:00:02.3327779
Time spent per iteration: 2.13 ms (σ: 0.24 ms)
Benchmark completed 1000 iterations in 00:00:02.2252589
Time spent per iteration: 2.17 ms (σ: 0.25 ms)
Benchmark completed 1000 iterations in 00:00:02.2431797
```
