### PR TITLE
9.20.4-rc.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -779,7 +779,7 @@ jobs:
       - GetVersion
       - Package-Win
     container:
-      image: ghcr.io/opentap/smartinstaller:2.0.0-beta.29
+      image: ghcr.io/opentap/smartinstaller:2.1.0-beta.5
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -836,7 +836,7 @@ jobs:
       - GetVersion
       - Package-Linux
     container:
-      image: ghcr.io/opentap/smartinstaller:2.0.0-beta.29
+      image: ghcr.io/opentap/smartinstaller:2.1.0-beta.5
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 9.20.3
+version = 9.20.4
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.

--- a/Package/PackageActions/LockingPackageAction.cs
+++ b/Package/PackageActions/LockingPackageAction.cs
@@ -103,7 +103,7 @@ namespace OpenTap.Package
                 log.Info("Waiting for other package manager operation to complete.");
                 try
                 {
-                    switch (WaitHandle.WaitAny(new WaitHandle[] { fileLock.WaitHandle, cancellationToken.WaitHandle }, 120000))
+                    switch (WaitHandle.WaitAny(new WaitHandle[] { fileLock.WaitHandle, cancellationToken.WaitHandle }, TimeSpan.FromMinutes(2)))
                     {
                         case 0: // we got the mutex
                             break;

--- a/Package/PackageInstallHelpers/PackageInstallStep.cs
+++ b/Package/PackageInstallHelpers/PackageInstallStep.cs
@@ -27,7 +27,8 @@ namespace OpenTap.Package.PackageInstallHelpers
                     .ToArray(),
                 Target = Target,
                 Repository = Repositories,
-                SystemWideOnly = SystemWideOnly
+                SystemWideOnly = SystemWideOnly,
+                AlreadyElevated = true,
             };
 
             try


### PR DESCRIPTION
* Update SmartInstaller to fix error causing .NET 6 to not be installed correctly
* Add warning when elevation fails during system-wide package install