### PR TITLE
Respect OS override when installing packages

### DIFF
--- a/Package/PackageActionHelpers.cs
+++ b/Package/PackageActionHelpers.cs
@@ -162,6 +162,8 @@ namespace OpenTap.Package
             }
 
             var img = ImageSpecifier.FromAddedPackages(installation, packages);
+            if (!string.IsNullOrWhiteSpace(OS))
+                img.OS = OS;
             if (noDowngrade)
             {
                 img.InstalledPackages = installation.GetPackages().ToImmutableArray();


### PR DESCRIPTION
Set the image OS if an OS is specified during package install

Closes #1139 