### PR TITLE
1006 Dynamic Serializer Dependency: Fix + Test

### DIFF
--- a/Engine.UnitTests/SerializerTests.cs
+++ b/Engine.UnitTests/SerializerTests.cs
@@ -288,10 +288,15 @@ namespace OpenTap.Engine.UnitTests
 
             public override double Order => 1000;
             HashSet<XElement> visitedNodes = new HashSet<XElement>();
+            static XName testPlanName = "TestPlan";
             public override bool Deserialize(XElement node, ITypeData t, Action<object> setter)
             {
-                if (visitedNodes.Add(node) == false) return false;
-                return Serializer.Deserialize(node, setter, t);
+                if (node.Name == testPlanName)
+                {
+                    if (visitedNodes.Add(node))
+                        return Serializer.Deserialize(node, setter, t);
+                }
+                return false;
             }
             public override bool Serialize(XElement node, object obj, ITypeData expectedType)
             {

--- a/Engine.UnitTests/SerializerTests.cs
+++ b/Engine.UnitTests/SerializerTests.cs
@@ -282,6 +282,49 @@ namespace OpenTap.Engine.UnitTests
                 tapTraceListener.ErrorMessage.Count(x =>
                     x.Contains("Unable to read StepWithLicenseException. A valid license cannot be granted")));
         }
+
+        public class DynamicDependencySerializerPlugin : TapSerializerPlugin, ITapSerializerPluginDependencyMarker
+        {
+
+            public override double Order => 1000;
+            HashSet<XElement> visitedNodes = new HashSet<XElement>();
+            public override bool Deserialize(XElement node, ITypeData t, Action<object> setter)
+            {
+                if (visitedNodes.Add(node) == false) return false;
+                return Serializer.Deserialize(node, setter, t);
+            }
+            public override bool Serialize(XElement node, object obj, ITypeData expectedType)
+            {
+                if (visitedNodes.Add(node) == false) return false;
+                return Serializer.Serialize(node, obj, expectedType);
+            }
+            
+            public bool NeededForDeserialization
+            {
+                get;
+                set;
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SerializerMaybeUsedType(bool addSerializerPluginDependency)
+        {
+            var serializer = new TapSerializer();
+            var obj = new TestPlan();
+            serializer.GetSerializer<DynamicDependencySerializerPlugin>().NeededForDeserialization = addSerializerPluginDependency;
+            serializer.SerializeToString(obj);
+            var usedTypes = serializer.GetUsedTypes();
+            var wasUsed = usedTypes.Contains(TypeData.FromType(typeof(DynamicDependencySerializerPlugin)));
+            if (addSerializerPluginDependency)
+            {
+                Assert.IsTrue(wasUsed);
+            }
+            else
+            {
+                Assert.IsFalse(wasUsed);
+            }
+        }
         
     }
 }

--- a/Engine/SerializerPlugins/ITapSerializerPluginDependencyMarker.cs
+++ b/Engine/SerializerPlugins/ITapSerializerPluginDependencyMarker.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenTap
+{
+    /// <summary>
+    /// Allows a serializer plugin to specify if it is needed for deserialization.
+    /// This can affect the package dependencies of test plans as the serializers used by the test plan
+    /// are otherwise always dependencies of the test plan itself.
+    /// </summary>
+    public interface ITapSerializerPluginDependencyMarker : ITapSerializerPlugin
+    {
+        /// <summary> Gets if the serializer is needed to deserialize.
+        /// If set to false, the serializer will not mark it as having been used. </summary>
+        bool NeededForDeserialization { get; }
+    }
+}

--- a/Engine/TapSerialization.cs
+++ b/Engine/TapSerialization.cs
@@ -464,7 +464,19 @@ namespace OpenTap
                     {
                         if (ser.Serialize(elem, obj, type))
                         {
-                            NotifyTypeUsed(TypeData.GetTypeData(ser));
+                            if (ser is ITapSerializerPluginDependencyMarker marker)
+                            {
+                                if (marker.NeededForDeserialization)
+                                {
+                                    NotifyTypeUsed(TypeData.GetTypeData(ser));
+                                }
+                                // else  serializer is specifically not a dependency.
+                            }
+                            else
+                            {    
+                                // mark the serializer plugin types as having been used during serialization.
+                                NotifyTypeUsed(TypeData.GetTypeData(ser));
+                            }
                             return true;
                         }
                     }
@@ -568,6 +580,8 @@ namespace OpenTap
         readonly HashSet<ITypeData> registeredTypes = new HashSet<ITypeData>();
         readonly HashSet<string> registeredFiles = new HashSet<string>();
 
+        /// <summary> This is used to keep track of which types has been used by the serializer. </summary>
+        /// <param name="type"></param>
         internal void NotifyTypeUsed(ITypeData type)
         {
             registeredTypes.Add(type);


### PR DESCRIPTION
Added a way for a serializer plugin to specify it is needed for deserialization and hence become added as a package dependency if a 3rd plugin (aside from OpenTAP) implements it.

Added a unit test to verify the behavior by checking TapSerializer.GetUsedTypes.

Close #1006