### PR TITLE
AssemblyLoadContext experimentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,6 +450,10 @@ jobs:
         env: 
           TAP_SIGN_CERT: ${{ github.workspace }}/sign.cer
         run:  echo "${{ secrets.SIGN_SERVER_CERT }}" > $env:TAP_SIGN_CERT
+      - name: Newtonsoft Hack
+        working-directory: bin/Release-${{ matrix.Architecture }}
+        # Manually copy the correct newtonsoft dll here since it was overwritten by a unittest
+        run: cp ../../Installer/Assets/Newtonsoft.Json.dll .
       - name: Create Package
         working-directory: bin/Release-${{ matrix.Architecture }}
         env: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           #Copy-Item .\bin\Release\runtimes\win-x64\native\git2-b7bad55.dll .\bin\Release
           cd bin/Release
-          dotnet vstest /framework:.NETFramework,Version=v4.62 /Platform:x64 OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" -- RunConfiguration.TreatNoTestsAsError=true
+          dotnet vstest OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" -- RunConfiguration.TreatNoTestsAsError=true
 
   TestWindowsPlan:
     runs-on: windows-2022

--- a/Cli/TapEntry.cs
+++ b/Cli/TapEntry.cs
@@ -167,23 +167,23 @@ namespace OpenTap.Cli
 
         }
 
-        private static void goInProcess()
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void loadCommandLine()
         {
             var start = DateTime.Now;
-            void loadCommandLine()
-            {
-                var args = Environment.GetCommandLineArgs();
-                bool isVerbose = args.Contains("--verbose") || args.Contains("-v");
-                bool isQuiet = args.Contains("--quiet") || args.Contains("-q"); ;
-                ConsoleTraceListener.SetStartupTime(start);
-                var cliTraceListener = new ConsoleTraceListener(isVerbose, isQuiet, IsColor());
-                Log.AddListener(cliTraceListener);
-                cliTraceListener.TraceEvents(TapInitializer.InitTraceListener.Instance.AllEvents.ToArray());
-                TapInitializer.InitTraceListener.Instance.AllEvents.Clear();
-                AppDomain.CurrentDomain.ProcessExit += (s, e) => cliTraceListener.Flush();
+            var args = Environment.GetCommandLineArgs();
+            bool isVerbose = args.Contains("--verbose") || args.Contains("-v");
+            bool isQuiet = args.Contains("--quiet") || args.Contains("-q"); ;
+            ConsoleTraceListener.SetStartupTime(start);
+            var cliTraceListener = new ConsoleTraceListener(isVerbose, isQuiet, IsColor());
+            Log.AddListener(cliTraceListener);
+            cliTraceListener.TraceEvents(TapInitializer.InitTraceListener.Instance.AllEvents.ToArray());
+            TapInitializer.InitTraceListener.Instance.AllEvents.Clear();
+            // AppDomain.CurrentDomain.ProcessExit += (s, e) => cliTraceListener.Flush();
 
-            }
-
+        }
+        private static void goInProcess()
+        {
             TapInitializer.Initialize(); // This will dynamically load OpenTap.dll
             // loadCommandLine has to be called after Initialize 
             // to ensure that we are able to load OpenTap.dll
@@ -198,6 +198,10 @@ namespace OpenTap.Cli
             CliActionExecutor.Execute();
         }
 
