### PR TITLE
970 search async memory leak fix

### DIFF
--- a/Engine.UnitTests/CacheClassTest.cs
+++ b/Engine.UnitTests/CacheClassTest.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+namespace OpenTap.UnitTests
+{
+    [TestFixture]
+    public class CacheClassTest
+    {
+        [Test]
+        public void TestInvalidationRemoval()
+        {
+            int changeId = 0;
+            for (int j = 0; j < 3; j++)
+            {
+                var cache = new Cache<int, int>(() => changeId);
+                for (int i = 0; i < 100; i++)
+                {
+                    cache.AddValue(i, i + 1);
+                }
+                for (int i = 0; i < 100; i++)
+                {
+                    Assert.IsTrue(cache.TryGetValue(i, out var i2));
+                    Assert.AreEqual(i + 1, i2);
+                }
+                changeId += 1;
+                for (int i = 0; i < 100; i++)
+                {
+                    Assert.IsFalse(cache.TryGetValue(i, out var i2));
+                }
+                Assert.AreEqual(0, cache.Count);
+            }
+        }
+    }
+}

--- a/Shared/Cache.cs
+++ b/Shared/Cache.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Immutable;
+namespace OpenTap
+{
+    /// <summary> Cache class which clears when a certain criteria is met. </summary>
+    internal class Cache<K, V>
+    {
+        // using immutable dictionary to avoid issues with race conditions.
+        // note that for caches data races are not that important.
+        ImmutableDictionary<K, V> dict = ImmutableDictionary<K, V>.Empty;
+        
+        // this function returns an object which is used for checking if the cache should be cleared.
+        readonly Func<object> clearTrigger;
+        
+        // last object returned by clearTrigger.
+        object currentObj;
+
+        ///<summary> The current number of cached elements. </summary> 
+        public int Count
+        {
+            get
+            {
+                CheckClear();
+                return dict.Count;
+            }
+        }
+
+        public Cache(Func<object> clearTrigger)
+        {
+            this.clearTrigger = clearTrigger;
+            currentObj = clearTrigger();
+        }
+        
+        void CheckClear()
+        {
+            var clearCheck = clearTrigger();
+            if (Equals(clearCheck, currentObj) == false)
+            {
+                dict = ImmutableDictionary<K, V>.Empty;
+                currentObj = clearTrigger();
+            }
+        }
+
+        /// <summary> tries getting a value for a key. </summary>
+        public bool TryGetValue(K key, out V value)
+        {
+            CheckClear();
+            return dict.TryGetValue(key, out value);
+        }
+
+        public V AddValue(K key, V value)
+        {
+            dict = dict.Add(key, value);
+            return value;
+        }
+    }
+}

--- a/Shared/Cache.cs
+++ b/Shared/Cache.cs
@@ -50,6 +50,7 @@ namespace OpenTap
 
         public V AddValue(K key, V value)
         {
+            CheckClear();
             dict = dict.Add(key, value);
             return value;
         }

--- a/Shared/Tap.Shared.projitems
+++ b/Shared/Tap.Shared.projitems
@@ -32,5 +32,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)PipeReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SudoHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakHashSet.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Cache.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The formally fixes #970. 

The issue was caused by a concurrent dictionary cache holding on to references to previous ITypeData instances.

Although this should generally not be an issue, this can save a few MBs of memory from time to time.

Another solution could have been to move to conditional weak tables, but they use reference equality instead of object equality which make it a not so great general solution.

Close #970