### PR TITLE
922 improve usability of package list when no releases are available

### DIFF
--- a/Package/PackageActions/List.cs
+++ b/Package/PackageActions/List.cs
@@ -157,18 +157,19 @@ namespace OpenTap.Package
                     }
 
 
+                    var allVersion = versions;
                     versions = versions.Where(v => versionSpec.IsCompatible(v.Version)).ToList();
                     if (versions.Any() == false) // No versions that are compatible
                     {
                         if (string.IsNullOrEmpty(Version))
-                            log.Warning($"There are no released versions of '{Name}'.");
+                            log.Warning($"There are no released versions of '{Name}'. Showing pre-releases instead.");
                         else
                             log.Warning($"Package '{Name}' does not exists with version '{Version}'.");
 
                         var anyPrereleaseSpecifier = new VersionSpecifier(versionSpec.Major, versionSpec.Minor, versionSpec.Patch, versionSpec.PreRelease, versionSpec.BuildMetadata, VersionMatchBehavior.AnyPrerelease | versionSpec.MatchBehavior);
-                        versions = versions.Where(v => anyPrereleaseSpecifier.IsCompatible(v.Version)).ToList();
+                        versions = allVersion.Where(v => anyPrereleaseSpecifier.IsCompatible(v.Version)).ToList();
                         if (versions.Any())
-                            log.Info($"There are {versions.Count} pre-released versions available. Use '--version <pre-release>' (e.g. '--version rc') or '--all' to show these.");
+                            PrintVersionsReadable(package, versions);
 
                         return (int)ExitCodes.Success;
                     }


### PR DESCRIPTION
We currently give a somewhat cryptic hint that there are no 'released' versions of a package, but it's not really obivous that this means that there are **pre**-released versions.

From the logic, there was supposed to be a message hinting that **all** versions could be shown with the  option, or by providing a prerelease specifier like

Instead of this teasing, I think we should just show the list of prereleases in the case where a user tried to list the versions of a package with no releases.

Closes #922