+        public static void Go2()
+        {
+            Console.WriteLine("Hello, {s} world!");
+        }
         public static void Go()
         {
             if (ExecutorClient.IsExecutorMode)

--- a/Cli/TapEntry.cs
+++ b/Cli/TapEntry.cs
@@ -194,14 +194,25 @@ namespace OpenTap.Cli
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void wrapGoInProcess()
         {
-            DebuggerAttacher.TryAttach();
-            CliActionExecutor.Execute();
+            try
+            {
+                DebuggerAttacher.TryAttach();
+                CliActionExecutor.Execute();
+            }
+            finally
+            {
+                try
+                {
+                    // Aborting the main tap thread signals that various OpenTAP components should shut down and clean up
+                    TapThread.Current.Abort();
+                }
+                catch (OperationCanceledException)
+                {
+                    // expected
+                }
+            }
         }
 
-        public static void Go2()
-        {
-            Console.WriteLine("Hello, {s} world!");
-        }
         public static void Go()
         {
             if (ExecutorClient.IsExecutorMode)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,11 +13,6 @@
     <TargetFrameworkIdentifier></TargetFrameworkIdentifier>
     <TargetFrameworkVersion></TargetFrameworkVersion>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)' != 'Unix'">
-    <!-- .net462 revert: on windows we build -->   
-    <OpenTapAppTargetFramework>net472</OpenTapAppTargetFramework>
-  </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <IsDebug>true</IsDebug>

--- a/Engine.UnitTests/AssemblyDataTest.cs
+++ b/Engine.UnitTests/AssemblyDataTest.cs
@@ -41,6 +41,7 @@ namespace OpenTap.UnitTests
         }
 
         [Test]
+        [Ignore("This is the expected behavior in .NET Framework. Sideloading works differently in .NET Core.")]
         public void ConflictingAssemblyVersionTest()
         {
             var s = PluginManager.GetSearcher();

--- a/Engine/AssemblyData.cs
+++ b/Engine/AssemblyData.cs
@@ -236,10 +236,11 @@ namespace OpenTap
     internal enum TargetFramework
     {
         Netstandard,
-        // .NETCore 2.x or 3.x -- We assume that these versions are roughly compatible with .NetFramework
-        // because we have done so in the past, and the assemblies can be loaded without error
-        Net,
         // .NET 5 or newer
+        Net,
+        // .NETCore 2.x or 3.x -- We assume that these versions are roughly compatible with .NetFramework
+        // because we have done so in the past, and the assemblies can be loaded without error.
+        // e.g. LibGit2Sharp is compiled against NetCoreApp 3.1, and we have not had issues with this.
         NetCoreApp,  
         NetFramework,
     }

--- a/Engine/AssemblyData.cs
+++ b/Engine/AssemblyData.cs
@@ -15,6 +15,10 @@ namespace OpenTap
     [DebuggerDisplay("{Name} ({Location})")]
     public class AssemblyData : ITypeDataSource
     {
+        internal TargetFramework? targetFramework = null;
+        // If the target framework was not resolved during load, just assume it's something netstandard compatible
+        internal TargetFramework TargetFramework => targetFramework ?? TargetFramework.Netstandard;
+        
         private static readonly TraceSource log = Log.CreateSource("AssemblyData");
         /// <summary>
         /// The name of the assembly. This is the same as the filename without extension
@@ -227,5 +231,16 @@ namespace OpenTap
 
         /// <summary> Returns name and version as a string. </summary>
         public override string ToString() =>  $"{Name}, {RawVersion}";
+    }
+
+    internal enum TargetFramework
+    {
+        Netstandard,
+        // .NETCore 2.x or 3.x -- We assume that these versions are roughly compatible with .NetFramework
+        // because we have done so in the past, and the assemblies can be loaded without error
+        Net,
+        // .NET 5 or newer
+        NetCoreApp,  
+        NetFramework,
     }
 }

