### PR TITLE
1097 Allow more flexible ordering of StringConverters

### DIFF
--- a/Engine.UnitTests/BeforeAttributeTest.cs
+++ b/Engine.UnitTests/BeforeAttributeTest.cs
@@ -12,7 +12,7 @@ namespace OpenTap.Engine.UnitTests
     {
         public class StringConvertProviderA : IStringConvertProvider
         {
-            public static List<Type> UseOrder = new List<Type>();
+            public static readonly List<Type> UseOrder = new List<Type>();
             public string GetString(object value, CultureInfo culture)
             {
                 if (UseOrder.Contains(GetType()) == false)
@@ -46,20 +46,19 @@ namespace OpenTap.Engine.UnitTests
             
         }
         
+        [Test]
         public void TestBeforeAttribute()
         {
             StringConvertProvider.GetString(new StringConvertProviderD());
-            int ia, ib, ic, id;
-            ia = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderA));
-            ib = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderB));
-            ic = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderC));
-            id = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderD));
+            
+            var ia = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderA));
+            var ib = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderB));
+            var ic = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderC));
+            var id = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderD));
             Assert.IsTrue(ib < ic);
             Assert.IsTrue(ib < id);
-            Assert.IsTrue(ic < id);
-            Assert.IsTrue(ia < ic);
-
-            
+            Assert.IsTrue(id < ic);
+            Assert.IsTrue(ic < ia);
         }
         
     }

--- a/Engine.UnitTests/BeforeAttributeTest.cs
+++ b/Engine.UnitTests/BeforeAttributeTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using NUnit.Framework;
+namespace OpenTap.Engine.UnitTests
+{
+    
+    
+    
+    [TestFixture]
+    public class BeforeAttributeTest
+    {
+        public class StringConvertProviderA : IStringConvertProvider
+        {
+            public static List<Type> UseOrder = new List<Type>();
+            public string GetString(object value, CultureInfo culture)
+            {
+                if (UseOrder.Contains(GetType()) == false)
+                {
+                    UseOrder.Add(GetType());
+                }
+                return null;
+            }
+        
+            public object FromString(string stringData, ITypeData type, object contextObject, CultureInfo culture)
+            {
+                return null;
+            }
+        }
+
+        [Before(typeof(StringConvertProviderC))]
+        [Before(typeof(StringConvertProviderD))]
+        public class StringConvertProviderB : StringConvertProviderA
+        {
+            
+        }
+        
+        [Before(typeof(StringConvertProviderA))]
+        public class StringConvertProviderC : StringConvertProviderA
+        {
+            
+        }
+        [Before(typeof(StringConvertProviderC))]
+        public class StringConvertProviderD : StringConvertProviderA
+        {
+            
+        }
+        
+        public void TestBeforeAttribute()
+        {
+            StringConvertProvider.GetString(new StringConvertProviderD());
+            int ia, ib, ic, id;
+            ia = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderA));
+            ib = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderB));
+            ic = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderC));
+            id = StringConvertProviderA.UseOrder.IndexOf(typeof(StringConvertProviderD));
+            Assert.IsTrue(ib < ic);
+            Assert.IsTrue(ib < id);
+            Assert.IsTrue(ic < id);
+            Assert.IsTrue(ia < ic);
+
+            
+        }
+        
+    }
+}

