### PR TITLE
Drop Ubuntu codename suffix from docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -910,7 +910,7 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
           target: ${{ matrix.target }}
-          tag: ${{env.TAG_NAME}}-bionic${{ matrix.tag-suffix }}
+          tag: ${{env.TAG_NAME}}${{ matrix.tag-suffix }}
           path: docker/Linux
 
   Package-Deb:


### PR DESCRIPTION
The codename is not really helpful, and it was incorrect anyway. Let's just remove it. Checking out the docker image `opentapio/opentap:9.20` looks better than `opentapio/opentap:9.20-focal` in my opinion. I don't think most people care that it's based on focal.

Closes #850 