### PR TITLE
915 Unable To Delete Bug: Fix

### DIFF
--- a/Package/PluginInstaller.cs
+++ b/Package/PluginInstaller.cs
@@ -641,6 +641,7 @@ namespace OpenTap.Package
                             // program _or_ a file in use.
                             
                             log.Warning("Unable to delete file '{0}' file might be in use. Retrying {1} of {2} in 1 second.", file.RelativeDestinationPath, totalDeleteRetries, maxRetries, totalDeleteRetries);
+                            log.Debug("Error: {0}", ex.Message);
                             TapThread.Sleep(1000);
                         }
                         else throw ex;

--- a/Shared/FileSystemHelper.cs
+++ b/Shared/FileSystemHelper.cs
@@ -67,6 +67,13 @@ namespace OpenTap
                 }
                 catch(Exception e)
                 {
+                    if (e is DirectoryNotFoundException)
+                    {
+                        // this occurs if the directory of the file being deleted does not exist.
+                        // But if the directory is not found it also means that the file does not exist.
+                        // so we can safely assume it is deleted.
+                        break;
+                    }
                     onError(i, e);
                 }
             }


### PR DESCRIPTION
For unknown reasons, a package can contain the same file multiple times. This is an issue in its own right. When this happens the file will get deleted twice, which causes and exception to occur on the second delete.

Apparantly a File.Delete can throw a DirectoryNotFoundException if the directory of the file being deleted does not exist.

Close #915