--- a/Engine/BeforeAttribute.cs
+++ b/Engine/BeforeAttribute.cs
@@ -1,0 +1,41 @@
+﻿using System;
+namespace OpenTap
+{
+    /// <summary>
+    /// Ordering constraint for plugin types. This should be used 'before' something else.
+    /// This is currently only support by implementations of IStringConvertProvider.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class BeforeAttribute: Attribute
+    {
+        readonly ITypeData type;
+        /// <summary>
+        ///  Creates a BeforeAttribute from a type parameter. This is the safest way, but requires a public C# type.
+        /// </summary>
+        public BeforeAttribute(Type type)
+        {
+            this.type = TypeData.FromType(type);
+        }
+        /// <summary>
+        ///  Creates a BeforeAttribute from a string type name..
+        /// </summary>
+        /// <param name="typeName"></param>
+        public BeforeAttribute(string typeName)
+        {
+            this.type = TypeData.GetTypeData(typeName);
+        }
+
+        /// <summary>
+        /// returns true if the marked type should come before the 'other' type.
+        /// This can method can be overridden for more custom 'before' behavior.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public virtual bool Before(ITypeData other)
+        {
+            if (type != null && Equals(type, other))
+                return true;
+            return false;
+        } 
+    }
+}

--- a/Engine/BeforeAttribute.cs
+++ b/Engine/BeforeAttribute.cs
@@ -5,7 +5,7 @@ namespace OpenTap
     /// Ordering constraint for plugin types. This should be used 'before' something else.
     /// This is currently only support by implementations of IStringConvertProvider.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class BeforeAttribute: Attribute
     {
         readonly ITypeData type;

--- a/Engine/BeforeAttribute.cs
+++ b/Engine/BeforeAttribute.cs
@@ -4,6 +4,7 @@ namespace OpenTap
     /// <summary>
     /// Ordering constraint for plugin types. This should be used 'before' something else.
     /// This is currently only support by implementations of IStringConvertProvider.
+    /// If more than one of these attributes are used, it will try to find a type before all of them.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class BeforeAttribute: Attribute

--- a/Engine/IStringConvertProvider.cs
+++ b/Engine/IStringConvertProvider.cs
@@ -77,10 +77,10 @@ namespace OpenTap
                                         // if BeforeAttribute is used, insert somewhere before the marked type.
                                         // otherwise insert at the end of the list.
                                         int addIndex = builder.Count;
-                                        if (type.GetAttribute<BeforeAttribute>() is BeforeAttribute before)
+                                        foreach (var before in type.GetAttributes<BeforeAttribute>())
                                         {
                                             int addIndex2 = builder.IndexWhen(item => before.Before(TypeData.GetTypeData(item)));
-                                            if (addIndex2 != -1)
+                                            if (addIndex2 != -1 && addIndex2 < addIndex)
                                                 addIndex = addIndex2;
                                         }
                                         

--- a/Engine/IStringConvertProvider.cs
+++ b/Engine/IStringConvertProvider.cs
@@ -32,12 +32,12 @@ namespace OpenTap
         /// <summary>
         /// Creates an object from stringdata. The returned object should be of type 'type'. Returns null if it cannot convert stringdata to type.
         /// </summary>
-        /// <param name="stringdata"></param>
+        /// <param name="stringData"></param>
         /// <param name="type"></param>
         /// <param name="contextObject">The object on which the value is set.</param>
         /// <param name="culture">The culture used for the conversion. This value can will default to InvariantCulture if nothing else is selected.</param>
         /// <returns></returns>
-        object FromString(string stringdata, ITypeData type, object contextObject, CultureInfo culture);
+        object FromString(string stringData, ITypeData type, object contextObject, CultureInfo culture);
     }
     
     /// <summary>
@@ -66,13 +66,25 @@ namespace OpenTap
                             foreach (var type in derivedTypes)
                             {
                                 if (type.CanCreateInstance == false) continue;
+                                
                                 if (saveTypes.ContainsKey(type) == false)
                                 {
                                     try
                                     {
                                         var newthing = (T)type.CreateInstance();
                                         saveTypes.Add(type, newthing);
-                                        builder.Add(newthing);
+                                        
+                                        // if BeforeAttribute is used, insert somewhere before the marked type.
+                                        // otherwise insert at the end of the list.
+                                        int addIndex = builder.Count;
+                                        if (type.GetAttribute<BeforeAttribute>() is BeforeAttribute before)
+                                        {
+                                            int addIndex2 = builder.IndexWhen(item => before.Before(TypeData.GetTypeData(item)));
+                                            if (addIndex2 != -1)
+                                                addIndex = addIndex2;
+                                        }
+                                        
+                                        builder.Insert(addIndex, newthing);
                                     }
                                     catch
                                     {
@@ -80,6 +92,7 @@ namespace OpenTap
                                     } // Ignore errors here.
                                 }
                             }