--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -36,7 +36,7 @@ namespace OpenTap.Authentication
             {
                 foreach (var wait in waits)
                 {
-                    await Task.Delay(wait, cancellationToken);
+                    TapThread.Sleep(wait);
                     var result = await base.SendAsync(request, cancellationToken);
                     if (result.IsSuccessStatusCode == false && HttpUtils.TransientStatusCode(result.StatusCode) && wait != waits.Last())
                         continue;

--- a/Engine/PluginManager.cs
+++ b/Engine/PluginManager.cs
@@ -435,7 +435,9 @@ namespace OpenTap
         {
             string hash = " - ";
 
-            using (var file = new FileStream(assembly.Location, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 4 * 4096))
+            var bytes = File.ReadAllBytes(assembly.Location);
+
+            using (var file = new MemoryStream(bytes))
             {
                 byte[] hashValue = BitConverter.GetBytes(MurMurHash3.Hash(file));
 

--- a/Engine/Properties/AssemblyInfo.cs
+++ b/Engine/Properties/AssemblyInfo.cs
@@ -22,3 +22,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("OpenTap.UnitTests")]
 [assembly: InternalsVisibleTo("OpenTap.Sdk.Commands")]
+[assembly: InternalsVisibleTo("tap")]

--- a/Engine/ThreadManager.cs
+++ b/Engine/ThreadManager.cs
@@ -295,6 +295,11 @@ namespace OpenTap
             Abort(null);
         }
 
+        internal void AbortManager()
+        {
+            manager?.Dispose();
+        }
+
         /// <summary>
         /// Aborts the execution of this current instance of the <see cref="TapThread">TapThread</see> with a
         /// specified reason.
@@ -535,7 +540,7 @@ namespace OpenTap
         /// <summary> Creates a new ThreadManager. </summary>
         internal ThreadManager()
         {
-            var threadManagerThread = new Thread(threadManagerWork) { Name = "Thread Manager", IsBackground = true, Priority = ThreadPriority.Normal };
+            threadManagerThread = new Thread(threadManagerWork) { Name = "Thread Manager", IsBackground = true, Priority = ThreadPriority.Normal };
             threadManagerThread.Start();
             //ThreadPool.GetMaxThreads(out MaxWorkerThreads, out int _);
         }
@@ -591,6 +596,9 @@ namespace OpenTap
         // this avoids the threads shutting down just because of this.
         static readonly int timeout = 5 * 60 * 1000; // 5 minutes
         int threads = 0;
+
+        private Thread threadManagerThread;
+
         // This method can be processed by many threads at once.
         void processQueue()
         {
@@ -670,6 +678,7 @@ namespace OpenTap
             cancelSrc.Cancel();
             while (threads > 0)
                 Thread.Sleep(10);
+            threadManagerThread?.Abort();
         }
     }
 

--- a/Engine/ThreadManager.cs
+++ b/Engine/ThreadManager.cs
@@ -295,11 +295,6 @@ namespace OpenTap
             Abort(null);
         }
 
-        internal void AbortManager()
-        {
-            manager?.Dispose();
-        }
-
         /// <summary>
         /// Aborts the execution of this current instance of the <see cref="TapThread">TapThread</see> with a
         /// specified reason.

--- a/Engine/TypeData.cs
+++ b/Engine/TypeData.cs
@@ -17,6 +17,7 @@ namespace OpenTap
     [DebuggerDisplay("{Name}")]
     public class TypeData : ITypeData
     {
+        internal TargetFramework TargetFramework => Assembly.TargetFramework;
         // Used to mark when no display attribute is present.
         static readonly DisplayAttribute noDisplayAttribute = new DisplayAttribute("<<Null>>");
 
@@ -332,6 +333,11 @@ namespace OpenTap
                 failedLoad = true;
                 log.Error("Unable to load type '{0}' from '{1}'. Reason: '{2}'.", Name, Assembly.Location,
                     ex.Message);
+                if (PluginSearcher.CurrentRuntime == TargetFramework.Net && TargetFramework == TargetFramework.NetFramework)
+                {
+                    log.Error(
+                        $"This may be due to a runtime mismatch. The current runtime is .NET, but {Name} was compiled against .NET Framework.");
+                }
                 log.Debug(ex);
             }
 

