### PR TITLE
Skip package name autocorrect when ignore-missing is specified

### DIFF
--- a/Package/AutoCorrectPackageNames.cs
+++ b/Package/AutoCorrectPackageNames.cs
@@ -17,7 +17,7 @@ namespace OpenTap.Package
     {
         /// <summary>
         /// Correct each name in the string array based on the available packages in the repositories.
-        /// If a package name does not exist, and is not corrected, return false; otherwise return true
+        /// If a package name does not exist, an exception is thrown.
         /// </summary>
         /// <param name="names"></param>
         /// <param name="repositories"></param>

--- a/Package/PackageActions/Uninstall.cs
+++ b/Package/PackageActions/Uninstall.cs
@@ -36,7 +36,9 @@ namespace OpenTap.Package
                 return (int) ExitCodes.ArgumentError;
             }
 
-            Packages = AutoCorrectPackageNames.Correct(Packages, Array.Empty<IPackageRepository>());
+            // Skip auto-correction if ignore-missing is specified
+            if (!IgnoreMissing) 
+                Packages = AutoCorrectPackageNames.Correct(Packages, Array.Empty<IPackageRepository>());
 
             Installer installer = new Installer(Target, cancellationToken) {DoSleep = false};
             installer.ProgressUpdate += RaiseProgressUpdate;


### PR DESCRIPTION
This fixes a regression introduced when package name corrections were added

Closes #1034