### PR TITLE
Revert locking package actions

### DIFF
--- a/Cli/TapEntry.cs
+++ b/Cli/TapEntry.cs
@@ -181,13 +181,7 @@ namespace OpenTap.Cli
                 cliTraceListener.TraceEvents(TapInitializer.InitTraceListener.Instance.AllEvents.ToArray());
                 TapInitializer.InitTraceListener.Instance.AllEvents.Clear();
                 AppDomain.CurrentDomain.ProcessExit += (s, e) => cliTraceListener.Flush();
-            }
 
-            if (!TapInitializer.CanAcquireInstallationLock())
-            {
-                Console.Error.WriteLine($"Unable to acquire a lock on the installation.");
-                Environment.ExitCode = (int)ExitCodes.FailedToAcquireLockError;
-                return;
             }
 
             TapInitializer.Initialize(); // This will dynamically load OpenTap.dll

--- a/Cli/TapInitializer.cs
+++ b/Cli/TapInitializer.cs
@@ -17,17 +17,12 @@ namespace OpenTap
     {
         internal static bool CanAcquireInstallationLock()
         {
-            var lockfile = FileLock.DefaultLockFile();
-            // We need to be able to override the installation lock in certain scenarios, e.g. package install actions
-            // that need to invoke `tap.exe ...` in the installation during install / uninstall.
-            var env = Environment.GetEnvironmentVariable(FileLock.InstallationLockEnv, EnvironmentVariableTarget.Process);
-            if (env != null) return true;
-            
             // Check if the lock for the current installation can be acquired
+            var target = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            var lockfile = Path.Combine(target, ".lock");
             FileSystemHelper.EnsureDirectoryOf(lockfile);
             const int limit = 30;
-            
-            var target = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+
             for (int i = 0; i < limit; i++)
             {
                 using var fileLock = FileLock.Create(lockfile);

--- a/Cli/TapInitializer.cs
+++ b/Cli/TapInitializer.cs
@@ -8,40 +8,12 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading;
 using OpenTap.Diagnostic;
 
 namespace OpenTap
 {
     internal static class TapInitializer
     {
-        internal static bool CanAcquireInstallationLock()
-        {
-            // Check if the lock for the current installation can be acquired
-            var target = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-            var lockfile = Path.Combine(target, ".lock");
-            FileSystemHelper.EnsureDirectoryOf(lockfile);
-            const int limit = 30;
-
-            for (int i = 0; i < limit; i++)
-            {
-                using var fileLock = FileLock.Create(lockfile);
-                try
-                {
-                    if (fileLock.WaitOne(TimeSpan.FromSeconds(1)))
-                        return true;
-                }
-                catch (AbandonedMutexException)
-                {
-                    // ignore -- this happens if the mutex is disposed in another process.
-                    // In this case we will most likely acquire the lock in the next iteration.
-                    continue;
-                }
-                Console.WriteLine($"{target} is locked by a locking package action. Waiting for it to become unlocked... ({i + 1} / {limit})");
-            }
-
-            return false;
-        }
 
         public class InitTraceListener : ILogListener {
             public readonly List<Event> AllEvents = new List<Event>();

--- a/Engine/Cli/CliActionExecutor.cs
+++ b/Engine/Cli/CliActionExecutor.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.IO;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Xml.Linq;
 
 namespace OpenTap.Cli

--- a/Engine/Cli/ExitCodes.cs
+++ b/Engine/Cli/ExitCodes.cs
@@ -64,12 +64,6 @@ namespace OpenTap.Cli
         /// Package resolution Error
         /// </summary>
         [Display("Package Resolution Error", "A package configuration was not able to be resolved.")]
-        PackageResolutionError = 199,
-        
-        /// <summary>
-        /// Directory locked error
-        /// </summary>
-        [Display("Installation Lock Error", "A lock on the installation could not be acquired.")]
-        FailedToAcquireLockError = 200,
+        PackageResolutionError = 199
     }
 }

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -385,10 +385,7 @@ namespace OpenTap.Package
                             "CLI", "Session", "Resolver", "AssemblyFinder", "PluginManager", "TestPlan",
                             "UpdateCheck",
                             "Installation"
-                        },
-                        // The current install action is a locking package action.
-                        // Setting this flag lets the child process bypass the lock on the installation.
-                        Unlocked = true,
+                        }
                     };
 
                     var result = processRunner.Run(installStep, true, cancellationToken);

--- a/Package/PackageInstallHelpers/FileLocks.cs
+++ b/Package/PackageInstallHelpers/FileLocks.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 
-namespace OpenTap
+namespace OpenTap.Package.PackageInstallHelpers
 {
     internal interface IFileLock : IDisposable
     {
@@ -65,7 +65,7 @@ namespace OpenTap
                 {
                     var remaining = timeout - sw.Elapsed;
                     if (remaining.TotalMilliseconds > 1)
-                        Thread.Sleep(1);
+                        TapThread.Sleep(1);
                     else Thread.Yield();
                 }
                 // Otherwise, create the file, thereby claiming the mutex
@@ -170,7 +170,7 @@ namespace OpenTap
 
                 var remaining = timeout - sw.Elapsed;
                 if (remaining.TotalMilliseconds > 1)
-                    Thread.Sleep(1);
+                    TapThread.Sleep(1);
                 else Thread.Yield();
             } while (sw.Elapsed < timeout);
 

--- a/Package/PluginInstaller.cs
+++ b/Package/PluginInstaller.cs
@@ -130,8 +130,6 @@ namespace OpenTap.Package
                 // If OPENTAP_COLOR is set, the escape symbols for colors in the child process will break the parsing of the forwarded logs.
                 // Ensure color is never set in the child process. Colors will still be set in the parent process.
                 pi.Environment["OPENTAP_COLOR"] = "never";
-                // Allow child processes to bypass the lock on the installation which is held by this process.
-                pi.Environment[FileLock.InstallationLockEnv] = "1";
 
                 try
                 {

--- a/Shared/FileLocks.cs
+++ b/Shared/FileLocks.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Buffers.Text;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 
 namespace OpenTap
@@ -20,17 +17,6 @@ namespace OpenTap
 
     internal static class FileLock
     {
-        internal static string InstallationLockEnv =>
-            Convert.ToBase64String(Encoding.UTF8.GetBytes(DefaultLockFile())).Replace("=", "");
-
-        internal static string DefaultLockFile()
-        {
-            // Check if the lock for the current installation can be acquired
-            var target = ExecutorClient.ExeDir;
-            var lockfile = Path.Combine(target, ".lock");
-            return lockfile;
-        }
-        
         public static IFileLock Create(string file)
         {
             if (OperatingSystem.Current == OperatingSystem.Windows) return new Win32FileLock(file);

--- a/Shared/SubProcessHost.cs
+++ b/Shared/SubProcessHost.cs
@@ -22,7 +22,6 @@ namespace OpenTap
     {
         public bool ForwardLogs { get; set; } 
         public string LogHeader { get; set; } = "";
-        public bool Unlocked { get; set; } = false;
         public HashSet<string> MutedSources { get; } = new HashSet<string>();
 
         public static bool IsAdmin()
@@ -142,9 +141,6 @@ namespace OpenTap
                 RedirectStandardError = true,
                 UseShellExecute = false,
             };
-
-            if (Unlocked)
-                pInfo.Environment[FileLock.InstallationLockEnv] = "1";
 
             if (elevate)
             {

--- a/Shared/Tap.Shared.projitems
+++ b/Shared/Tap.Shared.projitems
@@ -33,6 +33,5 @@
     <Compile Include="$(MSBuildThisFileDirectory)SudoHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakHashSet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cache.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)FileLocks.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This reverts the fix for #1122. I am removing this for now in order to de-risk the 9.21.1 patch, but it will be re-added in 9.22.0.