### PR TITLE
Dont require EULA accept for building SDK Examples

### DIFF
--- a/sdk/Examples/Directory.Build.props
+++ b/sdk/Examples/Directory.Build.props
@@ -9,7 +9,7 @@
 	<PropertyGroup>
 		<!-- This variable is only defined so we can compile locally without replacing GitVersion. 
 		     It will be removed in the build script. -->
-		<GitVersion>9.17.0</GitVersion>
+		<GitVersion>9.19.5</GitVersion>
 	</PropertyGroup>	
 	<PropertyGroup>
 		<!-- Ensure that all projects in this solution use the same version of OpenTAP -->		
@@ -31,6 +31,11 @@
 	<PropertyGroup Condition="'$(OS)'=='Windows_NT'">
 		<IsLinux>False</IsLinux>
 		<IsWindows>True</IsWindows>
+	</PropertyGroup>
+	
+	<PropertyGroup>
+		<DevelopersSystem Condition="'$(Configuration)' == 'Debug CE'">Developer's System CE</DevelopersSystem>
+		<DevelopersSystem Condition="'$(Configuration)' != 'Debug CE'">Developer's System</DevelopersSystem>
 	</PropertyGroup>
 
   <ItemGroup>

--- a/sdk/Examples/ExamplePlugin/ExamplePlugin.csproj
+++ b/sdk/Examples/ExamplePlugin/ExamplePlugin.csproj
@@ -7,6 +7,8 @@
     <!-- If your plugin should be cross platform but does not build in release mode, please verify that all API's you used are available. You might need references or nuget packages for API's that are available in NET framework, but not in NetStandard -->
     <OpenTapPackageDefinitionPath>package.xml</OpenTapPackageDefinitionPath>
     <AssemblyName>OpenTap.Plugins.ExamplePlugin</AssemblyName>
+    <Configurations>Debug;Release;Debug CE</Configurations>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsWindows)'=='True'">

