### PR TITLE
Improve TestStepStringConvertProvider

### DIFF
--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -1085,7 +1085,7 @@ namespace OpenTap.UnitTests
                 var a = AnnotationCollection.Annotate(repeat1);
                 setInputVerdict(a, repeat2);
                 Assert.AreSame(repeat2, repeat1.TargetStep);
-                Assert.AreSame(null, repeat2.TargetStep);
+                Assert.AreSame(repeat1, repeat2.TargetStep);
             }
 
             { // Set repeat2 independent of repeat1

--- a/Engine/IStringConvertProvider.cs
+++ b/Engine/IStringConvertProvider.cs
@@ -786,6 +786,14 @@ namespace OpenTap
         /// <summary> String convert provider for TestStep </summary>
         internal class TestStepConvertProvider : IStringConvertProvider
         {
+            internal static ITestStep GetStepFromContext(ITestStepParent context, Guid id)
+            {
+                ITestStepParent plan = context;
+                while (plan.Parent != null) 
+                    plan = plan.Parent;
+                return Utils.FlattenHeirarchy(plan.ChildTestSteps, x => x.ChildTestSteps)
+                    .FirstOrDefault(x => x.Id == id);
+            }
             /// <summary>
             /// Gets a TestStep from a string value. This will be a step from the test plan context object.
             /// </summary>
@@ -800,7 +808,7 @@ namespace OpenTap
                 {
                     if(Guid.TryParse(stringdata, out Guid id))
                     {
-                        return parent.ChildTestSteps.GetStep(id);
+                        return GetStepFromContext(parent, id);
                     }
                 }
                 return null;
@@ -843,12 +851,8 @@ namespace OpenTap
                 var inp = (IInput)type.CreateInstance(Array.Empty<object>());
                 if (id == Guid.Empty)
                     return inp;
-                    
-                ITestStepParent plan = step;
-                while (plan.Parent != null)
-                    plan = plan.Parent;
-                var step2 = Utils.FlattenHeirarchy(plan.ChildTestSteps, x => x.ChildTestSteps)
-                    .FirstOrDefault(x => x.Id == id);
+
+                var step2 = TestStepConvertProvider.GetStepFromContext(step, id);
                 if (step2 == null) return null;
                 inp.Step = step2;
                     


### PR DESCRIPTION
Our test step string convert provider now checks the containing test plan for the step id instead of just the step context

Closes #997