### PR TITLE
1052 fix nuget syswide install

### DIFF
--- a/Package/Image/ImageSpecifier.cs
+++ b/Package/Image/ImageSpecifier.cs
@@ -169,7 +169,7 @@ namespace OpenTap.Package
         /// Like Resolve, but includes the current installation as a base. In this case, packages can be upgraded and downgraded,
         /// but not removed if they do not exist in the image specification.
         /// </summary>
-        internal ImageIdentifier MergeAndResolve(Installation deploymentInstallation, CancellationToken cancellationToken)
+        public ImageIdentifier MergeAndResolve(Installation deploymentInstallation, CancellationToken cancellationToken)
         {
             var imageSpecifier2 = FromAddedPackages(deploymentInstallation, Packages);
             imageSpecifier2.Name = Name;


### PR DESCRIPTION
This detects when a system-wide package is requested, and fails the build immediately if this is the case. This will also give an error message stating the exact problem, instead of cryptically saying 'Some packages failed to install' with no further information.

Example output:

```bash
> dotnet build
MSBuild version 17.7.0-preview-23251-02+59879b095 for .NET
...
project.csproj : error OpenTAP Install: Requested package 'PathWave License Manager' is system-wide, and should not be in
stalled as part of a build.
project.csproj : error OpenTAP Install: Failed to install packages.
    0 Warning(s)
    2 Error(s)
```
Closes #1052 