--- a/OpenTAP.sln
+++ b/OpenTAP.sln
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tap.Upgrader", "Tap.Upgrade
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Templates", "templates\Templates.csproj", "{6E5F1D14-E4A4-40F5-9A98-926A05040CB6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tap-legacy", "tap-legacy\tap-legacy.csproj", "{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Shared\Tap.Shared.projitems*{11c58bd2-45e5-4a19-ae43-073b689fdb43}*SharedItemsImports = 13
@@ -189,6 +191,18 @@ Global
 		{6E5F1D14-E4A4-40F5-9A98-926A05040CB6}.Release|x64.Build.0 = Release|Any CPU
 		{6E5F1D14-E4A4-40F5-9A98-926A05040CB6}.Release|x86.ActiveCfg = Release|Any CPU
 		{6E5F1D14-E4A4-40F5-9A98-926A05040CB6}.Release|x86.Build.0 = Release|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Debug|x86.Build.0 = Debug|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Release|x64.Build.0 = Release|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Release|x86.ActiveCfg = Release|Any CPU
+		{3C5070E1-601D-43E3-A33E-AFC4AE843DCC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tap.Upgrader/Tap.Upgrader.csproj
+++ b/Tap.Upgrader/Tap.Upgrader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(OpenTapAppTargetFramework)</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,8 @@
     <Owner>OpenTAP</Owner>
     <!-- Common files  -->
     <Files Condition="$(Debug) == false">
-        <File  Condition="$(Platform) != Windows" Path="tap.runtimeconfig.json"/>
-        <File Condition="$(Platform) != Windows" Path="tap.dll">
+        <File Path="tap.runtimeconfig.json"/>
+        <File Path="tap.dll">
             <SetAssemblyInfo Attributes="Version" />
             <Sign Certificate="Keysight Technologies, Inc" Condition="$(Sign)==true"/>
         </File>
@@ -41,8 +41,8 @@
     </Files>
     <!-- For debug builds. Includes debugging symbols and puts all the DLLs in the OpenTAP root directory.  -->
     <Files Condition="$(Debug) == true">
-        <File Condition="$(Platform) != Windows" Path="tap.runtimeconfig.json"/>
-        <File Condition="$(Platform) != Windows" Path="tap.dll"/>
+        <File Path="tap.runtimeconfig.json"/>
+        <File Path="tap.dll"/>
         <File Path="tap.pdb"/>  
         <File Path="OpenTap.dll"/>
         <File Path="OpenTap.pdb"/>
@@ -57,6 +57,9 @@
     <!-- Windows only files -->
     <Files Condition="$(Platform) == Windows">
         <File Path="tap.exe">
+            <Sign Certificate="Keysight Technologies, Inc" Condition="$(Sign)==true"/>
+        </File>
+        <File Path="tap-legacy.exe">
             <Sign Certificate="Keysight Technologies, Inc" Condition="$(Sign)==true"/>
         </File>
         <!-- We ship an additional 'tap.exe' file because 'tap.exe' is not overwritten on Windows.

--- a/tap-legacy/Program.cs
+++ b/tap-legacy/Program.cs
@@ -1,0 +1,63 @@
+﻿//            Copyright Keysight Technologies 2012-2019
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+using System;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+
+namespace tap
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+            
+            // OPENTAP_INIT_DIRECTORY: Executing assembly is null when running with 'dotnet tap.dll' hence the following environment variable can be used.
+            Environment.SetEnvironmentVariable("OPENTAP_INIT_DIRECTORY", Path.GetDirectoryName(typeof(Program).Assembly.Location));
+            // in case TPM needs to update Tap.Cli.dll, we load it from memory to not keep the file in use
+            Assembly asm = null;
+            string entrypoint = "OpenTap.Cli.TapEntry";
+            try
+            {
+                string appDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+
+                Assembly load(string file)
+                {
+                    file = Path.Combine(appDir, file);
+                    if (File.Exists(file) == false)
+                        return null;
+                    return Assembly.Load(File.ReadAllBytes(file));
+                }
+                asm = load("Packages/OpenTAP/OpenTap.Cli.dll") ?? load("OpenTap.Cli.dll") ?? load("OpenTap.Cli.exe");
+                if (asm == null && File.Exists(Path.Combine(appDir, ".tapentry")))
+                {
+                    string[] lines = File.ReadAllLines(Path.Combine(appDir, ".tapentry"));
+                    asm = Assembly.Load(File.ReadAllBytes(Path.Combine(appDir, lines[0])));
+                    if (lines.Length > 1)
+                        entrypoint = lines[1];
+                }
+            }
+            catch
+            {
+                Console.WriteLine("Error finding OpenTAP CLI. Please try reinstalling OpenTAP.");
+                Environment.ExitCode = 7;
+                return;
+            }
+            if (asm == null)
+            {
+                Console.WriteLine("Missing OpenTAP CLI. Please try reinstalling OpenTAP.");
+                Environment.ExitCode = 8;
+                return;
+            }
+
+            var type = asm.GetType(entrypoint);
+            var method = type.GetMethod("Go", BindingFlags.Static | BindingFlags.Public);
+            method.Invoke(null, Array.Empty<object>());
+        }
+    }
+
+}

