### PR TITLE
1091 incorrect instrument assigned to sweep child steps

### DIFF
--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -1943,6 +1943,36 @@ namespace OpenTap.UnitTests
             annotation.Write();
             Assert.IsTrue(obj.Values.SequenceEqual(new int[] {1, 2, 3, 4}));
         }
+        
+        [Test]
+        public void WriteMergedAnnotationTest()
+        {
+            var names = new[] { "name1", "name1", "name2" };
+            var delaySteps = new DelayStep[3];
+            for (int i = 0; i < 3; i++)
+            {
+                var delay = new DelayStep() { Name = names[i] };
+                delaySteps[i] = delay;
+            }
+
+            var a = AnnotationCollection.Annotate(delaySteps);
+            { // verify merge fails
+                var mem = a.GetMember(nameof(DelayStep.Name));
+                var name = mem.Get<MergedValueAnnotation>();
+                Assert.AreEqual(null, name.Value);
+            }
+            { // Verify collection is not modified on write
+                a.Write();
+                CollectionAssert.AreEqual(names, delaySteps.Select(d => d.Name));   
+            }
+            { // Verify merge succeeds 
+                delaySteps[2].Name = "name1";
+                a.Read();   
+                var mem = a.GetMember(nameof(DelayStep.Name));
+                var name = mem.Get<MergedValueAnnotation>();
+                Assert.AreEqual("name1", name.Value);
+            }
+        }
 
         [Test]
         public void AvailableValuesUpdateTest()

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -737,7 +737,8 @@ namespace OpenTap
                     {
                         var x = merged[i];
                         var thisVal = x.Get<IObjectValueAnnotation>().Value;
-                        if (thisVal == selectedValue) return selectedValue;
+                        if (thisVal == selectedValue) 
+                            continue;
                         if (selectedValue is IEnumerable ie1 && !(selectedValue is string))
                         {
                             // if the two lists has the same content it is fine to just return one of them.
@@ -746,7 +747,7 @@ namespace OpenTap
                             if (thisVal is IEnumerable ie2)
                             {
                                 if (ie2.Cast<object>().SequenceEqual(ie1.Cast<object>()))
-                                    return selectedValue;
+                                    continue;
                             }
 
                             return null;


### PR DESCRIPTION
This fixes a bug causing merged values to be incorrectly reset during annotation writes.

The fix involves removing a short-hand in a performance critical annotation implementation, but it fixes a fairly critical bug. See the linked issue. 

closes #1091