### PR TITLE
Debug log installed packages when Installation is instantiated

### DIFF
--- a/Engine/IStartupInfo.cs
+++ b/Engine/IStartupInfo.cs
@@ -1,0 +1,13 @@
+namespace OpenTap
+{
+    /// <summary>
+    /// An IStartupInfo implementation logs some specific information about the current installation.
+    /// </summary>
+    public interface IStartupInfo : ITapPlugin
+    {
+        /// <summary>
+        /// LogStartupInfo is called exactly once immediately after session logging has been initialized.
+        /// </summary>
+        void LogStartupInfo();
+    }
+}

--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -139,7 +139,7 @@ namespace OpenTap
                     // this ensures that System.Runtime.InteropServices.RuntimeInformation.dll is loaded. (issue #4000).
                     .StartNew(PluginManager.Load)
                     // then get the system info on a separate thread (it takes ~1s)
-                    .ContinueWith(tsk => SystemInfo()); 
+                    .ContinueWith(tsk => LogStartupInfo()); 
 
                 AppDomain.CurrentDomain.ProcessExit += FlushOnExit;
                 AppDomain.CurrentDomain.UnhandledException += FlushOnExit;
@@ -481,7 +481,7 @@ namespace OpenTap
         }
 
         static Task SystemInfoTask;
-        private static void SystemInfo()
+        private static void LogStartupInfo()
         {
             foreach (var td in TypeData.GetDerivedTypes<IStartupInfo>().Where(td => td.CanCreateInstance))
             {
@@ -508,7 +508,7 @@ namespace OpenTap
                 }
                 catch (Exception ex)
                 {
-                    log.Debug($"Unhandled exception in '{td.Name}.{nameof(td.LogStartupInfo)}': {ex.Message}");
+                    log.Debug($"Unhandled exception in '{td.Name}.{nameof(si.LogStartupInfo)}': {ex.Message}");
                     log.Debug(ex);
                 }
             }

--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -508,7 +508,7 @@ namespace OpenTap
                 }
                 catch (Exception ex)
                 {
-                    log.Debug($"Unhandled exception in '{td.Name}.LogStartupInfo': {ex.Message}");
+                    log.Debug($"Unhandled exception in '{td.Name}.{nameof(td.LogStartupInfo)}': {ex.Message}");
                     log.Debug(ex);
                 }
             }

--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -442,7 +442,7 @@ namespace OpenTap
                 }
             });
         }
