### PR TITLE
947 Resource Adapters: fix

### DIFF
--- a/Engine.UnitTests/AdapterTest.cs
+++ b/Engine.UnitTests/AdapterTest.cs
@@ -1,0 +1,75 @@
+﻿using NUnit.Framework;
+using OpenTap.UnitTests;
+
+namespace OpenTap.Engine.UnitTests
+{
+    public class Instrument0 : Instrument
+    {
+        public virtual double DoMeasurement() => 10.0;
+    }
+
+    public class Instrument1 : Instrument
+    {
+        public virtual double DoMeasurement2() => 20.0;
+    }
+
+    public class Instrument1Step : TestStep
+    {
+        public Instrument1 Instrument { get; set; }
+        public override void Run()
+        {
+            
+        }
+    }
+
+    [Display("Instrument 0 to 1", Group: "Adapters")]
+    public class Instrument0to1Adapter : Instrument1, ITypeAdaptor
+    {
+        public override double DoMeasurement2() => Instrument.DoMeasurement();
+        public Instrument0 Instrument { get; set; }
+
+        public override string ToString() => $"{Instrument} (Adapter)";
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Instrument0to1Adapter other)
+                return other.Instrument == Instrument;
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Instrument?.GetHashCode() ?? 0 + 13214;
+        }
+    }
+    
+    public class AdapterTest
+    {
+        [Test]
+        public void TestBasicAdaptor()
+        {
+            using (Session.Create(SessionOptions.OverlayComponentSettings))
+            {
+                var instr = new Instrument0();
+                InstrumentSettings.Current.Add(instr);
+                var step = new AnnotationTest.InstrumentStep()
+                {
+                    Instrument = new Instrument0to1Adapter
+                    {
+                        Instrument = instr
+                    }
+                };
+                var plan = new TestPlan();
+                plan.Steps.Add(step);
+                var r = plan.Execute();
+                Assert.AreEqual(Verdict.Pass, r.Verdict);
+
+                var str = plan.SerializeToString();
+                var p2 = new TapSerializer().DeserializeFromString(str) as TestPlan;
+                var r0 = p2.Execute();
+                Assert.AreEqual(Verdict.Pass, r0.Verdict);
+
+            }
+        }
+    }
+}

--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -1691,6 +1691,7 @@ namespace OpenTap.UnitTests
             public IInstrument Instrument { get; set; }
             public override void Run()
             {
+                UpgradeVerdict(Verdict.Pass);
             }
         }
 

--- a/Engine.UnitTests/ReflectionHelperTest.cs
+++ b/Engine.UnitTests/ReflectionHelperTest.cs
@@ -43,6 +43,65 @@ namespace OpenTap.Engine.UnitTests
         }
 
         [Test]
+        public void PairWiseTest()
+        {
+            
+            var a = Enumerable.Range(0, 5);
+            var b = Enumerable.Range(1, 6);
+            var p2 = a.Pairwise(b);
+            Assert.AreEqual(5, p2.Count());
+            foreach (var pair in p2)
+            {
+                Assert.IsTrue(pair.Item1 == pair.Item2 - 1);
+            }
+        }
+
+        [Test]
+        public void PermutationsTest()
+        {
+            var source = new [] { new [] { 1, 2 }, new [] { 3, 4, 5 }, new []{6, 7} };
+            var perms = source.Permutations().ToArray();
+            var ordered = perms.OrderBy(x => x[1])
+                .ToArray()
+                .OrderBy(x => x[0])
+                .ToArray();
+            int index = 0;
+            for (int i = 0; i < source[0].Length; i++)
+            {
+                for (int j = 0; j < source[1].Length; j++)
+                {
+                    for (int k = 0; k < source[2].Length; k++)
+                    {
+                        Assert.IsTrue(source[0][i] == ordered[index][0]);
+                        Assert.IsTrue(source[1][j] == ordered[index][1]);
+                        Assert.IsTrue(source[2][k] == ordered[index][2]);
+                        index++;
+                    }
+                }
+            }
+
+            int len = 1;
+            foreach (var array in source)
+                len *= array.Length;
+            Assert.AreEqual(len, perms.Length);
+            
+            // edge case 1: An empty array yields no results.
+            var sourceEdgeCase1 = new [] { new [] { 1, 2 }, new int[] { }, new []{6, 7} };
+            var permsEdgeCase1 = sourceEdgeCase1.Permutations().ToArray();
+            Assert.AreEqual(0, permsEdgeCase1.Length);
+
+            // edge case 2: Nothing yields one empty array.
+            // This is the correct behavior, because there is exactly one valid permutation.
+            // this also makes sense if you try to calculate the number of permutations.
+            var sourceEdgeCase2 = new int[][] {}; 
+            var permsEdgeCase2 = sourceEdgeCase2.Permutations().ToArray();
+            Assert.AreEqual(1, permsEdgeCase2.Length);
+            Assert.AreEqual(0, permsEdgeCase2[0].Length);
+
+
+        }
+
+        [Test]
         public void MemoryMappedApiTest()
         {
             if(OpenTap.OperatingSystem.Current != OpenTap.OperatingSystem.Windows) 

--- a/Engine/ITypeAdaptor.cs
+++ b/Engine/ITypeAdaptor.cs
@@ -1,0 +1,15 @@
+﻿namespace OpenTap
+{
+    /// <summary>
+    /// Marker interface showing that a class is a type adaptor. This means that it can adapt one type to fit another type of object through this class.
+    /// Whether or not the type can be used depends on the properties which it has.
+    ///
+    /// If it adapts a type X to type Y, it should derive or implement Y, while having a property of type X.
+    ///
+    /// To adapt two types X and Z to type Y, it should have two properties of type X and Z.
+    /// </summary>
+    public interface ITypeAdaptor
+    {
+        
+    }
+}

--- a/Shared/ReflectionHelper.cs
+++ b/Shared/ReflectionHelper.cs
@@ -1851,6 +1851,37 @@ namespace OpenTap
             }
         }
 
+        /// <summary>
+        /// Generates all permutations for l[>= index]. The buffer is used to store intermediate results.
+        /// </summary>
+        static IEnumerable<T1[]> PermuteRec<T1>(T1[][] l, int index, T1[] buffer)
+        {
+            if (index >= l.Length)
+                // create a clone of the buffer which has been filled by the previous levels on the stack.
+                yield return buffer.ToArray();
+            else
+            {
+                foreach (var elem in l[index])
+                {
+                    buffer[index] = elem;
+                    
+                    // fill the rest of the array
+                    foreach (var r in PermuteRec(l, index + 1, buffer))
+                        yield return r;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generates all permutations over the supplied input array of arrays.
+        /// Each array in the source contains each possibility for each index in the output.
+        /// </summary>
+        public static IEnumerable<T1[]> Permutations<T1>(this T1[][] source)
+        {
+            T1[] buffer = new T1[source.Length];
+            return PermuteRec(source, 0, buffer);
+        }
+
         public static void Append<T>(ref T[]  array, params T[] appendage)
         {
             int preLen = array.Length;


### PR DESCRIPTION
- Added class ITypeAdaptor, which marks a type as an adaptor type.
- Added Available values annotation to show the available adaptors. This is based on permutations of all valid resources in the member slots of the adaptor.
- Added unit test to verify the behavior.


Closee #947 