--- a/sdk/Examples/ExamplePlugin/ExamplePlugin.csproj
+++ b/sdk/Examples/ExamplePlugin/ExamplePlugin.csproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsWindows)'=='True'">
-	  <AdditionalOpenTapPackage Include="Developer's System CE" />
+	  <AdditionalOpenTapPackage Include="$(DevelopersSystem)" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalOpenTapPackage Include="TUI" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/Examples/ExamplePlugin/Properties/launchSettings.json
+++ b/sdk/Examples/ExamplePlugin/Properties/launchSettings.json
@@ -1,10 +1,10 @@
 {
   "profiles": {
-    "Editor": {
+    "WPF Editor": {
       "commandName": "Executable",
       "executablePath": "./editor.exe"
     },
-    "TUI": {
+    "Terminal Editor": {
       "commandName": "Executable",
       "executablePath": "./tap.exe",
       "commandLineArgs": "tui"

--- a/sdk/Examples/ExamplePlugin/Properties/launchSettings.json
+++ b/sdk/Examples/ExamplePlugin/Properties/launchSettings.json
@@ -3,6 +3,11 @@
     "Editor": {
       "commandName": "Executable",
       "executablePath": "./editor.exe"
+    },
+    "TUI": {
+      "commandName": "Executable",
+      "executablePath": "./tap.exe",
+      "commandLineArgs": "tui"
     }
   }
 }

--- a/sdk/Examples/Examples.sln
+++ b/sdk/Examples/Examples.sln
@@ -33,6 +33,7 @@ Global
 		Release|Any CPU = Release|Any CPU
 		LinuxDebug|Any CPU = LinuxDebug|Any CPU
 		LinuxRelease|Any CPU = LinuxRelease|Any CPU
+		Debug CE|Any CPU = Debug CE|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8800F7AE-667D-4A38-816C-3D0135703490}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,6 +44,8 @@ Global
 		{8800F7AE-667D-4A38-816C-3D0135703490}.LinuxDebug|Any CPU.Build.0 = Debug|Any CPU
 		{8800F7AE-667D-4A38-816C-3D0135703490}.LinuxRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{8800F7AE-667D-4A38-816C-3D0135703490}.LinuxRelease|Any CPU.Build.0 = Release|Any CPU
+		{8800F7AE-667D-4A38-816C-3D0135703490}.Debug CE|Any CPU.ActiveCfg = Debug CE|Any CPU
+		{8800F7AE-667D-4A38-816C-3D0135703490}.Debug CE|Any CPU.Build.0 = Debug CE|Any CPU
 		{9BD72823-196E-4575-B779-DAF8FA3D17E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9BD72823-196E-4575-B779-DAF8FA3D17E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9BD72823-196E-4575-B779-DAF8FA3D17E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -51,6 +54,8 @@ Global
 		{9BD72823-196E-4575-B779-DAF8FA3D17E9}.LinuxDebug|Any CPU.Build.0 = Debug|Any CPU
 		{9BD72823-196E-4575-B779-DAF8FA3D17E9}.LinuxRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{9BD72823-196E-4575-B779-DAF8FA3D17E9}.LinuxRelease|Any CPU.Build.0 = Release|Any CPU
+		{9BD72823-196E-4575-B779-DAF8FA3D17E9}.Debug CE|Any CPU.ActiveCfg = Debug CE|Any CPU
+		{9BD72823-196E-4575-B779-DAF8FA3D17E9}.Debug CE|Any CPU.Build.0 = Debug CE|Any CPU
 		{4D4FCE41-556F-4D8A-8DA9-146FB6A15BAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4D4FCE41-556F-4D8A-8DA9-146FB6A15BAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4D4FCE41-556F-4D8A-8DA9-146FB6A15BAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -59,6 +64,8 @@ Global
 		{4D4FCE41-556F-4D8A-8DA9-146FB6A15BAC}.LinuxDebug|Any CPU.Build.0 = Debug|Any CPU
 		{4D4FCE41-556F-4D8A-8DA9-146FB6A15BAC}.LinuxRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{4D4FCE41-556F-4D8A-8DA9-146FB6A15BAC}.LinuxRelease|Any CPU.Build.0 = Release|Any CPU
+		{4D4FCE41-556F-4D8A-8DA9-146FB6A15BAC}.Debug CE|Any CPU.ActiveCfg = Debug CE|Any CPU
+		{4D4FCE41-556F-4D8A-8DA9-146FB6A15BAC}.Debug CE|Any CPU.Build.0 = Debug CE|Any CPU
 		{BCFDAD20-E2DC-4CBA-8817-FA5384427F3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BCFDAD20-E2DC-4CBA-8817-FA5384427F3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BCFDAD20-E2DC-4CBA-8817-FA5384427F3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -67,12 +74,16 @@ Global
 		{BCFDAD20-E2DC-4CBA-8817-FA5384427F3F}.LinuxDebug|Any CPU.Build.0 = Debug|Any CPU
 		{BCFDAD20-E2DC-4CBA-8817-FA5384427F3F}.LinuxRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{BCFDAD20-E2DC-4CBA-8817-FA5384427F3F}.LinuxRelease|Any CPU.Build.0 = Release|Any CPU
+		{BCFDAD20-E2DC-4CBA-8817-FA5384427F3F}.Debug CE|Any CPU.ActiveCfg = Debug CE|Any CPU
+		{BCFDAD20-E2DC-4CBA-8817-FA5384427F3F}.Debug CE|Any CPU.Build.0 = Debug CE|Any CPU
 		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.LinuxDebug|Any CPU.ActiveCfg = Debug|Any CPU
 		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.LinuxRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.Debug CE|Any CPU.ActiveCfg = Debug CE|Any CPU
+		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.Debug CE|Any CPU.Build.0 = Debug CE|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
+++ b/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsWindows)'=='True'">
-	<AdditionalOpenTapPackage Include="Developer's System CE" />
+	<AdditionalOpenTapPackage Include="$(DevelopersSystem)" />
 	<OpenTapPackageReference Include="WPF Controls" />
   </ItemGroup>
 

--- a/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
+++ b/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
@@ -7,6 +7,8 @@
     <!-- If your plugin should be cross platform but does not build in release mode, please verify that all API's you used are available. You might need references or nuget packages for API's that are available in NET framework, but not in NetStandard -->
     <OpenTapPackageDefinitionPath>package.xml</OpenTapPackageDefinitionPath>
     <TargetFramework>net472</TargetFramework>
+    <Configurations>Debug;Release;Debug CE</Configurations>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/Examples/PluginDevelopment.Gui/Properties/launchSettings.json
+++ b/sdk/Examples/PluginDevelopment.Gui/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Editor": {
+    "WPF Editor": {
       "commandName": "Executable",
       "executablePath": "./editor.exe"
     }

--- a/sdk/Examples/PluginDevelopment/PluginDevelopment.csproj
+++ b/sdk/Examples/PluginDevelopment/PluginDevelopment.csproj
@@ -11,7 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsWindows)'=='True'">
-	<AdditionalOpenTapPackage Include="Developer's System CE" />
+	<AdditionalOpenTapPackage Include="$(DevelopersSystem)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalOpenTapPackage Include="TUI" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/Examples/PluginDevelopment/PluginDevelopment.csproj
+++ b/sdk/Examples/PluginDevelopment/PluginDevelopment.csproj
@@ -8,6 +8,8 @@
     <OpenTapPackageDefinitionPath>package.xml</OpenTapPackageDefinitionPath>
     <AssemblyName>OpenTap.Plugins.PluginDevelopment</AssemblyName>
     <RootNamespace>OpenTap.Plugins.PluginDevelopment</RootNamespace>
+    <Configurations>Debug;Release;Debug CE</Configurations>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsWindows)'=='True'">

--- a/sdk/Examples/PluginDevelopment/Properties/launchSettings.json
+++ b/sdk/Examples/PluginDevelopment/Properties/launchSettings.json
@@ -1,10 +1,10 @@
 {
   "profiles": {
-    "Editor": {
+    "WPF Editor": {
       "commandName": "Executable",
       "executablePath": "./editor.exe"
     },
-    "TUI": {
+    "Terminal Editor": {
       "commandName": "Executable",
       "executablePath": "./tap.exe",
       "commandLineArgs": "tui"

--- a/sdk/Examples/PluginDevelopment/Properties/launchSettings.json
+++ b/sdk/Examples/PluginDevelopment/Properties/launchSettings.json
@@ -3,6 +3,11 @@
     "Editor": {
       "commandName": "Executable",
       "executablePath": "./editor.exe"
+    },
+    "TUI": {
+      "commandName": "Executable",
+      "executablePath": "./tap.exe",
+      "commandLineArgs": "tui"
     }
   }
 }

--- a/sdk/Examples/TestPlanExecution/BuildTestPlan.Api/BuildTestPlan.Api.csproj
+++ b/sdk/Examples/TestPlanExecution/BuildTestPlan.Api/BuildTestPlan.Api.csproj
@@ -6,6 +6,8 @@
     <!-- If your plugin is Windows only and you use Windows specific API's, feel free to change "netstandard2.0" below to "net462" and everything will work as when you are debugging. In this case, remember to change "OS" in package.xml to only "windows" -->
     <!-- If your plugin should be cross platform but does not build in release mode, please verify that all API's you used are available. You might need references or nuget packages for API's that are available in NET framework, but not in NetStandard -->
     <OpenTapPackageDefinitionPath>package.xml</OpenTapPackageDefinitionPath>
+    <Configurations>Debug;Release;Debug CE</Configurations>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
   
   <ItemGroup>

--- a/sdk/Examples/TestPlanExecution/RunTestPlan.Api/RunTestPlan.Api.csproj
+++ b/sdk/Examples/TestPlanExecution/RunTestPlan.Api/RunTestPlan.Api.csproj
@@ -6,6 +6,8 @@
     <!-- If your plugin is Windows only and you use Windows specific API's, feel free to change "netstandard2.0" below to "net462" and everything will work as when you are debugging. In this case, remember to change "OS" in package.xml to only "windows" -->
     <!-- If your plugin should be cross platform but does not build in release mode, please verify that all API's you used are available. You might need references or nuget packages for API's that are available in NET framework, but not in NetStandard -->
     <OpenTapPackageDefinitionPath>package.xml</OpenTapPackageDefinitionPath>
+    <Configurations>Debug;Release;Debug CE</Configurations>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Install TUI and add a launchSettings option to run TUI instead of the WPF editor

Make the default configuration install the non-CE version. Add a new configuration which installs the CE version.

Unfortunately, the launchSettings.json format doesn't allow the cross-platform friendly `./tap` to be inferred as `./tap.exe` on Windows, so these launch profiles will not work on Linux.

Closes #848 