### PR TITLE
Fix bug causing isolation to fail on mac/linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,8 +365,8 @@ jobs:
           chmod +x bin/Release/tap
           # The .pdb files are in use for some reason during `tap package install`
           rm ./bin/Release/*.pdb
-          ./bin/Release/tap package install ./bin/Release/dbg.zip -f
-          bin/Release/tap run tests/regression.TapPlan --verbose --color
+          ./bin/Release/tap package install ./bin/Release/dbg.zip -f --no-isolation
+          ./bin/Release/tap run tests/regression.TapPlan --verbose --color
 
   TestMacPlan:
     runs-on: macos-11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,8 @@ jobs:
       - name: Test
         run: |
           chmod +x bin/Release/tap
+          # The .pdb files are in use for some reason during `tap package install`
+          rm ./bin/Release/*.pdb
           ./bin/Release/tap package install ./bin/Release/dbg.zip -f
           bin/Release/tap run tests/regression.TapPlan --verbose --color
 

--- a/Cli/TapEntry.cs
+++ b/Cli/TapEntry.cs
@@ -85,7 +85,7 @@ namespace OpenTap.Cli
             string arguments = new CommandLineSplit(Environment.CommandLine).Args;
             string message = null;
             
-            using (ExecutorSubProcess subproc = ExecutorSubProcess.Create("tap", arguments))
+            using (ExecutorSubProcess subproc = ExecutorSubProcess.Create(Path.Combine(ExecutorClient.ExeDir, "tap"), arguments))
             {
                 subproc.MessageReceived += (s, msg) =>
                 {


### PR DESCRIPTION
Apparently Process has a slight behavior difference on Unix and Windows.

On Windows, executables in the current working directory will be considered, but on Mac/Linux, only executables in PATH and the working directory set on the StartInfo object will be considered.

This fixes a bug that caused isolation to fail on Linux/Mac if `tap` wasn't started from the `tap` directory.

Closes #960