### PR TITLE
Fix regression: Network paths not handled correctly

### DIFF
--- a/Package.UnitTests/PackageManagerTests.cs
+++ b/Package.UnitTests/PackageManagerTests.cs
@@ -63,6 +63,7 @@ namespace OpenTap.Package.UnitTests
         [TestCase("C:\\Packages/", "file:///C:/Packages", "Windows")]
         [TestCase("PackageCache", "file:///{CurrentDirectory}/PackageCache")]
         [TestCase("PackageCache/", "file:///{CurrentDirectory}/PackageCache")]
+        [TestCase(@"\\wsl.localhost\arch\packages\", "file://wsl.localhost/arch/packages")]
         public void FileRepositoryUrls(string input, string expectedUrl, string os = "Windows,Linux")
         {
             if (!os.Contains(OperatingSystem.Current.ToString()))

--- a/Package.UnitTests/PackageManagerTests.cs
+++ b/Package.UnitTests/PackageManagerTests.cs
@@ -64,6 +64,7 @@ namespace OpenTap.Package.UnitTests
         [TestCase("PackageCache", "file:///{CurrentDirectory}/PackageCache")]
         [TestCase("PackageCache/", "file:///{CurrentDirectory}/PackageCache")]
         [TestCase(@"\\wsl.localhost\arch\packages\", "file://wsl.localhost/arch/packages")]
+        [TestCase(@"\\192.168.0.100\some\directory\", "file://192.168.0.100/some/directory")]
         public void FileRepositoryUrls(string input, string expectedUrl, string os = "Windows,Linux")
         {
             if (!os.Contains(OperatingSystem.Current.ToString()))

--- a/Package/Tap.Package.csproj
+++ b/Package/Tap.Package.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>OpenTap.Package</AssemblyName>
     <RootNamespace>OpenTap.Package</RootNamespace>
     <DocumentationFile>$(OutputPath)\OpenTap.Package.xml</DocumentationFile>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It looks like we broke UNC paths when we added support for relative URLs.

Closes #1082