### PR TITLE
Fix issue where package.xml file might get corrupted 

### DIFF
--- a/Package/PackageActions/Create.cs
+++ b/Package/PackageActions/Create.cs
@@ -207,7 +207,7 @@ namespace OpenTap.Package
                 {
                     var path = PackageDef.GetDefaultPackageMetadataPath(pkg, Directory.GetCurrentDirectory());
                     Directory.CreateDirectory(Path.GetDirectoryName(path));
-                    using (FileStream fs = new FileStream(path, FileMode.OpenOrCreate))
+                    using (FileStream fs = new FileStream(path, FileMode.Create))
                     {
                         pkg.SaveTo(fs);
                     }


### PR DESCRIPTION
`tap package create --install` would open any existing file and start writing the new content to the beginning. If the file already existed, and had more content than the new content, partial stuff would be left at the end of the file. 