+                            
                             things = builder.ToArray();
                         }
                     }
@@ -109,9 +122,9 @@ namespace OpenTap
                     return str;
                 }
 
-                public object FromString(string stringdata, ITypeData type, object contextObject, CultureInfo culture)
+                public object FromString(string stringData, ITypeData type, object contextObject, CultureInfo culture)
                 {
-                    object obj = inner.FromString(stringdata, type, contextObject, culture);
+                    object obj = inner.FromString(stringData, type, contextObject, culture);
                     if (obj != null)
                         Popularity += 1;
                     return obj;
@@ -293,27 +306,27 @@ namespace OpenTap
         internal class ConvertibleStringConvertProvider : IStringConvertProvider
         {
             /// <summary> Returns an IConvertible if applicable. </summary>
-            public object FromString(string stringdata, ITypeData _type, object contextObject, CultureInfo culture)
+            public object FromString(string stringData, ITypeData _type, object contextObject, CultureInfo culture)
             {
                 var type = (_type as TypeData)?.Type;
                 if (type == null) return null;
                 if (type == typeof(DateTime))
                 {
-                    return DateTime.ParseExact(stringdata, "yyyy-MM-dd HH-mm-ss", culture);
+                    return DateTime.ParseExact(stringData, "yyyy-MM-dd HH-mm-ss", culture);
                 }
                 if (type.IsNumeric())
                 {
-                    if(new NumberFormatter(culture).TryParseNumber(stringdata, type, out object val))
+                    if(new NumberFormatter(culture).TryParseNumber(stringData, type, out object val))
                     {
                         return val;
                     }
                     return null;
                 }
                 else if (type == typeof(string))
-                    return stringdata;
+                    return stringData;
                 else if(type == typeof(bool))
                 {
-                    if (bool.TryParse(stringdata, out bool value))
+                    if (bool.TryParse(stringData, out bool value))
                         return value;
                     return null;
                 }
@@ -322,7 +335,7 @@ namespace OpenTap
                 {
                     try
                     {
-                        return Convert.ChangeType(stringdata, type, culture);
+                        return Convert.ChangeType(stringData, type, culture);
                     }
                     catch
                     {
@@ -363,26 +376,26 @@ namespace OpenTap
             }
 
             /// <summary> Creates an Enabled from a string. </summary>
-            public object FromString(string stringdata, ITypeData _type, object contextObject, CultureInfo culture)
+            public object FromString(string stringData, ITypeData _type, object contextObject, CultureInfo culture)
             {
                 Type type = (_type as TypeData)?.Type;
                 if (type == null) return null;
                 if (type.DescendsTo(typeof(IEnabledValue)) == false)
                     return null;
-                stringdata = stringdata.Trim();
+                stringData = stringData.Trim();
                 var disabled = "(disabled)";
                 IEnabledValue enabled = (IEnabledValue)Activator.CreateInstance(type);
                 var elemType = GetEnabledElementType(type);
-                if (stringdata.StartsWith(disabled))
+                if (stringData.StartsWith(disabled))
                 {
-                    if (StringConvertProvider.TryFromString(stringdata.Substring(disabled.Length).Trim(), TypeData.FromType(elemType), null, out object obj, culture))
+                    if (StringConvertProvider.TryFromString(stringData.Substring(disabled.Length).Trim(), TypeData.FromType(elemType), null, out object obj, culture))
                         enabled.Value = obj;
                     else return null;
                     enabled.IsEnabled = false;
                 }
                 else
                 {
-                    if (StringConvertProvider.TryFromString(stringdata, TypeData.FromType(elemType), null, out object obj, culture))
+                    if (StringConvertProvider.TryFromString(stringData, TypeData.FromType(elemType), null, out object obj, culture))
                         enabled.Value = obj;
                     else return null;
                     enabled.IsEnabled = true;
@@ -486,13 +499,13 @@ namespace OpenTap
             }
 
             /// <summary> Creates an enum from a string. </summary>
-            public object FromString(string stringdata, ITypeData type, object contextObject, CultureInfo culture)
+            public object FromString(string stringData, ITypeData type, object contextObject, CultureInfo culture)
             {
                 if (type is TypeData cst)
                 {
                     if (false == cst.Type.IsEnum) return null;
                     Enum result;
-                    if (tryParseEnumString(stringdata, cst.Type, out result) == false)
+                    if (tryParseEnumString(stringData, cst.Type, out result) == false)
                         return null;
                     return result;
                 }
@@ -557,7 +570,7 @@ namespace OpenTap
         internal class ListStringConvertProvider : IStringConvertProvider
         {
             /// <summary> Creates a sequence from string. </summary>
-            public object FromString(string stringdata, ITypeData _type, object contextObject, CultureInfo culture)
+            public object FromString(string stringData, ITypeData _type, object contextObject, CultureInfo culture)
             {
                 var type = (_type as TypeData)?.Type;
                 if (type.DescendsTo(typeof(IEnumerable)) == false) return null;
@@ -570,7 +583,7 @@ namespace OpenTap
                 if (elemType.IsNumeric())
                 {
                     var fmt = new NumberFormatter(culture);
-                    var data = fmt.Parse(stringdata);
+                    var data = fmt.Parse(stringData);
                     if (data.GetType().DescendsTo(type))
                         return data;
                     seq = data.CastTo(elemType).Cast<object>().ToArray();
@@ -580,12 +593,12 @@ namespace OpenTap
                     // unescape nested strings and put them into 'parsedStrings'.
                     // after this they will be handled individually.
                     List<string> parsedStrings = new List<string>();
-                    if (stringdata.Length > 0)
+                    if (stringData.Length > 0)
                     {
                         StringBuilder buffer = new StringBuilder();
-                        for (int i = 0; i < stringdata.Length; i++)
+                        for (int i = 0; i < stringData.Length; i++)
                         {
-                            var chr = stringdata[i];
+                            var chr = stringData[i];
                             if (chr == ',')
                             {
                                 parsedStrings.Add(buffer.ToString());
@@ -595,12 +608,12 @@ namespace OpenTap
 
                             if (chr == '"')
                             {
-                                for (i += 1; i < stringdata.Length; i++)
+                                for (i += 1; i < stringData.Length; i++)
                                 {
-                                    chr = stringdata[i];
+                                    chr = stringData[i];
                                     if (chr == '"')
                                     {
-                                        if (stringdata.Length > i + 1 && stringdata[i + 1] == '"')
+                                        if (stringData.Length > i + 1 && stringData[i + 1] == '"')
                                             i += 1; // skip escaped quotes and remove extra \".
                                         else break;
                                     }
@@ -731,11 +744,11 @@ namespace OpenTap
                 }
             }
             /// <summary> Finds a IResource based on strings. Only works on things loaded in Component Settings. </summary>
-            public object FromString(string stringdata, ITypeData type, object contextObject, CultureInfo culture)
+            public object FromString(string stringData, ITypeData type, object contextObject, CultureInfo culture)
             {
                 if (type.DescendsTo(typeof(IResource)) == false) return null;
                 if (type is TypeData)
-                    return allResources.FirstOrDefault(x => x.Name == stringdata && TypeData.GetTypeData(x).DescendsTo(type));
+                    return allResources.FirstOrDefault(x => x.Name == stringData && TypeData.GetTypeData(x).DescendsTo(type));
                 return null;
             }
 
@@ -797,16 +810,16 @@ namespace OpenTap
             /// <summary>
             /// Gets a TestStep from a string value. This will be a step from the test plan context object.
             /// </summary>
-            /// <param name="stringdata"></param>
+            /// <param name="stringData"></param>
             /// <param name="type"></param>
             /// <param name="contextObject"></param>
             /// <param name="culture"></param>
             /// <returns></returns>
-            public object FromString(string stringdata, ITypeData type, object contextObject, CultureInfo culture)
+            public object FromString(string stringData, ITypeData type, object contextObject, CultureInfo culture)
             {
                 if (type.DescendsTo(typeof(ITestStep)) && contextObject is ITestStepParent parent)
                 {
-                    if(Guid.TryParse(stringdata, out Guid id))
+                    if(Guid.TryParse(stringData, out Guid id))
                     {
                         return GetStepFromContext(parent, id);
                     }
@@ -830,16 +843,16 @@ namespace OpenTap
         internal class InputStringConvertProvider : IStringConvertProvider
         {
             /// <summary> Creates an Input from a string. contextObject must be an ITestStep.</summary>
-            /// <param name="stringdata"></param>
+            /// <param name="stringData"></param>
             /// <param name="type"></param>
             /// <param name="contextObject"></param>
             /// <param name="culture"></param>
             /// <returns></returns>
-            public object FromString(string stringdata, ITypeData type, object contextObject, CultureInfo culture)
+            public object FromString(string stringData, ITypeData type, object contextObject, CultureInfo culture)
             {
                 if (!type.DescendsTo(typeof(IInput))) return null;
                 
-                var s = stringdata.Split(':');
+                var s = stringData.Split(':');
                 var step = contextObject as ITestStep;
                 if (step == null) return null;
                 if (s.Length != 2) return null;
@@ -878,11 +891,11 @@ namespace OpenTap
         internal class BoolConverter : IStringConvertProvider
         {
             /// <summary> Creates a bool from a string. </summary>
-            public object FromString(string stringdata, ITypeData type, object ctx, CultureInfo culture)
+            public object FromString(string stringData, ITypeData type, object ctx, CultureInfo culture)
             {
                 if (type.IsA(typeof(bool)))
                 {
-                    var sd = stringdata.ToLower();
+                    var sd = stringData.ToLower();
 
                     switch (sd)
                     {

--- a/Engine/IStringConvertProvider.cs
+++ b/Engine/IStringConvertProvider.cs
@@ -98,11 +98,9 @@ namespace OpenTap
 
                             // iterate to find the correct ordering.
                             // this is a bit akin to bubble sorting, but the chance that these dependenceny chains gets very long is limited.
-                            // max number of iterations set to 10 to avoid looping infinitely in case of circular dependencies.
-                            for (int it = 0; it < 10; it++)
                             {
+                                HashSet<(T, T)> swapPairs = new HashSet<(T, T)>();
 
-                                bool changed = false;
                                 for (int i = 0; i < builder.Count; i++)
                                 {
                                     int addIndex = i;
@@ -115,12 +113,13 @@ namespace OpenTap
                                     }
                                     if (addIndex < i)
                                     {
-                                        changed = true;
+                                        if (swapPairs.Add((builder[addIndex], builder[i])) == false)
+                                            throw new Exception("Circular dependency in BeforeAttribute"); // these has been swapped before - that means there is a circular dependency.
+                                        
                                         (builder[i], builder[addIndex]) = (builder[addIndex], builder[i]);
+                                        i = addIndex;
                                     }
                                 }
-
-                                if (!changed) break;
                             }
 
                             things = builder.ToArray();


### PR DESCRIPTION
- Added BeforeAttribute, which adds an ordering constraint to plugin types (currently only supported by string convert providers).
- Added ordering to plugin resolver for IStringConvertProvider.
- Added unit test that verifies the new behavior.

Close #1097 