--- a/tap-legacy/tap-legacy.csproj
+++ b/tap-legacy/tap-legacy.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
+        <ApplicationIcon>../Installer/Assets/opentap.ico</ApplicationIcon>
+        <TargetFramework>net472</TargetFramework>
+    </PropertyGroup>
+</Project>

--- a/tap/DisposableLoadContext.cs
+++ b/tap/DisposableLoadContext.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace tap
+{
+    class DisposableLoadContext : AssemblyLoadContext, IDisposable
+    {
+
+        public DisposableLoadContext(string pluginPath) : base(true)
+        {
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            return base.Load(assemblyName);
+        }
+
+        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        {
+            return base.LoadUnmanagedDll(unmanagedDllName);
+        }
+
+        public void Dispose()
+        {
+            if (IsCollectible) 
+                Unload();
+        }
+    }
+}

--- a/tap/Program.cs
+++ b/tap/Program.cs
@@ -3,60 +3,132 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using System.Threading;
+using complex;
+using OpenTap;
+using OpenTap.Cli;
 
 namespace tap
 {
     class Program
     {
-        static void Main(string[] args)
+        private static void EnterAsm(Assembly asm)
         {
-            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
-            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+            // Setup assembly resolver before calling DeferLoad
+            string appDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            void DeferLoad()
+            {
+                var args = Environment.GetCommandLineArgs().Skip(1).ToArray();
+                var actionTree = new CliActionTree();
+                var selectedcmd = actionTree.GetSubCommand(args);
+                if (selectedcmd?.Type != null && selectedcmd?.SubCommands.Any() != true)
+                {
+                    var act = selectedcmd.Type;
+                    if (act.AsTypeData() is TypeData { TargetFramework: TargetFramework.NetFramework })
+                    {
+                        // execute in dotnet framework
+                        var proc = Process.Start(Path.Combine(appDir, "tap-legacy.exe"), string.Join(" ", args));
+                        proc.WaitForExit();
+                        Environment.Exit(proc.ExitCode);
+                    }
+
+                    var isolated = TypeData.GetTypeData("OpenTap.Package.IsolatedPackageAction");
+                    if (act.DescendsTo(isolated))
+                    {
+                        // go isolated
+                        // this involves unloading the current load context and creating a new, isolated context
+                        
+                    }
+                    else
+                    {
+                        var type = asm.GetType("OpenTap.Cli.TapEntry");
+                        var method = type.GetMethod("Go", BindingFlags.Static | BindingFlags.Public);
+                        method.Invoke(null, Array.Empty<object>());
+                    }
+                }
+            }
             
-            // OPENTAP_INIT_DIRECTORY: Executing assembly is null when running with 'dotnet tap.dll' hence the following environment variable can be used.
-            Environment.SetEnvironmentVariable("OPENTAP_INIT_DIRECTORY", Path.GetDirectoryName(typeof(Program).Assembly.Location));
-            // in case TPM needs to update Tap.Cli.dll, we load it from memory to not keep the file in use
-            Assembly asm = null;
-            string entrypoint = "OpenTap.Cli.TapEntry";
-            try
-            {
-                string appDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-
-                Assembly load(string file)
-                {
-                    file = Path.Combine(appDir, file);
-                    if (File.Exists(file) == false)
-                        return null;
-                    return Assembly.Load(File.ReadAllBytes(file));
-                }
-                asm = load("Packages/OpenTAP/OpenTap.Cli.dll") ?? load("OpenTap.Cli.dll") ?? load("OpenTap.Cli.exe");
-                if (asm == null && File.Exists(Path.Combine(appDir, ".tapentry")))
-                {
-                    string[] lines = File.ReadAllLines(Path.Combine(appDir, ".tapentry"));
-                    asm = Assembly.Load(File.ReadAllBytes(Path.Combine(appDir, lines[0])));
-                    if (lines.Length > 1)
-                        entrypoint = lines[1];
-                }
-            }
-            catch
-            {
-                Console.WriteLine("Error finding OpenTAP CLI. Please try reinstalling OpenTAP.");
-                Environment.ExitCode = 7;
-                return;
-            }
-            if (asm == null)
-            {
-                Console.WriteLine("Missing OpenTAP CLI. Please try reinstalling OpenTAP.");
-                Environment.ExitCode = 8;
-                return;
-            }
-
-            var type = asm.GetType(entrypoint);
+            var type = asm.GetType("OpenTap.Cli.TapEntry");
             var method = type.GetMethod("Go", BindingFlags.Static | BindingFlags.Public);
             method.Invoke(null, Array.Empty<object>());
+        }
+        
+
+        public static void CancelTapThreads(AssemblyLoadContext ctx)
+        {
+            var mainthread = TapThread.Current;
+            while (mainthread.Parent != null)
+                mainthread = mainthread.Parent;
+            ctx.Unloading += context =>
+            {
+                try
+                {
+                    mainthread.Abort("Context unloaded.");
+                }
+                catch
+                {
+                    // ignore -- Abort is supposed to throw
+                }
+
+                try
+                {
+                    mainthread.AbortManager();
+                }
+                catch
+                {
+                    // this shouldn't throw but let's be safe
+                }
+            };
+        }
+        
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ExecuteAndUnload(string assemblyPath, out WeakReference alcWeakRef)
+        {
+            string appDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            var alc = new TestAssemblyLoadContext(appDir);
+            Assembly a = alc.LoadFromAssemblyPath(assemblyPath);
+            var thisasm = alc.LoadFromAssemblyPath(Assembly.GetExecutingAssembly().Location);
+            var program = thisasm.GetType("tap.Program");
+            var cancelTapThread = program!.GetMethod("CancelTapThreads", BindingFlags.Static | BindingFlags.Public)!;
+            cancelTapThread.Invoke(null, new object[] { alc });
+            
+
+            alcWeakRef = new WeakReference(alc, trackResurrection: true);
+            
+            var type = a.GetType("OpenTap.Cli.TapEntry");
+            var entryPoint = type!.GetMethod("Go", BindingFlags.Static | BindingFlags.Public)!;
+            entryPoint.Invoke(null, Array.Empty<object>());
+
+            alc.Unload();
+        }
+        static void Main(string[] args)
+        {
+            string appDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            var asmPath = Path.Combine(appDir, "OpenTap.Cli.dll");
+            ExecuteAndUnload(asmPath, out var testAlcWeakRef);
+
+            if (args.Contains("test"))
+            {
+                for (int i = 0; testAlcWeakRef.IsAlive && (i < 10); i++)
+                {
+                    Console.WriteLine($"Waiting for context to be collected: {i}.");
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                }
+
+                if (testAlcWeakRef.IsAlive)
+                    Console.WriteLine($"Failed to collect context.");
+                else
+                    Console.WriteLine($"Context was collected.");
+                Console.ReadKey();
+            }
         }
     }
 

--- a/tap/TestAssemblyLoadContext.cs
+++ b/tap/TestAssemblyLoadContext.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace complex
+{
+    class TestAssemblyLoadContext : AssemblyLoadContext
+    {
+        private AssemblyDependencyResolver _resolver;
+
+        public TestAssemblyLoadContext(string mainAssemblyToLoadPath) : base(isCollectible: true)
+        {
+            _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath);
+        }
+
+        protected override Assembly? Load(AssemblyName name)
+        {
+            string? assemblyPath = _resolver.ResolveAssemblyToPath(name);
+            if (assemblyPath != null)
+            {
+                return LoadFromAssemblyPath(assemblyPath);
+            }
+
+            return null;
+        }
+    }
+}

