### PR TITLE
980 add Required option to CommandLineArgumentAttribute

### DIFF
--- a/Engine/Cli/CommandLineArgumentAttribute.cs
+++ b/Engine/Cli/CommandLineArgumentAttribute.cs
@@ -36,6 +36,11 @@ namespace OpenTap.Cli
         /// </summary>
         [Obsolete("Please use the 'Browsable' attribute.")]
         public bool Visible { get; set; } = true;
+        
+        /// <summary>
+        /// Indicates whether this argument is required or optional.
+        /// </summary>
+        public bool Required { get; set; }
 
         /// <summary>
         /// Primary constructor.

--- a/Shared/ICliActionExtensions.cs
+++ b/Shared/ICliActionExtensions.cs
@@ -132,10 +132,15 @@ namespace OpenTap.Cli
                 SessionLogs.Rename(args.Argument("log"));
             }
 
+            var requiredNamedArgs = argToProp.Values.Where(x => x.GetAttribute<CommandLineArgumentAttribute>().Required)
+                .ToHashSet();
+
             foreach (var opts in args)
             {
                 if (argToProp.ContainsKey(opts.Key) == false) continue;
                 var prop = argToProp[opts.Key];
+                if (requiredNamedArgs.Contains(prop))
+                    requiredNamedArgs.Remove(prop);
 
                 if (prop.TypeDescriptor is TypeData propTd)
                 {
@@ -183,6 +188,7 @@ namespace OpenTap.Cli
             unnamedArgToProp = unnamedArgToProp.OrderBy(p => p.GetAttribute<UnnamedCommandLineArgument>().Order)
                 .ToList();
             var requiredArgs = unnamedArgToProp.Where(x => x.GetAttribute<UnnamedCommandLineArgument>().Required)
+                .Concat(requiredNamedArgs)
                 .ToHashSet();
             int idx = 0;
 
@@ -225,8 +231,14 @@ namespace OpenTap.Cli
                     Console.WriteLine("Unknown options: " + string.Join(" ", args.UnknownsOptions));
 
                 if (requiredArgs.Any())
-                    Console.WriteLine("Missing argument: " + string.Join(" ",
-                        requiredArgs.Select(p => p.GetAttribute<UnnamedCommandLineArgument>().Name)));
+                {
+                    var unnamed = requiredArgs.Where(p => p.HasAttribute<UnnamedCommandLineArgument>())
+                        .Select(p => p.GetAttribute<UnnamedCommandLineArgument>().Name);
+                    var named = requiredArgs.Where(p => p.HasAttribute<CommandLineArgumentAttribute>())
+                        .Select(p => p.GetAttribute<CommandLineArgumentAttribute>().Name);
+                    
+                    Console.WriteLine("Missing argument: " + string.Join(", ", unnamed.Concat(named)));
+                }
 
                 printOptions(action.GetType().GetAttribute<DisplayAttribute>().Name, ap.AllOptions, unnamedArgToProp);
                 return (int)ExitCodes.ArgumentParseError;


### PR DESCRIPTION
This adds the Required option to CommandLineArgumentAttribute

This allows authors of CLI actions to indicate that a named argument is required. If the required argument is not provided, the CLI action executor will give an appropriate error message, and fail with the help text for the CLI action.

This should save CLI action authors to avoid a lot of boiler plate that we ourselves duplicate in all of our plugins:

Code like this should no longer be necessary:
```csharp
if (string.IsNullOrWhiteSpace(SomeProp))
  throw new Exception($"{nameof(SomeProp)} is required");

```

Closes #980