### PR TITLE
9.19.5-rc.1: Result table optimizer patch

### DIFF
--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 9.19.4
+version = 9.19.5
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.

--- a/Engine.UnitTests/Results2.cs
+++ b/Engine.UnitTests/Results2.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using OpenTap.Plugins.BasicSteps;
+
+namespace OpenTap.UnitTests
+{
+    public class ResultRow
+    {
+        public string ResultName { get; set; }
+        public int ResultValue { get; set; }
+    }
+
+    public class PublishResultsSameValues : TestStep
+    {
+
+        public int Count { get; set; } = 100;
+
+        public override void Run()
+        {
+            var resultValue = new Random().Next();
+            for (var i = 0; i < Count; i++)
+            {
+                Results.Publish(new ResultRow
+                {
+                    ResultName = $"{this.StepRun.TestStepId}",
+                    ResultValue = resultValue
+                });
+            }
+        }
+    }
+    public class PublishResultsSameValues2 : TestStep
+    {
+
+        public int Count { get; set; } = 100;
+        public override void Run()
+        {
+            var rnd = new Random();
+            var resultValue = rnd.Next();
+            var resultValue2 = rnd.NextDouble();
+            
+            for (var i = 0; i < Count; i++)
+                Results.Publish("Test", new List<string> { "X", "Y" }, resultValue, resultValue2);   
+        }
+    }
+
+    [TestFixture]
+    public class Results2
+    {
+        [TestCase(typeof(PublishResultsSameValues))]
+        [TestCase(typeof(PublishResultsSameValues2))]
+        public void TestManyResults(Type stepType)
+        {
+            var record = new RecordAllResultListener();
+            var plan = new TestPlan();
+            var repeat = new RepeatStep { Count = 10 };
+            var parallel = new ParallelStep();
+            
+            plan.ChildTestSteps.Add(repeat);
+
+            var results1 = (TestStep)Activator.CreateInstance(stepType);
+            var results2 = (TestStep)Activator.CreateInstance(stepType);
+            parallel.ChildTestSteps.Add(results1);
+            parallel.ChildTestSteps.Add(results2);
+            
+            repeat.ChildTestSteps.Add(parallel);
+
+            var run = plan.Execute(new IResultListener[] { record });
+            Assert.AreEqual(Verdict.NotSet, run.Verdict);
+            foreach (var table in record.Results)
+            {
+                foreach (var column in table.Columns)
+                {
+                    var distinctCount = column.Data.Cast<object>().Distinct().Count();
+                    Assert.AreEqual(1, distinctCount);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds @rmadsen-ks' Result Table Optimizer fix from https://github.com/opentap/opentap/pull/962 to version 9.19 as a patch release.