-        
+
         static string addLogRotateNumber(string fullname, int cnt)
         {
             if (cnt == 0) return fullname;
@@ -472,7 +472,8 @@ namespace OpenTap
             {
                 log.Warning("Unable to rename log file to {0} as permissions was denied.", path);
                 log.Debug(e);
-            }catch (IOException e)
+            }
+            catch (IOException e)
             { // This could also be an error the the user does not have permissions. E.g OpenTAP installed in C:\\
                 log.Warning("Unable to rename log file to {0} as the file could not be created.", path);
                 log.Debug(e);
@@ -482,15 +483,37 @@ namespace OpenTap
         static Task SystemInfoTask;
         private static void SystemInfo()
         {
-            if (!String.IsNullOrEmpty(RuntimeInformation.OSDescription))
-                log.Debug("{0}{1}", RuntimeInformation.OSDescription, RuntimeInformation.OSArchitecture); // This becomes something like "Microsoft Windows 10.0.14393 X64"
+            foreach (var td in TypeData.GetDerivedTypes<IStartupInfo>().Where(td => td.CanCreateInstance))
+            {
+                IStartupInfo si = null;
+                try 
+                {
+                    si = td.CreateInstance() as IStartupInfo;
+                    if (si == null)
+                    {
+                        log.Debug($"Failed to instantiate '{td.Name}'.");
+                        continue;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    log.Debug($"Failed to instantiate '{td.Name}': {ex.Message}");
+                    log.Debug(ex);
+                    continue;
+                }
 
-            if (!String.IsNullOrEmpty(RuntimeInformation.FrameworkDescription))
-                log.Debug(RuntimeInformation.FrameworkDescription); // This becomes something like ".NET Framework 4.6.1586.0"
-            var version = SemanticVersion.Parse(Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion);
-            log.Debug("OpenTAP Engine {0} {1}", version, RuntimeInformation.ProcessArchitecture);
+                try
+                {
+                    si.LogStartupInfo();
+                }
+                catch (Exception ex)
+                {
+                    log.Debug($"Unhandled exception in '{td.Name}.LogStartupInfo': {ex.Message}");
+                    log.Debug(ex);
+                }
+            }
         }
-        
+
         /// <summary>
         /// Flushes the buffered logs. Useful as the last thing to do in case of crash.
         /// </summary>

--- a/Engine/SystemStartupInfo.cs
+++ b/Engine/SystemStartupInfo.cs
@@ -4,17 +4,6 @@ using System.Runtime.InteropServices;
 
 namespace OpenTap
 {
-    /// <summary>
-    /// An IStartupInfo implementation logs some specific information about the current installation.
-    /// </summary>
-    public interface IStartupInfo : ITapPlugin
-    {
-        /// <summary>
-        /// LogStartupInfo is called exactly once immediately after session logging has been initialized.
-        /// </summary>
-        void LogStartupInfo();
-    }
-    
     internal class SystemStartupInfo : IStartupInfo
     {
         public void LogStartupInfo()

--- a/Engine/SystemStartupInfo.cs
+++ b/Engine/SystemStartupInfo.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace OpenTap
+{
+    /// <summary>
+    /// An IStartupInfo implementation logs some specific information about the current installation.
+    /// </summary>
+    public interface IStartupInfo : ITapPlugin
+    {
+        /// <summary>
+        /// LogStartupInfo is called exactly once immediately after session logging has been initialized.
+        /// </summary>
+        void LogStartupInfo();
+    }
+    
+    internal class SystemStartupInfo : IStartupInfo
+    {
+        public void LogStartupInfo()
+        {
+            var log = Log.CreateSource("SystemInfo");
+            if (!String.IsNullOrEmpty(RuntimeInformation.OSDescription))
+                log.Debug("{0}{1}", RuntimeInformation.OSDescription, RuntimeInformation.OSArchitecture); // This becomes something like "Microsoft Windows 10.0.14393 X64"
+
+            if (!String.IsNullOrEmpty(RuntimeInformation.FrameworkDescription))
+                log.Debug(RuntimeInformation.FrameworkDescription); // This becomes something like ".NET Framework 4.6.1586.0"
+            var version = SemanticVersion.Parse(Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion);
+            log.Debug("OpenTAP Engine {0} {1}", version, RuntimeInformation.ProcessArchitecture);
+        }
+    }
+}

--- a/Package/Installation.cs
+++ b/Package/Installation.cs
@@ -11,6 +11,27 @@ using Tap.Shared;
 namespace OpenTap.Package
 {
     /// <summary>
+    /// Log information about the current installation at startup.
+    /// </summary>
+    public class InstallationLoggerStartupInfo : IStartupInfo
+    {
+        /// <summary>
+        /// Log information about the current installation at startup.
+        /// </summary>
+        public void LogStartupInfo()
+        {
+            var log = Log.CreateSource("Installation");
+            var packages = Installation.Current.GetPackages();
+            var longestName = packages.Max(p => p.Name.Length);
+            foreach (var pkg in packages)
+            {
+                var padded = pkg.Name.PadRight(longestName);
+                log.Debug($"{padded} - {pkg.Version}");
+            }
+        }
+    }
+
+    /// <summary>
     /// Represents an OpenTAP installation in a specific directory.
     /// </summary>
     public class Installation
@@ -86,31 +107,7 @@ namespace OpenTap.Package
         /// <summary>
         /// Get the installation of the currently running tap process
         /// </summary>
-        public static Installation Current
-        {
-            get
-            {
-                if (current == null)
-                {
-                    current = new Installation(ExecutorClient.ExeDir);
-                    current.PrintReadable();
-                }
-
-                return current;
-            }
-        }
-
-        // This is included for debugging purposes so we know exactly what plugins are installed when people create issues with session logs.
-        private void PrintReadable()
-        {
-            var packages = GetPackages();
-            var longestName = packages.Max(p => p.Name.Length);
-            foreach (var pkg in GetPackages())
-            {
-                var padded = pkg.Name.PadRight(longestName);
-                log.Debug($"{padded} - {pkg.Version}");
-            }
-        }
+        public static Installation Current => current ??= new Installation(ExecutorClient.ExeDir);
 
         /// <summary> Target installation architecture. This could be anything as 32-bit is supported on 64bit systems.</summary>
         internal CpuArchitecture Architecture => GetOpenTapPackage()?.Architecture ?? ArchitectureHelper.GuessBaseArchitecture;

--- a/Package/Installation.cs
+++ b/Package/Installation.cs
@@ -86,7 +86,31 @@ namespace OpenTap.Package
         /// <summary>
         /// Get the installation of the currently running tap process
         /// </summary>
-        public static Installation Current => current ??= new Installation(ExecutorClient.ExeDir);
+        public static Installation Current
+        {
+            get
+            {
+                if (current == null)
+                {
+                    current = new Installation(ExecutorClient.ExeDir);
+                    current.PrintReadable();
+                }
+
+                return current;
+            }
+        }
+
+        // This is included for debugging purposes so we know exactly what plugins are installed when people create issues with session logs.
+        private void PrintReadable()
+        {
+            var packages = GetPackages();
+            var longestName = packages.Max(p => p.Name.Length);
+            foreach (var pkg in GetPackages())
+            {
+                var padded = pkg.Name.PadRight(longestName);
+                log.Debug($"{padded} - {pkg.Version}");
+            }
+        }
 
         /// <summary> Target installation architecture. This could be anything as 32-bit is supported on 64bit systems.</summary>
         internal CpuArchitecture Architecture => GetOpenTapPackage()?.Architecture ?? ArchitectureHelper.GuessBaseArchitecture;

--- a/Package/Installation.cs
+++ b/Package/Installation.cs
@@ -11,27 +11,6 @@ using Tap.Shared;
 namespace OpenTap.Package
 {
     /// <summary>
-    /// Log information about the current installation at startup.
-    /// </summary>
-    public class InstallationLoggerStartupInfo : IStartupInfo
-    {
-        /// <summary>
-        /// Log information about the current installation at startup.
-        /// </summary>
-        public void LogStartupInfo()
-        {
-            var log = Log.CreateSource("Installation");
-            var packages = Installation.Current.GetPackages();
-            var longestName = packages.Max(p => p.Name.Length);
-            foreach (var pkg in packages)
-            {
-                var padded = pkg.Name.PadRight(longestName);
-                log.Debug($"{padded} - {pkg.Version}");
-            }
-        }
-    }
-
-    /// <summary>
     /// Represents an OpenTAP installation in a specific directory.
     /// </summary>
     public class Installation

--- a/Package/InstallationLoggerStartupInfo.cs
+++ b/Package/InstallationLoggerStartupInfo.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+
+namespace OpenTap.Package
+{
+    /// <summary>
+    /// Log information about the current installation at startup.
+    /// </summary>
+    internal class InstallationLoggerStartupInfo : IStartupInfo
+    {
+        /// <summary>
+        /// Log information about the current installation at startup.
+        /// </summary>
+        public void LogStartupInfo()
+        {
+            var log = Log.CreateSource("Installation");
+            var packages = Installation.Current.GetPackages();
+            var longestName = packages.Max(p => p.Name.Length);
+            foreach (var pkg in packages)
+            {
+                var padded = pkg.Name.PadRight(longestName);
+                log.Debug($"{padded} - {pkg.Version}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This will log a summary of installed packages at most once per OpenTAP instance when Installation.Current is instantiated.

This should make it easier for us to reproduce issues when people submit bug reports with session logs. 

In execution paths that don't instantiate Installation.Current, this information will not be logged, but that is probably okay. It will always be instantiated in test plan logs because of the ITestPlanRunMonitor which adds the currently installed packages to the run result set.

@witoldpiet the output looks something like this:

```
00:00:00.437 : Installation  : Debug       : Editor                           - 9.21.0+185bec68
00:00:00.437 : Installation  : Debug       : TestWithDependencies             - 2.3.0+9b084a8
00:00:00.437 : Installation  : Debug       : Keysight Licensing               - 1.4.3+4185d1cf
00:00:00.437 : Installation  : Debug       : OpenTAP                          - 9.22.0-alpha.4+89e79075.800-log-installed-packages
00:00:00.437 : Installation  : Debug       : OSIntegration                    - 1.4.2+15f32a31
00:00:00.437 : Installation  : Debug       : Test                             - 1.2.3-alpha+test
00:00:00.437 : Installation  : Debug       : Test1                            - 1.2.3+4
00:00:00.437 : Installation  : Debug       : Test2                            - 1.2.3+4
00:00:00.437 : Installation  : Debug       : Test3                            - 0.0.0
00:00:00.437 : Installation  : Debug       : TUI                              - 1.0.0+48ed6e30
00:00:00.437 : Installation  : Debug       : WPF Controls                     - 9.21.0+185bec68
00:00:00.437 : Installation  : Debug       : Keysight Fixed License Manager   - 1.6.2+d58f8a89
00:00:00.437 : Installation  : Debug       : PathWave License Manager         - 2.7.0+398d3a87
00:00:00.437 : Installation  : Debug       : PathWave License Manager Minimal - 1.1.2+0ff8f1b5
00:00:00.437 : Installation  : Debug       : VCRedist                         - 1.1.0+67bba1c4
```

Closes #800