### PR TITLE
1050 expand-default-references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -717,6 +717,9 @@ jobs:
           #Remove-Item ./nuget/build/payload/tap.dll
           #Remove-Item ./nuget/build/payload/tap.runtimeconfig.json
 
+          New-Item -Force nuget/build/payload/Packages -ItemType Directory | Out-Null
+          Move-Item ./bin/Release/OpenTap.Plugins.BasicSteps.dll ./nuget/build/payload/Packages/OpenTap.Plugins.BasicSteps.dll
+          Move-Item ./bin/Release/OpenTap.Plugins.BasicSteps.xml ./nuget/build/payload/Packages/OpenTap.Plugins.BasicSteps.xml
           Move-Item ./bin/Release/OpenTap.Package.xml ./nuget/build/payload
           Move-Item ./bin/Release/OpenTap.xml ./nuget/build/payload
           Push-Location ./nuget/build/payload

--- a/BasicSteps/Tap.Plugins.BasicSteps.csproj
+++ b/BasicSteps/Tap.Plugins.BasicSteps.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AssemblyName>OpenTap.Plugins.BasicSteps</AssemblyName>
     <RootNamespace>OpenTap.Plugins.BasicSteps</RootNamespace>
+    <DocumentationFile>$(OutputPath)\OpenTap.Plugins.BasicSteps.xml</DocumentationFile>
   </PropertyGroup>
 
   <!-- Comment this out for now, until we can get to adding all the missing XML comments

--- a/nuget/OpenTAP.nuspec
+++ b/nuget/OpenTAP.nuspec
@@ -14,6 +14,8 @@
     <tags>OpenTAP</tags>
     <references>
     	<reference file="OpenTap.dll"/>
+    	<reference file="OpenTap.Package.dll"/>
+    	<reference file="OpenTap.Plugins.BasicSteps.dll"/>
     </references>
     <license type="expression">MPL-2.0</license>
   </metadata>
@@ -22,7 +24,8 @@
     <file src="build/payload/OpenTap.xml" target="lib/netstandard2.0" />
     <file src="build/payload/OpenTap.Package.dll" target="lib/netstandard2.0" />
     <file src="build/payload/OpenTap.Package.xml" target="lib/netstandard2.0" />
-    
+    <file src="build/payload/Packages/OpenTap.Plugins.BasicSteps.dll" target="lib/netstandard2.0" />
+    <file src="build/payload/Packages/OpenTap.Plugins.BasicSteps.xml" target="lib/netstandard2.0" />
     <file src="build/**/*" exclude="**\.*"/>
   </files>
 </package>


### PR DESCRIPTION
This adds a dll reference to BasicSteps and Packages by default when using the OpenTAP nuget package

Closes #1050