### PR TITLE
Build and publish installer for windows and linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -811,15 +811,15 @@ jobs:
           path: .
       - run: mv OpenTAP.*.Linux.TapPackage Installer/Assets/OpenTAP.TapPackage
         name: Rename package
-      - run: tap installer create "opentap.installer.xml" -v --target-os linux
+      - run: tap installer create "opentap.installer.linux.xml" -v --target-os linux
         working-directory: Installer/Assets
         name: Build installer
-      - run: mv Installer/Assets/Installer OpenTAP
+      - run: mv Installer/Assets/Installer Installer/Assets/OpenTAP
       - uses: actions/upload-artifact@v2
         with:
           name: installer-linux
           retention-days: 14
-          path: OpenTAP
+          path: Installer/Assets/OpenTAP
 
   Publish-Installer-Linux:
     if: contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/r') || github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,7 +768,7 @@ jobs:
           path: OpenTAP.*.exe
 
   Publish-Installer-Windows:
-    # if: contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/r') || github.ref == 'refs/heads/main'
+    if: contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/r') || github.ref == 'refs/heads/main'
     environment: packages.opentap.io 
     runs-on: ubuntu-latest 
     needs:
@@ -822,7 +822,7 @@ jobs:
           path: OpenTAP
 
   Publish-Installer-Linux:
-    # if: contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/r') || github.ref == 'refs/heads/main'
+    if: contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/r') || github.ref == 'refs/heads/main'
     environment: packages.opentap.io 
     runs-on: ubuntu-latest 
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -732,18 +732,18 @@ jobs:
           name: installer-linux
           retention-days: 14
           path: OpenTAP.tar
-          
-  Installer-Windows:
+
+  Build-Installer-Windows:
     runs-on: ubuntu-latest
     environment: sign
     needs:
       - GetVersion
       - Package-Win
     container:
-      image: registry.gitlab.com/opentap/buildrunners/smartinstaller:1.1.0-beta.7
+      image: ghcr.io/opentap/smartinstaller:2.0.0-beta.24
       credentials:
-        username: github
-        password: ${{ secrets.GITLAB_REGISTRY_TOKEN}}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -753,13 +753,8 @@ jobs:
           name: win-x64-package
           path: .
       - run: mv OpenTAP.*.Windows.TapPackage Installer/Assets/OpenTAP.TapPackage
-      - run: ls /root/go/bin
-      #- name: Remove certificate
-      #  if: github.ref != 'refs/heads/main' && !contains(github.ref, 'refs/heads/release') && !contains(github.ref, 'refs/tags/v')
-      #  run: sed -i 's/<SignCert>Keysight Technologies, Inc<\/SignCert>/<SignCert><\/SignCert>/' 'opentap.installer.xml'
-      #  working-directory: Installer/Assets
       - run: echo "${{ secrets.SIGN_SERVER_CERT }}" > $GITHUB_WORKSPACE/sign.cer
-      - run: tap installer create "opentap.installer.xml"
+      - run: tap installer create "opentap.installer.xml" -v --target-os win
         working-directory: Installer/Assets
         env:
           TAP_SIGN_ADDRESS: ${{ secrets.TAP_SIGN_ADDRESS }}
@@ -771,6 +766,83 @@ jobs:
           name: installer-windows
           retention-days: 14
           path: OpenTAP.*.exe
+
+  Publish-Installer-Windows:
+    # if: contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/r') || github.ref == 'refs/heads/main'
+    environment: packages.opentap.io 
+    runs-on: ubuntu-latest 
+    needs:
+      - Build-Installer-Windows 
+      - GetVersion
+    steps: 
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: installer-windows
+      - name: Rename Artifact 
+        run: mv OpenTAP.*.exe OpenTAP.exe
+      - name: Upload Installer 
+        env: 
+          REPO_WWW_PASS: ${{ secrets.REPO_WWW_PASS }}
+        run: | 
+          curl -i -X POST 'http://packages.opentap.io/4.0/Objects/www/' \
+               -H 'Metadata-Version: "${{ needs.GetVersion.outputs.LongVersion }}"' \
+               -H 'Metadata-OS: "Windows"' \
+               -H "Auth-Key: $REPO_WWW_PASS" \
+               --form 'file=@"'$(pwd)'/OpenTAP.exe"'
+
+  Build-Installer-Linux:
+    runs-on: ubuntu-latest
+    needs:
+      - GetVersion
+      - Package-Linux
+    container:
+      image: ghcr.io/opentap/smartinstaller:2.0.0-beta.24
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download Linux package
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-x64-package
+          path: .
+      - run: mv OpenTAP.*.Linux.TapPackage Installer/Assets/OpenTAP.TapPackage
+        name: Rename package
+      - run: tap installer create "opentap.installer.xml" -v --target-os linux
+        working-directory: Installer/Assets
+        name: Build installer
+      - run: mv Installer/Assets/Installer OpenTAP
+      - uses: actions/upload-artifact@v2
+        with:
+          name: installer-linux
+          retention-days: 14
+          path: OpenTAP
+
+  Publish-Installer-Linux:
+    # if: contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/r') || github.ref == 'refs/heads/main'
+    environment: packages.opentap.io 
+    runs-on: ubuntu-latest 
+    needs:
+      - Build-Installer-Linux
+      - GetVersion
+    steps: 
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: installer-linux
+      - name: Upload Installer 
+        env: 
+          REPO_WWW_PASS: ${{ secrets.REPO_WWW_PASS }}
+        run: | 
+          curl -i -X POST 'http://packages.opentap.io/4.0/Objects/www/' \
+               -H 'Metadata-Version: "${{ needs.GetVersion.outputs.LongVersion }}"' \
+               -H 'Metadata-OS: "Linux"' \
+               -H "Auth-Key: $REPO_WWW_PASS" \
+               --form 'file=@"'$(pwd)'/OpenTAP"'
+
 
   Test-Installer-Linux:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -740,7 +740,7 @@ jobs:
       - GetVersion
       - Package-Win
     container:
-      image: ghcr.io/opentap/smartinstaller:2.0.0-beta.24
+      image: ghcr.io/opentap/smartinstaller:2.0.0-beta.29
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -797,7 +797,7 @@ jobs:
       - GetVersion
       - Package-Linux
     container:
-      image: ghcr.io/opentap/smartinstaller:2.0.0-beta.24
+      image: ghcr.io/opentap/smartinstaller:2.0.0-beta.29
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/Installer/Assets/opentap.installer.linux.xml
+++ b/Installer/Assets/opentap.installer.linux.xml
@@ -4,7 +4,7 @@
 
   <Name>OpenTAP 9</Name>
 
-  <DefaultInstallDir>OpenTAP</DefaultInstallDir>
+  <DefaultInstallDir>/opt/opentap</DefaultInstallDir>
   <Publisher>Keysight Technologies</Publisher>
   <URL>http://opentap.io</URL>
   <SetupIcon>opentap.ico</SetupIcon>


### PR DESCRIPTION
With this we will be able to always download the latest installer from:

Windows: `https://packages.opentap.io/4.0/Objects/www/OpenTAP.exe(?version=specifier)`
Linux: `https://packages.opentap.io/4.0/Objects/www/OpenTAP(?version=specifier)`