### PR TITLE
Allow arrays to be target of MultiSelect annotations

### DIFF
--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -2212,31 +2212,64 @@ namespace OpenTap.UnitTests
 
         [Test]
         public void TestAddToArrayWithAvailableValues()
-        {
+        {   
             var av = new AvailableValuesArrayUser();
-            var names = new string[] { nameof(av.SelectedListItems), nameof(av.SelectedArrayItems) };
 
-            foreach (var name in names)
-            {
-                var a = AnnotationCollection.Annotate(av);
+            var a = AnnotationCollection.Annotate(av);
+            var selectedItems = a.GetMember(nameof(av.SelectedArrayItems));
 
-                var selectedItems = a.GetMember(name);
+            var availProxy = selectedItems.Get<IAvailableValuesAnnotationProxy>();
+            var multiselect = selectedItems.Get<IMultiSelectAnnotationProxy>();
 
-                var availProxy = selectedItems.Get<IAvailableValuesAnnotationProxy>();
-                var multiselect = selectedItems.Get<IMultiSelectAnnotationProxy>();
-
+            { // Test writing two values
                 multiselect.SelectedValues = availProxy.AvailableValues.Take(2);
-
                 a.Write();
                 a.Read();
+
+                Assert.AreEqual(2, av.SelectedArrayItems.Length);
+                Assert.AreEqual("A", av.SelectedArrayItems[0]);
+                Assert.AreEqual("B", av.SelectedArrayItems[1]);
             }
-            
-            Assert.AreEqual("A", av.SelectedListItems[0]);
-            Assert.AreEqual("B", av.SelectedListItems[1]);
-            
-            
-            Assert.AreEqual("A", av.SelectedArrayItems[0]);
-            Assert.AreEqual("B", av.SelectedArrayItems[1]);
+
+            {
+                multiselect.SelectedValues = availProxy.AvailableValues.Skip(2).Take(1);
+                a.Write();
+                a.Read();
+
+                Assert.AreEqual(1, av.SelectedArrayItems.Length);
+                Assert.AreEqual("C", av.SelectedArrayItems[0]);
+            }
+        }
+
+        [Test]
+        public void TestAddToListWithAvailableValues()
+        {
+            var av = new AvailableValuesArrayUser();
+
+            var a = AnnotationCollection.Annotate(av);
+            var selectedItems = a.GetMember(nameof(av.SelectedListItems));
+
+            var availProxy = selectedItems.Get<IAvailableValuesAnnotationProxy>();
+            var multiselect = selectedItems.Get<IMultiSelectAnnotationProxy>();
+
+            { // Test writing two values
+                multiselect.SelectedValues = availProxy.AvailableValues.Take(2);
+                a.Write();
+                a.Read();
+
+                Assert.AreEqual(2, av.SelectedListItems.Count);
+                Assert.AreEqual("A", av.SelectedListItems[0]);
+                Assert.AreEqual("B", av.SelectedListItems[1]);
+            }
+
+            {
+                multiselect.SelectedValues = availProxy.AvailableValues.Skip(2).Take(1);
+                a.Write();
+                a.Read();
+
+                Assert.AreEqual(1, av.SelectedListItems.Count);
+                Assert.AreEqual("C", av.SelectedListItems[0]);
+            }
         }
     }
 }

