### PR TITLE
1025 quiet prepareuninstall

### DIFF
--- a/Package.UnitTests/PackageTestTest.cs
+++ b/Package.UnitTests/PackageTestTest.cs
@@ -129,7 +129,7 @@ namespace OpenTap.Package.UnitTests
         public void BasicTest()
         {
             Restore();
-            var (stdout, stderr, exitCode) = RunTest(false);
+            var (stdout, stderr, exitCode) = RunTest(true);
 
             StringAssert.Contains("Tried to test MyPlugin5, but there was nothing to do.", stdout);
             Assert.AreEqual(exitCode, 0);

--- a/Package/Installer.cs
+++ b/Package/Installer.cs
@@ -186,7 +186,7 @@ namespace OpenTap.Package
                     }
                     else if(res == ActionResult.NothingToDo)
                     {
-                        log.Info($"Tried to {command} {pkg.Name}, but there was nothing to do.");
+                        log.Debug($"Tried to {command} {pkg.Name}, but there was nothing to do.");
                     }
                     else
                         log.Info(timer, $"{verb} {pkg.Name} version {pkg.Version}.");


### PR DESCRIPTION
This logs the 'Tried to prepareuninstall package', but there was nothing to do' at the debug level instead of info level.

Closes #1025 