### PR TITLE
Improve Log Output On Install Failure

### DIFF
--- a/Engine/Cli/ExitCodes.cs
+++ b/Engine/Cli/ExitCodes.cs
@@ -17,40 +17,53 @@ namespace OpenTap.Cli
         /// </summary>
         [Display("Success", "Action completed successfully")]
         Success = 0,
+
         /// <summary>
         /// User cancelled CLI action
         /// </summary>
         [Display("User Cancelled", "Action cancelled by user")]
         UserCancelled = 192,
+
         /// <summary>
         /// CLI action threw an unhandled exception
         /// </summary>
         [Display("General Error", "An unhandled exception occurred")]
         GeneralException = 193,
+
         /// <summary>
         /// No CLI action found matching commands
         /// </summary>
         [Display("Unknown Action", "Found no CLI action matching command")]
         UnknownCliAction = 194,
+
         /// <summary>
         /// CLI action missing a license
         /// </summary>
         [Display("LicenseError", "A required license is missing")]
         LicenseError = 195,
+
         /// <summary>
         /// Unable to parse one or more arguments
         /// </summary>
         [Display("Argument Parse Error", "Unable to parse one or more arguments")]
         ArgumentParseError = 196,
+
         /// <summary>
         /// One or more arguments is incorrect
         /// </summary>
         [Display("Argument Error", "One or more arguments are incorrect")]
         ArgumentError = 197,
+
         /// <summary>
         /// Network error occurred
         /// </summary>
         [Display("Network Error", "A network error occurred")]
         NetworkError = 198,
+
+        /// <summary>
+        /// Package resolution Error
+        /// </summary>
+        [Display("Package Resolution Error", "A package configuration was not able to be resolved.")]
+        PackageResolutionError = 199
     }
 }

--- a/Package.UnitTests/CliTests.cs
+++ b/Package.UnitTests/CliTests.cs
@@ -553,7 +553,7 @@ namespace OpenTap.Package.UnitTests
                 int exitCode;
                 string output = RunPackageCli("install Dummy2", out exitCode);
                 Assert.AreNotEqual(0, exitCode, "Unexpected exit code");
-                StringAssert.Contains("Unable to resolve Dummy2", output);
+                StringAssert.Contains("Could not resolve Dummy2", output);
             }
             finally
             {

--- a/Package.UnitTests/CliTests.cs
+++ b/Package.UnitTests/CliTests.cs
@@ -553,7 +553,7 @@ namespace OpenTap.Package.UnitTests
                 int exitCode;
                 string output = RunPackageCli("install Dummy2", out exitCode);
                 Assert.AreNotEqual(0, exitCode, "Unexpected exit code");
-                StringAssert.Contains("Unable to resolve image", output);
+                StringAssert.Contains("Unable to resolve Dummy2", output);
             }
             finally
             {

--- a/Package/Image/ImageSpecifier.cs
+++ b/Package/Image/ImageSpecifier.cs
@@ -132,10 +132,12 @@ namespace OpenTap.Package
                         return $"{x.Name} missing {missingMsg}";
                     }));
                     throw new ImageResolveException(image,
-                        $"Unable to resolve the packages: {this}. This is probably due to: {unsatisfiedString}."
+                        $"Unable to resolve the packages: {this}. This is probably due to: {unsatisfiedString}.",
+                        this,
+                        InstalledPackages
                        );
                 }
-                throw new ImageResolveException(image);
+                throw new ImageResolveException(image, image.ToString(), this, InstalledPackages);
             }
             
             log.Debug(sw, "Resolved image: {0}", this);
@@ -216,18 +218,29 @@ namespace OpenTap.Package
     /// </summary>
     public class ImageResolveException : AggregateException
     {
+        internal readonly ImageSpecifier Image;
+        internal ImmutableArray<PackageDef> InstalledPackages = ImmutableArray<PackageDef>.Empty;
+
         internal ImageResolveException(string dotGraph, string message, List<Exception> dependencyIssues) : base(message, dependencyIssues)
         {
             DotGraph = dotGraph;
         }
         internal ImageResolveException(ImageResolution result) : base(result.ToString())
         {
-            this.Result = result;
+            Result = result;
         }
         
         internal ImageResolveException(ImageResolution result, string message) : base(message)
         {
-            this.Result = result;
+            Result = result;
+        }
+        
+        internal ImageResolveException(ImageResolution result, string message, ImageSpecifier image,
+            ImmutableArray<PackageDef> installedPackages) : base(message)
+        {
+            Result = result;
+            Image = image;
+            InstalledPackages = installedPackages;
         }
 
         internal ImageResolution Result;

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -383,7 +383,7 @@ namespace OpenTap.Package
                 }
 
                 log.Debug("{0}", ex.Message);
-                return (int) ExitCodes.ArgumentError;
+                return (int) ExitCodes.PackageResolutionError;
             }
             catch (Exception e)
             {

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -18,6 +18,8 @@ namespace OpenTap.Package
     [Display("install", Group: "package", Description: "Install one or more packages.")]
     public class PackageInstallAction : IsolatedPackageAction
     {
+        static readonly TraceSource log = Log.CreateSource("Install");
+        
         [Obsolete("Use Force instead.")]
         public bool ForceInstall { get => Force; set => Force = value; }
 
@@ -341,8 +343,46 @@ namespace OpenTap.Package
             }
             catch (ImageResolveException ex)
             {
-                log.Error("Could not resolve one or more packages.");
-                log.Info("{0}", ex.Message);
+                if (Packages != null && Packages.Length > 0)
+                {
+                    log.Error("Could not resolve {0}{1}", 
+                        string.Join(", ", Packages.Select(x => $"{x}")),
+                        string.IsNullOrWhiteSpace(Version) ? "" : $" v{Version}");    
+                }
+                else
+                {
+                    log.Error("Could not resolve one or more packages.");
+                }
+
+                if (ex.Image != null)
+                {
+                    log.Info("Image configuration:");
+                    foreach (var req in ex.Image.Packages)
+                    {
+                        log.Info($"  {req.Name}: {req.Version}");
+                    }
+                }
+                var unsatisfiedDependencies = ex.InstalledPackages.Where(x => false == x.Dependencies.All(dep =>
+                    ex.InstalledPackages.Any(x2 =>
+                        x2.Name == dep.Name && dep.Version.IsSatisfiedBy(x2.Version.AsExactSpecifier())))).ToArray();
+                if (unsatisfiedDependencies.Any())
+                {
+                    log.Warning("This might be because of the following broken packages:");
+                    
+                    var unsatisfiedStrings =unsatisfiedDependencies.Select(x =>
+                    {
+                        var missingDeps = x.Dependencies.Where(dep => !ex.InstalledPackages.Any(x2 =>
+                            x2.Name == dep.Name && dep.Version.IsSatisfiedBy(x2.Version.AsExactSpecifier())));
+                        string missingMsg = string.Join(" and ", missingDeps.Select(x2 => $"{x2.Name}:{x2.Version}"));
+                        return $"{x.Name} missing {missingMsg}";
+                    });
+                    foreach (var str in unsatisfiedStrings)
+                    {
+                        log.Info("   {0}.", str);
+                    }
+                }
+
+                log.Debug("{0}", ex.Message);
                 return (int) ExitCodes.ArgumentError;
             }
             catch (Exception e)


### PR DESCRIPTION
Added improved log messages when tap package install fails.
- print which package was being installed
- print all the packages in the image
- Print all the packages with broken dependencies (This might be the issue).