### PR TITLE
1186 SweepLoop Multi Select

### DIFF
--- a/BasicSteps/SweepLoop.cs
+++ b/BasicSteps/SweepLoop.cs
@@ -121,7 +121,8 @@ namespace OpenTap.Plugins.BasicSteps
             {
                 if (CrossPlan == SweepBehaviour.Across_Runs)
                     return SweepParameters
-                        .Select(param => param.Values.GetValue(crossPlanSweepIndex))
+                            // crossPlanSweepIndex is 0 by default. Even if the number of rows is also 0.
+                        .Select(param => param.Values.ElementAtOrDefault(crossPlanSweepIndex))
                         .OfType<IResource>();
                 return SweepParameters
                     .SelectMany(param => param.Values)


### PR DESCRIPTION
- Added a unit test to show the issue.
- Fixed the issue by using a range-checking array indexer.


Close #1186 