### PR TITLE
876 Uninstall Delete Retry: added delete retry

### DIFF
--- a/Package/PluginInstaller.cs
+++ b/Package/PluginInstaller.cs
@@ -602,6 +602,7 @@ namespace OpenTap.Package
                 result = ActionResult.Error;
             }
 
+            int totalDeleteRetries = 0;
             bool ignore(string filename) => filename.ToLower() == "tap" || filename.ToLower() == "tap.exe" || filename.ToLower() == "tap.dll";
             foreach (var file in package.Files)
             {
@@ -632,10 +633,12 @@ namespace OpenTap.Package
                     {
                         if (ex is UnauthorizedAccessException || ex is IOException)
                         {
+                            if (totalDeleteRetries >= 10) throw ex;
+                            totalDeleteRetries++;
                             // File.Delete might throw either exception depending on if it is a
                             // program _or_ a file in use.
                             
-                            log.Warning("Unable to delete file '{0}' file might be in use. retrying ({1} of {2}) in 500ms.", file.RelativeDestinationPath, i + 1, 5);
+                            log.Warning("Unable to delete file '{0}' file might be in use. Retrying {1} of {2} in 1 second.", file.RelativeDestinationPath, totalDeleteRetries, 5, totalDeleteRetries);
                             TapThread.Sleep(1000);
                         }
                         else throw ex;

--- a/Shared/FileSystemHelper.cs
+++ b/Shared/FileSystemHelper.cs
@@ -56,6 +56,22 @@ namespace OpenTap
             }
         }
 
+        public static void SafeDelete(string file, int retries, Action<int, Exception> onError)
+        {
+            for(int i = 0; i < retries; i++)
+            {
+                try
+                {
+                    File.Delete(file);
+                    break;
+                }
+                catch(Exception e)
+                {
+                    onError(i, e);
+                }
+            }
+        }
+
         /// <summary>
         /// Creates a directory if it does not already exist.
         /// </summary>


### PR DESCRIPTION
…in used during install

In some unlikely cases, it seems like the file can be in use while uninstalling. The root cause for this was never found and it only happens intermittently on some PCs. Since it is probably an AV issue or such, let's retry and give the user a chance to close the document or application.

Closes #876