### PR TITLE
906 Test Plan License Exception improvements

### DIFF
--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -580,6 +580,8 @@ namespace OpenTap
             public object CreateInstance(object[] arguments) => BaseType.CreateInstance(arguments);
 
             public bool CanCreateInstance => BaseType.CanCreateInstance;
+            
+            public override string ToString() => "*" + BaseType;
 
         }
 
@@ -731,6 +733,9 @@ namespace OpenTap
             }
 
             public bool CanCreateInstance => innerType.CanCreateInstance;
+            
+            public override string ToString() => innerType.ToString();
+            
         }
 
         // memorize for reference equality.

--- a/Engine/SerializerPlugins/TestStepSerializer.cs
+++ b/Engine/SerializerPlugins/TestStepSerializer.cs
@@ -113,15 +113,16 @@ namespace OpenTap.Plugins
                         {
                             setResult(step);
                             FixupStep(step, true);
-                            return true;
                         }
+                        // return true even tough the deserialization failed. 
+                        // since this is a test step being deserialized
+                        // it should always be handled here.
+                        // otherwise the errors will show up twice.
+                        return true;
                     }finally
                     {
                         currentNode.Remove(elem);
                     }
-                    
-                    return false;
-
                 }
             }
             return false;

--- a/Engine/TapSerialization.cs
+++ b/Engine/TapSerialization.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
@@ -74,6 +75,14 @@ namespace OpenTap
         public void PushError(XElement element, string message, Exception e)
         {
             messages.Add(new XmlError( element, message, e));
+        }
+
+        
+        internal void HandleError(XElement element, string message, Exception e)
+        {
+            while (e is TargetInvocationException && e.InnerException != null)
+                e = e.InnerException;
+            PushError(element, $"{message} {e.Message}", e);
         }
         
         /// <summary> Pushes a message. </summary>


### PR DESCRIPTION
Improved the way exceptions are printed when they occur during deserialization by adding a general HandleError method.

Added printing the exception directly in the error and not some generic error message.

Added ToString overloads for TypeData specilizations.