--- a/tap/tap.csproj
+++ b/tap/tap.csproj
@@ -22,4 +22,8 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Engine\Tap.Engine.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Once we move away from .NET Framework on Windows, we can start using .NET 6+ features in OpenTAP. One feature that is particularly of interest is `AssemblyLoadContext`. This feature is somewhat analogous to AppDomains, but also very different. I have created this draft PR to document my findings related to how `AssemblyLoadContext` can be realistically implemented and used in OpenTAP.

There are many pitfalls and gotchas related to using load contexts. Below are my learnings and takeaways based on the [microsoft docs](https://learn.microsoft.com/en-us/dotnet/standard/assembly/unloadability), and my own experimentation with unloading OpenTAP.

## Collectability
Whether a load context is "collectable" refers to whether or not it can be unloaded. When a load context is unloaded, it also releases the file handle of any assembly that was loaded in it. After `unload` is called on a load context, anything loaded inside the context will be garbage collected as soon as:
1. There are no outside references to objects within the load context
2. The load context does not have any references to objects outside the load context
3. There are no active threads within the load context

There are probably other conditions, but these are the primary concerns for OpenTAP. A load context can very easily have references to objects outside the load context: `AppDomain.CurrentDomain.GetAssemblies()`, for instance, will return all assemblies loaded both inside and outside the load context (and sibling load contexts potentially). This means our custom assembly resolver needs to be aware of load contexts always, which is made a bit trickier by the fact that our resolver lives in a .NETStandard project, and also needs to remain backwards compatible with .NET Framework.

The restriction about not keeping long-lived references across load context barriers is also made tricky by our TypeData and Annotation system, which keep make liberal use of caches. This also introduces another potential pitfall: If two different load contexts load the same assembly, the types from those two assembly instances are considered different types. E.g. instantiating a type from assembly instance A will cause a type error if that type is used as an argument to a method in instance B. Currently, many of our caches use `type.FullName` as a key, but these caches will now also need to be aware of the source assembly.

The condition that no threads can be active also means that an AssemblyLoadContext must have an associated TapThread hierarchy, such that a thread hierarchy can be cancelled when a load context unload is triggered.



## Conclusion (WIP)
Implementing all of this correctly in OpenTAP itself is going to be tricky to say the least, but the conditions for ensuring unloadability are impossible for us to enforce in plugins. If a plugin constructs a static object with a reference to something outside of the load context, that load context can never be collected. If a plugin starts a thread that doesn't terminate, that load context can never be collected. Therefore, load contexts cannot replace our current isolation logic.

## Other observations

1. `Assembly.LoadFrom(...)` will load an assembly into the appdomain, and not the current load context. A custom load context which has the override `protected override Assembly? Load(AssemblyName name)` must be implemented, which will receive all load events from inside the load context. This load event should then be delegated to the assembly resolver inside the load context. This of course also makes it possible for plugins to leak assemblies into the main context. But this might not be a big deal.
2. It is possible to side-load different versions of the same assembly, so long as each version is in a different load context. This could potentially enable us to use session-based load contexts, where an OpenTAP session is created which loads one version of a plugin, while another concurrent session has a different version of the same plugin loaded. This will however require quite some work in our TypeData implementation to support.

