### PR TITLE
884 Allow Setting Package Cache: Fix

### DIFF
--- a/Package/PackageCacheHelper.cs
+++ b/Package/PackageCacheHelper.cs
@@ -18,7 +18,7 @@ namespace OpenTap.Package
         // - Linux: /home/<USER>/.local/share/OpenTAP/PackageCache
         // - Windows: C:\Users\<USER>\AppData\Local\OpenTAP\PackageCache
         //
-        // Unless OPENTAP_PACKAGE_CACHE is set, then that path will be used instead.
+        // Unless OPENTAP_PACKAGE_CACHE_DIR is set, then that path will be used instead.
         public static string PackageCacheDirectory
         {
             get
@@ -30,7 +30,7 @@ namespace OpenTap.Package
             }
         } 
 
-        const string PackageCacheOverrideEnvironmentVariable = "OPENTAP_PACKAGE_CACHE";
+        const string PackageCacheOverrideEnvironmentVariable = "OPENTAP_PACKAGE_CACHE_DIR";
         
         readonly static TraceSource log =  Log.CreateSource("PackageCache");
 

--- a/Package/PackageCacheHelper.cs
+++ b/Package/PackageCacheHelper.cs
@@ -17,7 +17,21 @@ namespace OpenTap.Package
         // Resolves to:
         // - Linux: /home/<USER>/.local/share/OpenTAP/PackageCache
         // - Windows: C:\Users\<USER>\AppData\Local\OpenTAP\PackageCache
-        public static string PackageCacheDirectory { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTap", "PackageCache");
+        //
+        // Unless OPENTAP_PACKAGE_CACHE is set, then that path will be used instead.
+        public static string PackageCacheDirectory
+        {
+            get
+            {
+                var alt = Environment.GetEnvironmentVariable(PackageCacheOverrideEnvironmentVariable);
+                if (string.IsNullOrWhiteSpace(alt) == false)
+                    return alt;
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "OpenTap", "PackageCache");
+            }
+        } 
+
+        const string PackageCacheOverrideEnvironmentVariable = "OPENTAP_PACKAGE_CACHE";
+        
         readonly static TraceSource log =  Log.CreateSource("PackageCache");
 
         static PackageCacheHelper()


### PR DESCRIPTION
Added support for setting the environment OPENTAP_PACKAGE_CACHE, which affects the package cache location.

Tested it by setting it and calling "tap package install" and everything seems to work.