### PR TITLE
968 prevent isolated tap.exe from hanging

### DIFF
--- a/Package/PackageActions/IsolatedPackageAction.cs
+++ b/Package/PackageActions/IsolatedPackageAction.cs
@@ -255,7 +255,6 @@ namespace OpenTap.Package
                         newname = $"{newname} --target \"{target}\"";
 
                     tpmClient.MessageServer("run " + newname);
-                    tpmClient.Dispose();
                 }
             }
         }

--- a/Package/PackageActions/LockingPackageAction.cs
+++ b/Package/PackageActions/LockingPackageAction.cs
@@ -139,7 +139,7 @@ namespace OpenTap.Package
         {
             try
             {
-                IsolatedPackageAction.RunIsolated(application,target);
+                IsolatedPackageAction.RunIsolated(application, target);
                 return true;
             }
             catch(InvalidOperationException)

--- a/Shared/ExecutorInterop.cs
+++ b/Shared/ExecutorInterop.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -214,7 +213,10 @@ namespace OpenTap
 
         internal void MessageServer(string newname)
         {
-            pipeConnect.Wait();
+            if (!pipeConnect.Wait(TimeSpan.FromSeconds(10)))
+            {
+                throw new TimeoutException("Isolated process failed to connect to host process within reasonable time.");
+            }
             var toWrite = Encoding.UTF8.GetBytes(newname);
             pipe.Write(toWrite, 0, toWrite.Length);
         }


### PR DESCRIPTION
This adds a timeout so the tap.exe subprocess will exit if it fails to connect  to the parent process within a reasonable timeframe.

I'm not sure under what circumstances this was triggered in the issue. I reproduced it by deliberately setting an incorrect TPM pipe name and exiting the parent process with CTRL-C, and that left the isolated subprocess running in the background, indefinitely waiting for the pipe to connect. 

I assume it's possible to trigger this under normal circumstances with a well timed CTRL-C. In that case, I don't think the timeout matters so much, as long as the subprocess exits eventually.

Closes #968