### PR TITLE
Fixes to hardened Docker image

### DIFF
--- a/docker/Linux/Dockerfile
+++ b/docker/Linux/Dockerfile
@@ -43,19 +43,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends libunwind8 curl
 ENV PATH="/opt/tap:${PATH}"
 ENV TAP_PATH="/opt/tap"
 
+### Hardened security - will run as non-root user by default 
 FROM production AS production-hardened
 
-# Create non-root system user and group
-ARG USER=opentap UID=101 GROUP=opentap GID=101 DUMMYSHELL=/bin/false
-ARG USERHOME="/home/${USER}"
-RUN groupadd --system --gid=$GID $GROUP && \
-  useradd --system --uid $UID --gid $GID --shell $DUMMYSHELL $USER
+# Create system user and group
+# - set home dir, since OpenTAP expects home dir to maintain cache
+# - no default shell, as user should only run tap
+ARG USER=opentap UID=101 GROUP=opentap GID=101 DUMMYSHELL=/bin/false HOMEDIR=/var/lib/tap
+RUN groupadd --gid=$GID $GROUP && \
+  useradd --uid $UID --gid $GID --shell $DUMMYSHELL --home-dir $HOMEDIR $USER && \
+  install --directory --owner $USER --group $GROUP --mode u=rwx,g=rwx,o= $HOMEDIR
 
+# Set ownership and permissions for OpenTAP installation
 WORKDIR $TAP_PATH
-# Fix ownership and permissions
 RUN chown --recursive "${UID}:${GID}" .
 RUN chmod --recursive u=rwx,g=rwx,o= .
 
 ENTRYPOINT [ "tap" ]
+
+# Create mount point to persist OpenTAP cache across restarts
+VOLUME $HOMEDIR
 
 USER $USER

--- a/docker/Linux/Dockerfile
+++ b/docker/Linux/Dockerfile
@@ -46,10 +46,11 @@ ENV TAP_PATH="/opt/tap"
 ### Hardened security - will run as non-root user by default 
 FROM production AS production-hardened
 
-# Create system user and group
+# Create opentap user and group
 # - set home dir, since OpenTAP expects home dir to maintain cache
 # - no default shell, as user should only run tap
-ARG USER=opentap UID=101 GROUP=opentap GID=101 DUMMYSHELL=/bin/false HOMEDIR=/var/lib/tap
+ARG USER=opentap UID=1001 GROUP=opentap GID=1001 DUMMYSHELL=/bin/false HOMEDIR=/home/opentap
+ARG OPENTAP_CACHE=${HOMEDIR}/share/OpenTap
 RUN groupadd --gid=$GID $GROUP && \
   useradd --uid $UID --gid $GID --shell $DUMMYSHELL --home-dir $HOMEDIR $USER && \
   install --directory --owner $USER --group $GROUP --mode u=rwx,g=rwx,o= $HOMEDIR
@@ -62,6 +63,6 @@ RUN chmod --recursive u=rwx,g=rwx,o= .
 ENTRYPOINT [ "tap" ]
 
 # Create mount point to persist OpenTAP cache across restarts
-VOLUME $HOMEDIR
+VOLUME $OPENTAP_CACHE
 
 USER $USER

--- a/docker/Linux/Dockerfile
+++ b/docker/Linux/Dockerfile
@@ -49,11 +49,13 @@ FROM production AS production-hardened
 # Create opentap user and group
 # - set home dir, since OpenTAP expects home dir to maintain cache
 # - no default shell, as user should only run tap
-ARG USER=opentap UID=1001 GROUP=opentap GID=1001 DUMMYSHELL=/bin/false HOMEDIR=/home/opentap
-ARG OPENTAP_CACHE=${HOMEDIR}/share/OpenTap
+ARG USER=opentap UID=1001 GROUP=opentap GID=1001 DUMMYSHELL=/bin/false
+ARG HOMEDIR=/home/${USER}
+ARG OPENTAP_CACHE=${HOMEDIR}/.local/share/OpenTap
 RUN groupadd --gid=$GID $GROUP && \
   useradd --uid $UID --gid $GID --shell $DUMMYSHELL --home-dir $HOMEDIR $USER && \
-  install --directory --owner $USER --group $GROUP --mode u=rwx,g=rwx,o= $HOMEDIR
+  install --directory --owner $USER --group $GROUP --mode u=rwx,g=rwx,o= $HOMEDIR && \
+  install --directory --owner $USER --group $GROUP --mode u=rwx,g=rwx,o= $OPENTAP_CACHE
 
 # Set ownership and permissions for OpenTAP installation
 WORKDIR $TAP_PATH
@@ -65,4 +67,5 @@ ENTRYPOINT [ "tap" ]
 # Create mount point to persist OpenTAP cache across restarts
 VOLUME $OPENTAP_CACHE
 
-USER $USER
+# Must use $UID as $USER could potentially alias root user
+USER $UID


### PR DESCRIPTION
~~It seems that OpenTAP requires `$HOME` to be set and for that dir to be writeable for the running user.
I've chosen `/var/lib/tap` for this, as it seems to be the convention for system processes.~~

~~Note: It is not enough to set `OPENTAP_PACKAGE_CACHE_DIR`, as the home dir is also used for logs and ID.~~

Fixes include:

- Proper set up of installation and cache dirs
- Set user to UID instead of user name (user name could hide root user)