### PR TITLE
Fix resolver issues

### DIFF
--- a/Package/Image/ImageResolver.cs
+++ b/Package/Image/ImageResolver.cs
@@ -183,23 +183,29 @@ namespace OpenTap.Package
                 bool allExact = allVersions.All(x => x.Length  == 1);
                 if (allExact)
                 {
-                    foreach (var pkg in packages)
-                    {
-                        if (!pkg.Version.TryAsExactSemanticVersion(out var semver))
-                            throw new InvalidOperationException();
-                        var deps = graph.GetDependencies(pkg.Name, semver);
-                        foreach (var dep in deps)
+                    {   // now double check that all packages has their dependencies included in the resolved image.
+                        // under rare circumstances this is not the case and we need to re-run the resolution
+                        // to add those dependencies.
+                        foreach (var pkg in packages)
                         {
-                            var satisfied = packages.Any(x => x.Name == dep.Name);
-                            if (!satisfied)
+                            if (!pkg.Version.TryAsExactSemanticVersion(out var semver))
+                                // this should never happen.
+                                throw new InvalidOperationException("An unexact package version was resolved.");
+                            var deps = graph.GetDependencies(pkg.Name, semver);
+                            foreach (var dep in deps)
                             {
-                                // all packages has only one specific version, but there are still unresolved dependencies.
-                                return ResolveImage(new ImageSpecifier(packages.ToList()){FixedPackages = image.FixedPackages}, graph);
+                                var satisfied = packages.Any(x => x.Name == dep.Name);
+                                if (!satisfied)
+                                {
+                                    // all packages has only one specific version, but there are still unresolved dependencies.
+                                    // this will be fixed in the next iteration, when dependencies are added.
+                                    return ResolveImage(
+                                        new ImageSpecifier(packages.ToList()) { FixedPackages = image.FixedPackages },
+                                        graph);
+                                }
                             }
                         }
                     }
-                    
-                    
                     // this is the final case.
                     return new ImageResolution(packages.ToArray(), Iterations);
                 }

--- a/Package/Image/ImageResolver.cs
+++ b/Package/Image/ImageResolver.cs
@@ -183,6 +183,23 @@ namespace OpenTap.Package
                 bool allExact = allVersions.All(x => x.Length  == 1);
                 if (allExact)
                 {
+                    foreach (var pkg in packages)
+                    {
+                        if (!pkg.Version.TryAsExactSemanticVersion(out var semver))
+                            throw new InvalidOperationException();
+                        var deps = graph.GetDependencies(pkg.Name, semver);
+                        foreach (var dep in deps)
+                        {
+                            var satisfied = packages.Any(x => x.Name == dep.Name);
+                            if (!satisfied)
+                            {
+                                // all packages has only one specific version, but there are still unresolved dependencies.
+                                return ResolveImage(new ImageSpecifier(packages.ToList()){FixedPackages = image.FixedPackages}, graph);
+                            }
+                        }
+                    }
+                    
+                    
                     // this is the final case.
                     return new ImageResolution(packages.ToArray(), Iterations);
                 }

--- a/Package/Image/ImageSpecifier.cs
+++ b/Package/Image/ImageSpecifier.cs
@@ -102,7 +102,11 @@ namespace OpenTap.Package
         /// <exception cref="ImageResolveException">The exception thrown if the image could not be resolved</exception>
         public ImageIdentifier Resolve(CancellationToken cancellationToken)
         {
-            List<IPackageRepository> repositories = Repositories.Distinct().Select(PackageRepositoryHelpers.DetermineRepositoryType).GroupBy(p => p.Url).Select(g => g.First()).ToList();
+            List<IPackageRepository> repositories = Repositories.Distinct()
+                .Select(PackageRepositoryHelpers.DetermineRepositoryType)
+                .GroupBy(p => p.Url)
+                .Select(g => g.First())
+                .ToList();
 
             var cache = new PackageDependencyCache(OS, Architecture, Repositories);
             cache.LoadFromRepositories();
@@ -120,7 +124,6 @@ namespace OpenTap.Package
                         x2.Name == dep.Name && dep.Version.IsSatisfiedBy(x2.Version.AsExactSpecifier())))).ToArray();
                 if (unsatisfiedDependencies.Any())
                 {
-                    var packagesString = string.Join(",", image.Packages.Select(x => $"{x.Name}:{x.Version}"));
                     var unsatisfiedString = string.Join(" and ", unsatisfiedDependencies.Select(x =>
                     {
                         var missingDeps = x.Dependencies.Where(dep => !InstalledPackages.Any(x2 =>
@@ -129,7 +132,7 @@ namespace OpenTap.Package
                         return $"{x.Name} missing {missingMsg}";
                     }));
                     throw new ImageResolveException(image,
-                        $"Unable to resolve the packages: {packagesString}. This is probably due to: {unsatisfiedString}."
+                        $"Unable to resolve the packages: {this}. This is probably due to: {unsatisfiedString}."
                        );
                 }
                 throw new ImageResolveException(image);


### PR DESCRIPTION
Close #892


Now, when running the test build, 'Keg' gets installed:
```
2>/builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : warning OpenTAP Install: PackageRepository : Repository '/builds/Rolf/testbuildthing/ClassLibrary1/../References' is ambiguous. It will be interpreted as a directory. Please specify a URI scheme if this is not correct.
141      2>/builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : warning OpenTAP Install: PackageRepository : Repository '/builds/Rolf/testbuildthing/ClassLibrary1/../References' is ambiguous. It will be interpreted as a directory. Please specify a URI scheme if this is not correct.
[142](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L142)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : Modifying installation in bin/Release/netstandard2.0/:
[143](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L143)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : - Skipping OpenTAP version 9.19.3-alpha.7.1+49fa9a09.pull-890-merge (x64-Linux,MacOS) - Already installed.
[144](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L144)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : - Installing Keg version 0.1.0-beta.17+cd0310b9
[145](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L145)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : - Installing Keysight Licensing version 1.3.0-beta.7+81fbef21
[146](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L146)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : - Installing License Injector version 9.9.0-alpha.1.3+4f36805b.noLicensePlus
[147](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L147)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : - Installing Sign version 1.3.1-alpha.2.1+24d9f5f8.sdkEasySigh
[148](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L148)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : Downloading Keg version 0.1.0-beta.17+cd0310b9 from https://packages.opentap.keysight.com
[149](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L149)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : Downloading Keysight Licensing version 1.3.0-beta.7+81fbef21 from https://packages.opentap.io
[150](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L150) Downloading [==============================] (100.00% | 3.97 MB of 3.97 MB)   
[151](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L151)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : Downloading Sign version 1.3.1-alpha.2.1+24d9f5f8.sdkEasySigh from https://packages.opentap.keysight.com
[152](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L152)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: OpenTAP : Downloading License Injector version 9.9.0-alpha.1.3+4f36805b.noLicensePlus from https://packages.opentap.keysight.com
[153](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L153)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: Installer : Installing /root/.local/share/OpenTap/PackageCache/Keg.0.1.0-beta.17+cd0310b9.Windows,Linux.TapPackage
[154](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L154)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: Installer : Installed Keg version 0.1.0-beta.17+cd0310b9 [62.7 ms]
[155](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L155)      2>/builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : warning OpenTAP Install: Installer : Package 'Keg' contains possibly relevant plugins for next package installations, but these will not be loaded.
[156](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L156)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: Installer : Installing /root/.local/share/OpenTap/PackageCache/Keysight Licensing.1.3.0-beta.7+81fbef21.x64.Linux.TapPackage
[157](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L157)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: Installer : Installed Keysight Licensing version 1.3.0-beta.7+81fbef21 [729 ms]
[158](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L158)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: Installer : Installing /root/.local/share/OpenTap/PackageCache/Sign.1.3.1-alpha.2.1+24d9f5f8.sdkEasySigh.Windows,Linux.TapPackage
[159](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L159)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: Installer : Installed Sign version 1.3.1-alpha.2.1+24d9f5f8.sdkEasySigh [9.65 ms]
[160](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L160)      2>/builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : warning OpenTAP Install: Installer : Package 'Sign' contains possibly relevant plugins for next package installations, but these will not be loaded.
[161](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L161)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: Installer : Installing /root/.local/share/OpenTap/PackageCache/License Injector.9.9.0-alpha.1.3+4f36805b.noLicensePlus.Windows,Linux.TapPackage
[162](http://gitlab.it.keysight.com/Rolf/testbuildthing/-/jobs/1053146#L162)        /builds/Rolf/testbuildthing/ClassLibrary1/ClassLibrary1.csproj : message OpenTAP Install: Installer : Installed License Injector version 9.9.0-alpha.1.3+4f36805b.noLicensePlus [5.89 ms]
```