### PR TITLE
1079 link resource open tapthread to testplan execution thread

### DIFF
--- a/Engine.UnitTests/ResourceTest.cs
+++ b/Engine.UnitTests/ResourceTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using OpenTap.Diagnostic;
 using OpenTap.Engine.UnitTests;
@@ -84,6 +85,59 @@ namespace OpenTap.UnitTests
                 RunChildSteps();
                 Assert.IsFalse(SomeInstrument.IsConnected);
             }
+        }
+
+        public class SlowOpenInstrument : IInstrument
+        {
+            public event PropertyChangedEventHandler PropertyChanged;
+            public string Name { get; set; }
+            public void Open()
+            {
+                var trd = TapThread.Current;
+                while (trd != null)
+                {
+                    if (trd.Name == "Plan Thread")
+                        break;
+                    trd = trd.Parent;
+                }
+                Assert.That(trd, Is.Not.Null);
+                
+                var cancel = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                WasStopped = false;
+                int handle = WaitHandle.WaitAny(new[] { TapThread.Current.AbortToken.WaitHandle, cancel.Token.WaitHandle });
+                WasStopped = handle == 0;
+            }
+
+            public void Close()
+            {
+                
+            }
+
+            public bool IsConnected => true;
+            public bool WasStopped { get; set; }
+        }
+
+        [Test]
+        public void SlowOpenInstrumentTest([Values(false, true)] bool UseLazyResourceManager)
+        {
+            using var session = Session.Create(SessionOptions.OverlayComponentSettings);
+            IResourceManager manager =
+                UseLazyResourceManager ? (IResourceManager)new LazyResourceManager() : new ResourceTaskManager();
+            EngineSettings.Current.ResourceManagerType = manager;
+            
+            var instrument = new SlowOpenInstrument();
+            var step = new ResourceTestStep {MyTestResource = instrument, ResourceEnabled = true};
+            var plan = new TestPlan()
+            {
+                ChildTestSteps = { step }
+            };
+
+            Assert.IsFalse(instrument.WasStopped);
+            var abortToken = new CancellationTokenSource(TimeSpan.FromMilliseconds(1000));
+            var run = plan.ExecuteAsync(abortToken.Token);
+            abortToken.Token.WaitHandle.WaitOne();
+            TapThread.Sleep(TimeSpan.FromSeconds(1));
+            Assert.IsTrue(instrument.WasStopped);
         }
         
         

--- a/Engine.UnitTests/TapThreadTest.cs
+++ b/Engine.UnitTests/TapThreadTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace OpenTap.UnitTests
@@ -94,6 +95,36 @@ namespace OpenTap.UnitTests
             Assert.IsTrue(hierarchyCompletedCallbackCalled.Wait(30 * 1000), "onHierarchyCompleted callback not called.");
             Assert.IsTrue(level1CompletedBeforeHierarchyCompletedCallback, "Child thread did not complete before onHierarchyCompleted callback.");
             Assert.IsTrue(level2CompletedBeforeHierarchyCompletedCallback, "Second level child thread did not complete before onHierarchyCompleted callback.");
+        }
+
+        [Test]
+        public async Task TestAwaitedThreadThrows([Values(true, false)] bool throws)
+        {
+            void callback()
+            {
+                if (throws)
+                    throw new Exception("Throws");
+            }
+
+            var trd = TapThread.StartAwaitable(callback);
+
+            if (throws)
+            {
+                try
+                {
+                    await trd;
+                    Assert.Fail("This should have thrown.");
+                }
+                catch (Exception ex)
+                {
+                    StringAssert.Contains("Throws", ex.Message);
+                }
+            }
+            else
+            {
+                await trd;
+                Assert.Pass();
+            }
         }
 
         /// <summary>

--- a/Engine.UnitTests/TestPlanTest.cs
+++ b/Engine.UnitTests/TestPlanTest.cs
@@ -2001,7 +2001,7 @@ namespace OpenTap.Engine.UnitTests
                 isopening = true;
 
                 if(OpenWait)
-                    TapThread.Sleep(20);
+                    Thread.Sleep(20);
                 
                 isopening = false;
                 
@@ -2115,6 +2115,7 @@ namespace OpenTap.Engine.UnitTests
         }
         
         [Test]
+        [Repeat(10)]
         public void OpenCloseOrderLazyRM()
         {
             var lastrm = EngineSettings.Current.ResourceManagerType;

--- a/Engine/ResourceTaskManager.cs
+++ b/Engine/ResourceTaskManager.cs
@@ -254,7 +254,7 @@ namespace OpenTap
             try
             {
                 // start a new thread to do synchronous work
-                TapThread.Start(node.Resource.Open);
+                node.Resource.Open();
 
                 reslog.Info(swatch, "Resource \"{0}\" opened.", node.Resource);
 

--- a/Engine/ResourceTaskManager.cs
+++ b/Engine/ResourceTaskManager.cs
@@ -583,11 +583,8 @@ namespace OpenTap
                 {
                     try
                     {
-                        // start a new thread to do synchronous work
                         node.Resource.Open();
-        
                         reslog.Info(swatch, "Resource \"{0}\" opened.", node.Resource);
-
                     }
                     finally
                     {

--- a/Engine/ThreadManager.cs
+++ b/Engine/ThreadManager.cs
@@ -367,7 +367,9 @@ namespace OpenTap
             var awaiter = new Awaitable(wait);
             return Task.Factory.FromAsync(awaiter, x =>
             {
-                if (ex != null) throw ex;
+                // rethrow the exception if there was one.
+                // The Rethrow extension method preserves the original stacktrace.
+                ex?.Rethrow();
             });
         }
 


### PR DESCRIPTION
This attaches the resource Open calls to the TapThread hierarchy that started them to allow instrument developers to detect when a testplan is aborted during e.g. the resource Open method

Closes #1079 