### PR TITLE
Freeze Package Diff in version 0.1.0-beta.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,7 +621,7 @@ jobs:
       - name: Diff Package
         run: |
           mv OpenTAP.*.TapPackage OpenTAP.TapPackage
-          tap package install "Package Diff" --version any
+          tap package install "Package Diff" --version 0.1.0-beta.19+2b1aa952
           tap package diff OpenTAP.TapPackage -o diff
 
   Package-NuGet:


### PR DESCRIPTION
This version of Package Diff makes it a breaking change to remove or upgrade a DLL, which would have helped catch the fact that #1004 removed netwonsoft from the Linux package.

After we merge this, `Package Diff` is going to fail on the main branch because we updated `Mono.Cecil` from `0.11.3` to `0.11.4` on Linux. This happened in the same PR that removed Newtonsoft, though this is much lower impact. Once we make a release, the main branch will no longer fail because `Package Diff` only compares with the previous release.

See the current diff from the main branch here demonstrating that Mono.Cecil was updated: https://github.com/opentap/opentap/actions/runs/4173528230/jobs/7226154057