### PR TITLE
900 Fix StepSelector when it appears on the testplan itself

### DIFF
--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -2805,7 +2805,7 @@ namespace OpenTap
 
                     if (csharpType.IsValueType == false && type.DescendsTo(typeof(IResource)))
                         annotation.Add(new ResourceAnnotation(annotation, type));
-                    else if (csharpType.IsValueType == false && type.DescendsTo(typeof(ITestStep)) && mem?.Member.DeclaringType?.DescendsTo(typeof(ITestStep)) == true)
+                    else if (csharpType.IsValueType == false && type.DescendsTo(typeof(ITestStep)) && mem?.Member.DeclaringType?.DescendsTo(typeof(ITestStepParent)) == true)
                         annotation.Add(new TestStepSelectAnnotation(annotation));
                 }
             }


### PR DESCRIPTION
It seems we only annotated `ITestStep` descendants with `TestStepSelectAnnotation`. This PR slightly relaxes this restriction to put it on all `ITestStepParent` instances, in order to allow properties using `StepSelectorAttribute` to be parameterized on the test plan.

Closes #900