### PR TITLE
CliUserInputInterface: Read from stdin pipe if no terminal is connected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,10 +231,11 @@ jobs:
         run: |
           dotnet restore /p:Platform=${{ matrix.Architecture }}
       - name: Build
-        run: |
-          dotnet build --no-restore -c Release /p:Platform=${{ matrix.Architecture }}
-          dotnet build --no-restore tap/tap.csproj -c Release /p:Platform=${{ matrix.Architecture }}
-          get-content ./bin/Release/tap.runtimeconfig.json
+        run: dotnet build --no-restore -c Release /p:Platform=${{ matrix.Architecture }}
+      - name: Build tap.csproj
+        run: dotnet build --no-restore tap/tap.csproj -c Release /p:Platform=${{ matrix.Architecture }}
+      - name: cat tap.runtimeconfig.json 
+        run: get-content ./bin/Release/tap.runtimeconfig.json
       - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
@@ -339,9 +340,8 @@ jobs:
           name: win-x64-bin
           path: bin/Release/
       - name: Test
-        run: |
-          cd bin/Release
-          ./tap.exe run ../../tests/regression.TapPlan --verbose --color
+        working-directory: bin/Release
+        run: ./tap.exe run ../../tests/regression.TapPlan --verbose --color
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/Engine.UnitTests/TestTestSteps/PipingProcessStep.cs
+++ b/Engine.UnitTests/TestTestSteps/PipingProcessStep.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using OpenTap.Cli;
+using OpenTap;
+
+namespace OpenTap.Engine.UnitTests.TestTestSteps
+{
+    [Display("user-input", "Used to verify user-input implementations", Group: "test")]
+    public class UserInputTestAction : ICliAction
+    {
+        public class RequestObject
+        {
+            [Submit] public string Answer { get; set; }
+        }
+
+        [CommandLineArgument("answers", ShortName = "a",
+            Description = "The answers that the caller is intending to give.")]
+        public string[] ExpectedAnswers { get; set; }
+
+        private static TraceSource log = Log.CreateSource(nameof(UserInputTestAction));
+
+        public static string DescribeBytes(IEnumerable<char> i)
+        {
+            var s = i.ToArray();
+            if (s.Length == 0) return "[]";
+
+            var sb = new StringBuilder();
+            sb.Append('[');
+            foreach (var ch in s)
+            {
+                sb.Append(string.Format("0x{0:X}", (int)ch));
+                sb.Append(", ");
+            }
+            sb.Remove(sb.Length - 2, 2);
+            sb.Append(']');
+            return sb.ToString();
+        }
+
+        public int Execute(CancellationToken cancellationToken)
+        {
+            try
+            {
+                for (int i = 0; i < ExpectedAnswers.Length; i++)
+                {
+                    var r = new RequestObject();
+                    log.Info($"Checking input {i + 1} of {ExpectedAnswers.Length} ({ExpectedAnswers[i]})");
+                    UserInput.Request(r);
+                    var exp = DescribeBytes(ExpectedAnswers[i]);
+                    var act = DescribeBytes(r.Answer);
+                    log.Info($"Expected: {exp}");
+                    log.Info($"  Actual: {act}");
+                    if (r.Answer.Equals(ExpectedAnswers[i], StringComparison.InvariantCulture) == false)
+                    {
+                        log.Error($"Input {i + 1} did not match the expected input:");
+                        log.Error($"Expected '{ExpectedAnswers[i]}', got '{r.Answer}'");
+                        return 3;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Error($"Error while reading input: {ex.Message}");
+                log.Debug(ex);
+            }
+
+            return 0;
+        }
+    }
+
+    [Display("Piping Process Step", "A run process step with support for piping", "Tests")]
+    public class PipingProcessStep : TestStep
+    {
+        [Display("Application", Order: -2.5,
+            Description:
+            "The path to the program. It should contain either a relative path to OpenTAP installation folder or an absolute path to the program.")]
+        [FilePath(FilePathAttribute.BehaviorChoice.Open, "exe")]
+        public string Application { get; set; } = "";
+
+        [Display("Command Line Arguments", Order: -2.4, Description: "The arguments passed to the program.")]
+        [DefaultValue("")]
+        public string Arguments { get; set; } = "";
+
+        [Display("Expected Exit Code", "The expected exit code of the process.")]
+        public int ExpectedExitCode { get; set; } = 0;
+
+        [Display("Write Speed", "How fast should the input be written to the process stream. Measured in number of milliseconds between writes")]
+        [Unit("ms")]
+        public int WriteSpeed { get; set; } = 100;
+
+        [Layout(LayoutMode.Normal, 2, maxRowHeight: 5)]
+        [Display("Pipe Data", "The data that should be written to the process' input stream.")]
+        public string StdIn { get; set; } = "";
+
+        public enum WriteMode
+        {
+            WriteLines,
+            WriteChars,
+            WriteAll,
+        }
+
+        [Display("Write Mode", "How should the data be written to the pipe?")]
+        public WriteMode Mode { get; set; }
+
+        public override void Run()
+        {
+            using var process = new Process
+            {
+                StartInfo =
+                {
+                    FileName = Application,
+                    Arguments = Arguments,
+                    WorkingDirectory = Directory.GetCurrentDirectory(),
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    CreateNoWindow = true,
+                }
+            };
+
+            Log.Info($"Starting process '{Application}' with arguments '{Arguments}'.");
+
+            if (!process.Start())
+            {
+                Log.Error("Process failed to start.");
+                UpgradeVerdict(Verdict.Error);
+                return;
+            }
+            
+            process.OutputDataReceived += (sender, args) =>
+            {
+                if (args.Data == null) return;
+                Log.Info(args.Data);
+            };
+            process.ErrorDataReceived += (sender, args) =>
+            {
+                if (args.Data == null) return;
+                Log.Error(args.Data);
+            };
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            process.StandardInput.AutoFlush = true;
+
+            Log.Info($"Writing payload to process: {UserInputTestAction.DescribeBytes(StdIn)}");
+
+            try
+            {
+                var w = process.StandardInput;
+                switch (Mode)
+                {
+                    case WriteMode.WriteAll:
+                        w.Write(StdIn);
+                        break;
+                    case WriteMode.WriteLines:
+                        foreach (var line in StdIn.Trim().Split('\n'))
+                        {
+                            if (WriteSpeed > 0)
+                                TapThread.Sleep(WriteSpeed);
+                            if (process.HasExited) break;
+                            w.WriteLine(line);
+                        }
+
+                        break;
+                    case WriteMode.WriteChars:
+                        foreach (char ch in StdIn)
+                        {
+                            if (WriteSpeed > 0)
+                                TapThread.Sleep(WriteSpeed);
+                            if (process.HasExited) break;
+                            w.Write(ch);
+                        }
+
+                        break;
+                }
+            }
+            // Writing to the input pipe will fail if the process has already exited
+            catch (Exception) when (process.HasExited)
+            {
+                // suppress
+            }
+            if (!process.HasExited)
+                process.StandardInput.Close(); 
+
+            if (!process.WaitForExit((int)TimeSpan.FromSeconds(10).TotalMilliseconds))
+            {
+                Log.Error("Process did not exit in a timely fashion.");
+                UpgradeVerdict(Verdict.Error);
+                return;
+            }
+
+            if (process.ExitCode == ExpectedExitCode)
+                UpgradeVerdict(Verdict.Pass);
+            else
+            {
+                Log.Error($"Expected exit code {ExpectedExitCode}, was {process.ExitCode}.");
+                UpgradeVerdict(Verdict.Fail);
+            }
+        }
+    }
+}

--- a/Package.UnitTests/PackageDefTest2.cs
+++ b/Package.UnitTests/PackageDefTest2.cs
@@ -56,7 +56,7 @@ namespace OpenTap.Package.UnitTests
                 for (int i = 0; i < 2; i++)
                 {
                     // uninstall twice, once for each Test4 package xml.
-                    new PackageUninstallAction { Packages = new[] { "Test4" } }.Execute(CancellationToken.None);
+                    new PackageUninstallAction { Packages = new[] { "Test4" }, NonInteractive = true }.Execute(CancellationToken.None);
                 }
                 var i2 = new Installation(installDir);
                 

--- a/Package/AutoCorrectPackageNames.cs
+++ b/Package/AutoCorrectPackageNames.cs
@@ -25,8 +25,6 @@ namespace OpenTap.Package
         public static string[] Correct(string[] names, IEnumerable<IPackageRepository> repositories)
         {
             if (names == null || names.Length == 0) return names;
-            // We can't provide any corrections if the non-interactive user input is set
-            if (NonInteractiveUserInputInterface.IsSet()) return names;
             // Copy the input array to use as return value
             var result = names.ToArray();
             

--- a/Package/Installer.cs
+++ b/Package/Installer.cs
@@ -273,7 +273,7 @@ namespace OpenTap.Package
                 var tries = 0;
                 const int maxTries = 10;
                 var delaySeconds = 3;
-                var noninteractive = NonInteractiveUserInputInterface.IsSet();
+                var noninteractive = UserInput.GetInterface() is NonInteractiveUserInputInterface;
                 var inUseString = BuildString(filesInUse);
                 if (noninteractive)
                     log.Warning(inUseString);

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -113,7 +113,8 @@ namespace OpenTap.Package
 
             if (NoCache) PackageManagerSettings.Current.UseLocalPackageCache = false;
             List<IPackageRepository> repositories = PackageManagerSettings.Current.GetEnabledRepositories(Repository);
-            Packages = AutoCorrectPackageNames.Correct(Packages, repositories);
+            if (!NonInteractive)
+                Packages = AutoCorrectPackageNames.Correct(Packages, repositories);
 
             bool installError = false;
             var installer = new Installer(Target, cancellationToken)
@@ -166,7 +167,7 @@ namespace OpenTap.Package
                     // We could also ask for an RC / Any, but if there are no releases, then it is likely also the case that there are no RCs.
                     // 'any' would be the most likely specifier to succeed, but it is probably a bit too extreme to suggest something so bleeding edge.
                     // A beta version strikes a good middle ground. It is pretty likely to resolve, and probably won't be too unstable.
-                    if (NonInteractiveUserInputInterface.IsSet()) throw;
+                    if (NonInteractive) throw;
                     if (Packages.Length != 1) throw;
                     if (fir.resolveProblems.Count != 1) throw;
 

--- a/Package/PackageActions/Uninstall.cs
+++ b/Package/PackageActions/Uninstall.cs
@@ -47,7 +47,7 @@ namespace OpenTap.Package
             }
 
             // Skip auto-correction if ignore-missing is specified
-            if (!IgnoreMissing) 
+            if (IgnoreMissing == false && NonInteractive == false) 
                 Packages = AutoCorrectPackageNames.Correct(Packages, Array.Empty<IPackageRepository>());
 
             var installation = new Installation(Target);

--- a/tests/regression.TapPlan
+++ b/tests/regression.TapPlan
@@ -109,6 +109,10 @@
           <Filepath>../../tests/test-cli-load-plan-with-error.TapPlan</Filepath>
           <Name Metadata="Step Name">Test Plan {Referenced Plan}</Name>
         </TestStep>
+        <TestStep type="ref@OpenTap.Plugins.BasicSteps.TestPlanReference" Id="beef7d35-9a8e-4b78-b04b-c0ffe98d2a83">
+          <Filepath>../../tests/test-piped-input.TapPlan</Filepath>
+          <Name Metadata="Step Name">Test Plan {Referenced Plan}</Name>
+        </TestStep>
       </ChildTestSteps>
     </TestStep>
   </Steps>

--- a/tests/test-piped-input.TapPlan
+++ b/tests/test-piped-input.TapPlan
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestPlan type="OpenTap.TestPlan">
+  <Steps>
+    <TestStep type="OpenTap.Plugins.BasicSteps.SweepParameterStep" Id="d81ecd6a-9e5f-41f1-bc2f-6546a7aae264" OpenTap.Visibility="Visible">
+      <SweepValues>
+        <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+          <Enabled>true</Enabled>
+          <Loop>d81ecd6a-9e5f-41f1-bc2f-6546a7aae264</Loop>
+          <Parameters_x0020__x005C__x0020_Write_x0020_Speed>500</Parameters_x0020__x005C__x0020_Write_x0020_Speed>
+        </SweepRow>
+        <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+          <Enabled>true</Enabled>
+          <Loop>d81ecd6a-9e5f-41f1-bc2f-6546a7aae264</Loop>
+          <Parameters_x0020__x005C__x0020_Write_x0020_Speed>100</Parameters_x0020__x005C__x0020_Write_x0020_Speed>
+        </SweepRow>
+        <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+          <Enabled>true</Enabled>
+          <Loop>d81ecd6a-9e5f-41f1-bc2f-6546a7aae264</Loop>
+          <Parameters_x0020__x005C__x0020_Write_x0020_Speed>10</Parameters_x0020__x005C__x0020_Write_x0020_Speed>
+        </SweepRow>
+        <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+          <Enabled>true</Enabled>
+          <Loop>d81ecd6a-9e5f-41f1-bc2f-6546a7aae264</Loop>
+          <Parameters_x0020__x005C__x0020_Write_x0020_Speed>0</Parameters_x0020__x005C__x0020_Write_x0020_Speed>
+        </SweepRow>
+      </SweepValues>
+      <Selected>
+        <KeyValuePairOfString>
+          <Key>Parameters \ Write Speed</Key>
+          <Value>true</Value>
+        </KeyValuePairOfString>
+      </Selected>
+      <Name Metadata="Step Name">Sweep {Parameters}</Name>
+      <ChildTestSteps>
+        <TestStep type="OpenTap.Plugins.BasicSteps.SweepParameterStep" Id="2b9606bd-385e-46c5-ad11-a2f9b4f022d0" OpenTap.Visibility="Visible">
+          <SweepValues>
+            <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+              <Enabled>true</Enabled>
+              <Loop>2b9606bd-385e-46c5-ad11-a2f9b4f022d0</Loop>
+              <Parameters_x0020__x005C__x0020_Write_x0020_Mode>WriteChars</Parameters_x0020__x005C__x0020_Write_x0020_Mode>
+            </SweepRow>
+            <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+              <Enabled>true</Enabled>
+              <Loop>2b9606bd-385e-46c5-ad11-a2f9b4f022d0</Loop>
+              <Parameters_x0020__x005C__x0020_Write_x0020_Mode>WriteLines</Parameters_x0020__x005C__x0020_Write_x0020_Mode>
+            </SweepRow>
+            <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+              <Enabled>true</Enabled>
+              <Loop>2b9606bd-385e-46c5-ad11-a2f9b4f022d0</Loop>
+              <Parameters_x0020__x005C__x0020_Write_x0020_Mode>WriteAll</Parameters_x0020__x005C__x0020_Write_x0020_Mode>
+            </SweepRow>
+          </SweepValues>
+          <Selected>
+            <KeyValuePairOfString>
+              <Key>Parameters \ Write Mode</Key>
+              <Value>true</Value>
+            </KeyValuePairOfString>
+          </Selected>
+          <Name Metadata="Step Name">Sweep {Parameters}</Name>
+          <ChildTestSteps>
+            <TestStep type="OpenTap.Plugins.BasicSteps.SweepParameterStep" Id="db563fc5-9dd9-4777-925d-7b490560c8fe" OpenTap.Visibility="Visible">
+              <SweepValues>
+                <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+                  <Enabled>true</Enabled>
+                  <Loop>db563fc5-9dd9-4777-925d-7b490560c8fe</Loop>
+                  <Parameters_x0020__x005C__x0020_Pipe_x0020_Data>
+                    <Base64>aGVsbG8Kd29ybGQK</Base64>
+                  </Parameters_x0020__x005C__x0020_Pipe_x0020_Data>
+                  <Parameters_x0020__x005C__x0020_Expected_x0020_Exit_x0020_Code>0</Parameters_x0020__x005C__x0020_Expected_x0020_Exit_x0020_Code>
+                </SweepRow>
+                <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+                  <Enabled>true</Enabled>
+                  <Loop>db563fc5-9dd9-4777-925d-7b490560c8fe</Loop>
+                  <Parameters_x0020__x005C__x0020_Pipe_x0020_Data>
+                    <Base64>aGVsbG8Kd29ybGQyCg==</Base64>
+                  </Parameters_x0020__x005C__x0020_Pipe_x0020_Data>
+                  <Parameters_x0020__x005C__x0020_Expected_x0020_Exit_x0020_Code>3</Parameters_x0020__x005C__x0020_Expected_x0020_Exit_x0020_Code>
+                </SweepRow>
+                <SweepRow type="OpenTap.Plugins.BasicSteps.SweepRow">
+                  <Enabled>true</Enabled>
+                  <Loop>db563fc5-9dd9-4777-925d-7b490560c8fe</Loop>
+                  <Parameters_x0020__x005C__x0020_Pipe_x0020_Data>
+                    <Base64>aGVsbG8yCndvcmxkCg==</Base64>
+                  </Parameters_x0020__x005C__x0020_Pipe_x0020_Data>
+                  <Parameters_x0020__x005C__x0020_Expected_x0020_Exit_x0020_Code>3</Parameters_x0020__x005C__x0020_Expected_x0020_Exit_x0020_Code>
+                </SweepRow>
+              </SweepValues>
+              <Selected>
+                <KeyValuePairOfString>
+                  <Key>Parameters \ Expected Exit Code</Key>
+                  <Value>true</Value>
+                </KeyValuePairOfString>
+                <KeyValuePairOfString>
+                  <Key>Parameters \ Pipe Data</Key>
+                  <Value>true</Value>
+                </KeyValuePairOfString>
+              </Selected>
+              <Name Metadata="Step Name">Sweep {Parameters}</Name>
+              <ChildTestSteps>
+                <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.PipingProcessStep" Id="897f3045-5f3b-4520-831c-1e69c4f129c1">
+                  <Application>tap</Application>
+                  <Arguments>test user-input -a hello -a world</Arguments>
+                  <ExpectedExitCode Parameter="Parameters \ Expected Exit Code" Scope="db563fc5-9dd9-4777-925d-7b490560c8fe">3</ExpectedExitCode>
+                  <WriteSpeed Parameter="Parameters \ Write Speed" Scope="d81ecd6a-9e5f-41f1-bc2f-6546a7aae264">0</WriteSpeed>
+                  <StdIn Parameter="Parameters \ Pipe Data" Scope="db563fc5-9dd9-4777-925d-7b490560c8fe">
+                    <Base64>aGVsbG8yCndvcmxkCg==</Base64>
+                  </StdIn>
+                  <Mode Parameter="Parameters \ Write Mode" Scope="2b9606bd-385e-46c5-ad11-a2f9b4f022d0">WriteAll</Mode>
+                  <Name Metadata="Step Name">{Write Mode} - {Write Speed} - Expect {Expected Exit Code}</Name>
+                </TestStep>
+              </ChildTestSteps>
+              <Parameters_x0020__x005C__x0020_Pipe_x0020_Data>
+                <Base64>aGVsbG8yCndvcmxkCg==</Base64>
+              </Parameters_x0020__x005C__x0020_Pipe_x0020_Data>
+              <Parameters_x0020__x005C__x0020_Expected_x0020_Exit_x0020_Code>3</Parameters_x0020__x005C__x0020_Expected_x0020_Exit_x0020_Code>
+            </TestStep>
+          </ChildTestSteps>
+          <Parameters_x0020__x005C__x0020_Write_x0020_Mode>WriteAll</Parameters_x0020__x005C__x0020_Write_x0020_Mode>
+        </TestStep>
+      </ChildTestSteps>
+      <Parameters_x0020__x005C__x0020_Write_x0020_Speed>0</Parameters_x0020__x005C__x0020_Write_x0020_Speed>
+    </TestStep>
+  </Steps>
+</TestPlan>


### PR DESCRIPTION
This adds a separate reader mode for the CLI user input handler. This reader mode is automatically used when `Console.IsInputRedirected` is set. This will be set whenever the the stdin of the process is not attached to a terminal. 


| Input Mode | Description |
| --- | --- |
| Piped | Stdin is read line by line. UserInput request `n` gets the value of line `n`. If EOF is reached, and there are more UserInput requests, an EOF exception is thrown. |
| Stdin | (unchanged) Stdin is continously read line by line by a background thread. When a user input arrives, it blocks until it times out, or a line is produced by the worker thread. |

Closes #1092