--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -2201,74 +2201,150 @@ namespace OpenTap.UnitTests
 
         public class AvailableValuesArrayUser
         {
-            public List<string> AvailableItems { get; set; } = new List<string>() { "A", "B", "C" };
+            #region Test strings
 
-            [AvailableValues(nameof(AvailableItems))]
-            public List<string> SelectedListItems { get; set; } = new List<string>();
+            public List<string> AvailableStrings { get; set; } = new List<string>() { "A", "B", "C" };
 
-            [AvailableValues(nameof(AvailableItems))]
-            public string[] SelectedArrayItems { get; set; } = Array.Empty<string>();
+            [AvailableValues(nameof(AvailableStrings))]
+            public List<string> SelectedStringsList { get; set; } = new List<string>();
+
+            [AvailableValues(nameof(AvailableStrings))]
+            public string[] SelectedStringsArray { get; set; } = Array.Empty<string>();
+
+            #endregion
+
+            #region Test numbers
+
+            public List<int> AvailableNumbers { get; set; } = new List<int>() { 7, 9, 13 };
+
+            [AvailableValues(nameof(AvailableNumbers))]
+            public List<int> SelectedNumbersList { get; set; } = new List<int>();
+
+            [AvailableValues(nameof(AvailableNumbers))]
+            public int[] SelectedNumbersArray { get; set; } = Array.Empty<int>();
+
+            #endregion
         }
 
         [Test]
         public void TestAddToArrayWithAvailableValues()
         {   
-            var av = new AvailableValuesArrayUser();
+            { // Test writing strings
+                var av = new AvailableValuesArrayUser();
+                var a = AnnotationCollection.Annotate(av);
+                var selectedItems = a.GetMember(nameof(av.SelectedStringsArray));
 
-            var a = AnnotationCollection.Annotate(av);
-            var selectedItems = a.GetMember(nameof(av.SelectedArrayItems));
+                var availProxy = selectedItems.Get<IAvailableValuesAnnotationProxy>();
+                var multiselect = selectedItems.Get<IMultiSelectAnnotationProxy>();
 
-            var availProxy = selectedItems.Get<IAvailableValuesAnnotationProxy>();
-            var multiselect = selectedItems.Get<IMultiSelectAnnotationProxy>();
+                {
+                    multiselect.SelectedValues = availProxy.AvailableValues.Take(2);
+                    a.Write();
+                    a.Read();
 
-            { // Test writing two values
-                multiselect.SelectedValues = availProxy.AvailableValues.Take(2);
-                a.Write();
-                a.Read();
+                    Assert.AreEqual(2, av.SelectedStringsArray.Length);
+                    Assert.AreEqual("A", av.SelectedStringsArray[0]);
+                    Assert.AreEqual("B", av.SelectedStringsArray[1]);
+                }
 
-                Assert.AreEqual(2, av.SelectedArrayItems.Length);
-                Assert.AreEqual("A", av.SelectedArrayItems[0]);
-                Assert.AreEqual("B", av.SelectedArrayItems[1]);
+                {
+                    multiselect.SelectedValues = availProxy.AvailableValues.Skip(2).Take(1);
+                    a.Write();
+                    a.Read();
+
+                    Assert.AreEqual(1, av.SelectedStringsArray.Length);
+                    Assert.AreEqual("C", av.SelectedStringsArray[0]);
+                }
             }
 
-            {
-                multiselect.SelectedValues = availProxy.AvailableValues.Skip(2).Take(1);
-                a.Write();
-                a.Read();
+            { // Test writing numbers
+                var av = new AvailableValuesArrayUser();
+                var a = AnnotationCollection.Annotate(av);
+                var selectedItems = a.GetMember(nameof(av.SelectedNumbersArray));
 
-                Assert.AreEqual(1, av.SelectedArrayItems.Length);
-                Assert.AreEqual("C", av.SelectedArrayItems[0]);
+                var availProxy = selectedItems.Get<IAvailableValuesAnnotationProxy>();
+                var multiselect = selectedItems.Get<IMultiSelectAnnotationProxy>();
+
+                {
+                    multiselect.SelectedValues = availProxy.AvailableValues.Take(2);
+                    a.Write();
+                    a.Read();
+
+                    Assert.AreEqual(2, av.SelectedNumbersArray.Length);
+                    Assert.AreEqual(7, av.SelectedNumbersArray[0]);
+                    Assert.AreEqual(9, av.SelectedNumbersArray[1]);
+                }
+
+                {
+                    multiselect.SelectedValues = availProxy.AvailableValues.Skip(2).Take(1);
+                    a.Write();
+                    a.Read();
+
+                    Assert.AreEqual(1, av.SelectedNumbersArray.Length);
+                    Assert.AreEqual(13, av.SelectedNumbersArray[0]);
+                }
             }
         }
 
         [Test]
         public void TestAddToListWithAvailableValues()
         {
-            var av = new AvailableValuesArrayUser();
+            { // Test writing strings
+                var av = new AvailableValuesArrayUser();
 
-            var a = AnnotationCollection.Annotate(av);
-            var selectedItems = a.GetMember(nameof(av.SelectedListItems));
+                var a = AnnotationCollection.Annotate(av);
+                var selectedItems = a.GetMember(nameof(av.SelectedStringsList));
 
-            var availProxy = selectedItems.Get<IAvailableValuesAnnotationProxy>();
-            var multiselect = selectedItems.Get<IMultiSelectAnnotationProxy>();
+                var availProxy = selectedItems.Get<IAvailableValuesAnnotationProxy>();
+                var multiselect = selectedItems.Get<IMultiSelectAnnotationProxy>();
 
-            { // Test writing two values
-                multiselect.SelectedValues = availProxy.AvailableValues.Take(2);
-                a.Write();
-                a.Read();
+                {
+                    // Test writing two values
+                    multiselect.SelectedValues = availProxy.AvailableValues.Take(2);
+                    a.Write();
+                    a.Read();
 
-                Assert.AreEqual(2, av.SelectedListItems.Count);
-                Assert.AreEqual("A", av.SelectedListItems[0]);
-                Assert.AreEqual("B", av.SelectedListItems[1]);
+                    Assert.AreEqual(2, av.SelectedStringsList.Count);
+                    Assert.AreEqual("A", av.SelectedStringsList[0]);
+                    Assert.AreEqual("B", av.SelectedStringsList[1]);
+                }
+
+                {
+                    multiselect.SelectedValues = availProxy.AvailableValues.Skip(2).Take(1);
+                    a.Write();
+                    a.Read();
+
+                    Assert.AreEqual(1, av.SelectedStringsList.Count);
+                    Assert.AreEqual("C", av.SelectedStringsList[0]);
+                }
             }
+            { // Test writing numbers
+                var av = new AvailableValuesArrayUser();
+                var a = AnnotationCollection.Annotate(av);
+                var selectedItems = a.GetMember(nameof(av.SelectedNumbersList));
 
-            {
-                multiselect.SelectedValues = availProxy.AvailableValues.Skip(2).Take(1);
-                a.Write();
-                a.Read();
+                var availProxy = selectedItems.Get<IAvailableValuesAnnotationProxy>();
+                var multiselect = selectedItems.Get<IMultiSelectAnnotationProxy>();
 
-                Assert.AreEqual(1, av.SelectedListItems.Count);
-                Assert.AreEqual("C", av.SelectedListItems[0]);
+                {
+                    // Test writing strings
+                    multiselect.SelectedValues = availProxy.AvailableValues.Take(2);
+                    a.Write();
+                    a.Read();
+
+                    Assert.AreEqual(2, av.SelectedNumbersList.Count);
+                    Assert.AreEqual(7, av.SelectedNumbersList[0]);
+                    Assert.AreEqual(9, av.SelectedNumbersList[1]);
+                }
+
+                {
+                    multiselect.SelectedValues = availProxy.AvailableValues.Skip(2).Take(1);
+                    a.Write();
+                    a.Read();
+
+                    Assert.AreEqual(1, av.SelectedNumbersList.Count);
+                    Assert.AreEqual(13, av.SelectedNumbersList[0]);
+                }
             }
         }
     }

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -58,7 +58,7 @@ namespace OpenTap
     {
         /// <summary> Annotated available values. </summary>
         IEnumerable<AnnotationCollection> AvailableValues { get; }
-        /// <summary> Annotated selected value. Not this should belong to the set of AvailableValues as well.</summary>
+        /// <summary> Annotated selected value. Note this should belong to the set of AvailableValues as well.</summary>
         AnnotationCollection SelectedValue { get; set; }
     }
     /// <summary> Specifies how suggested value proxies are implemented. This class should rarely be implemented. Consider implementing just ISuggestedValuesAnnotation instead.</summary>

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -1812,13 +1812,13 @@ namespace OpenTap
                     {
                         lst2.Clear();
 
-                        if (lst2 is object[] o)
+                        if (lst2.GetType().IsArray)
                         {
                             // If lst2 is an array, resize it to have the exact number of elements required
                             var cnt = Elements.Count();
-                            if (cnt != o.Length)
+                            if (cnt != lst2.Count)
                             {
-                                ResizeGenericArray(ref lst2, Elements.Count());
+                                ResizeGenericArray(ref lst2, cnt);
                                 objValue.Value = lst2;
                             }
                         }


### PR DESCRIPTION
Our BasicCollectionAnnotation writer just assumes a fixed size collection is going to be the correct size. I have added some logic to resize generic arrays. Let's hope it doesn't cause huge issues.

Closes #854 