### PR TITLE
Add PrepareUninstall package action verb

### DIFF
--- a/Package/Image/ImageIdentifier.cs
+++ b/Package/Image/ImageIdentifier.cs
@@ -222,7 +222,12 @@ namespace OpenTap.Package
             newInstaller.DoSleep = false;
 
             newInstaller.PackagePaths.AddRange(orderedPackagesToUninstall.Select(x => (x.PackageSource as XmlPackageDefSource)?.PackageDefFilePath).ToList());
-            int exitCode = newInstaller.RunCommand("uninstall", false, true);
+            
+            int exitCode = newInstaller.RunCommand(Installer.PrepareUninstall, false, false);
+            if (uninstallErrors.Any() || exitCode != 0)
+                throw new AggregateException("Image deployment failed to uninstall existing packages.", uninstallErrors);
+            
+            exitCode = newInstaller.RunCommand(Installer.Uninstall, false, true);
 
             if (uninstallErrors.Any() || exitCode != 0)
                 throw new AggregateException("Image deployment failed to uninstall existing packages.", uninstallErrors);

--- a/Package/Installer.cs
+++ b/Package/Installer.cs
@@ -128,8 +128,13 @@ namespace OpenTap.Package
 
         internal void UninstallThread()
         {
-            RunCommand("uninstall", false, true);
+            RunCommand(PrepareUninstall, false, false);
+            RunCommand(Uninstall, false, true);
         }
+
+        internal const string Uninstall = "uninstall";
+        internal const string PrepareUninstall = "prepareuninstall";
+        internal const string Install = "install";
 
         internal int RunCommand(string command, bool force, bool modifiesPackageFiles)
         {

--- a/Package/PackageActions/Uninstall.cs
+++ b/Package/PackageActions/Uninstall.cs
@@ -84,7 +84,10 @@ namespace OpenTap.Package
                 }
             }
 
-            var status = installer.RunCommand("uninstall", Force, true);
+            var status = installer.RunCommand(Installer.PrepareUninstall, Force, false);
+            if (status == (int) ExitCodes.GeneralException)
+                return (int) PackageExitCodes.PackageUninstallError;
+            status = installer.RunCommand(Installer.Uninstall, Force, true);
             if (status == (int) ExitCodes.GeneralException)
                 return (int) PackageExitCodes.PackageUninstallError;
             return status;

--- a/Package/PluginInstaller.cs
+++ b/Package/PluginInstaller.cs
@@ -96,7 +96,7 @@ namespace OpenTap.Package
 
             foreach (var step in package.PackageActionExtensions)
             {
-                if (step.ActionName != ActionName)
+                if (step.ActionName.Equals(ActionName, StringComparison.OrdinalIgnoreCase) == false)
                     continue;
 
                 var stepName = $"'{step.ExeFile} {step.Arguments}'";
@@ -261,7 +261,7 @@ namespace OpenTap.Package
     {
         static List<ActionExecuter> builtinActions = new List<ActionExecuter>
         {
-            new ActionExecuter{ ActionName = "uninstall", Execute = DoUninstall }
+            new ActionExecuter{ ActionName = Installer.Uninstall, Execute = DoUninstall }
         };
 
         static TraceSource log = OpenTap.Log.CreateSource("package");
@@ -341,7 +341,7 @@ namespace OpenTap.Package
             }
 
             var pi = new PluginInstaller();
-            if (pi.ExecuteAction(package, "install", false, target) == ActionResult.Error)
+            if (pi.ExecuteAction(package, Installer.Install, false, target) == ActionResult.Error)
             {
                 log.Error($"Install package action failed to execute for '{package.Name}'.");
                 tryUninstall(path, package, target);
@@ -555,7 +555,8 @@ namespace OpenTap.Package
         {
             var pi = new PluginInstaller();
 
-            pi.ExecuteAction(package, "uninstall", true, target);
+            pi.ExecuteAction(package, Installer.PrepareUninstall, true, target);
+            pi.ExecuteAction(package, Installer.Uninstall, true, target);
         }
 
         internal ActionResult ExecuteAction(PackageDef package, string actionName, bool force, string target)


### PR DESCRIPTION
adds the PrepareUninstall ActionName to PackageActionExtension. A PrepareUninstall action runs right before uninstalling a package, before OpenTAP checks whether files are in use. This can be used to ensure that files in the installation are released if this is the case.

Closes #957