### PR TITLE
Remove SDK install action

### DIFF
--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 9.20.2
+version = 9.20.3
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.

--- a/sdk/sdk.package.xml
+++ b/sdk/sdk.package.xml
@@ -56,12 +56,4 @@
     <File Path="Packages/SDK/Examples/TestPlanExecution/RunTestPlan.Api/RunTestPlan.Api.csproj"/>
     <File Path="Packages/SDK/Examples/TestPlanExecution/RunTestPlan.Api/Properties/AssemblyInfo.cs"/>
   </Files>
-  <PackageActionExtensions>
-    <!-- 
-      The template install will fail with various exit codes dependening on the dotnet version, and whether or not the templates are already installed:
-      106        : .NET 7 or later if the template is already installed
-      -2147352567: Earlier than .NET 7 if the template is already installed
-    -->
-    <ActionStep ExpectedExitCodes="0,106,-2147352567" ExeFile="dotnet" Arguments='new --install Packages/SDK/OpenTap.Templates.$(GitLongVersion).nupkg' ActionName="install" /> 
-  </PackageActionExtensions>
 </Package>


### PR DESCRIPTION
There is currently no way of specifying that a package install action is always allowed to fail. Instead, let's remove this install action until 9.21 and re-enable it when that is possible.

Closes #1060