### PR TITLE
1183 ParameterizeUnparameterizeBug: Fix

### DIFF
--- a/Engine.UnitTests/ResultTest.cs
+++ b/Engine.UnitTests/ResultTest.cs
@@ -70,6 +70,20 @@ namespace OpenTap.UnitTests
             Assert.AreEqual(1.0, columnA.Data.GetValue(0));
             Assert.AreEqual(2.0, columnB.Data.GetValue(0));
         }
+
+        [Test]
+        public void TestResultParameters()
+        {
+            var plan = new TestPlan();
+            var step = new SimpleResultTest();
+            plan.Steps.Add(step);
+
+            var rl = new RecordAllResultListener();
+            
+            plan.Execute(new []{rl});
+            var run = rl.Runs.Values.OfType<TestStepRun>().FirstOrDefault();
+
+        }
         
         [Test]
         public void TestSimpleResults2()

--- a/Engine.UnitTests/ScopeParametersTest.cs
+++ b/Engine.UnitTests/ScopeParametersTest.cs
@@ -361,7 +361,7 @@ namespace OpenTap.UnitTests
                 // verify Enabled<T> works with SweepParameterStep.
                 var annotation = AnnotationCollection.Annotate(sweep);
                 var col = annotation.GetMember(nameof(SweepParameterStep.SelectedParameters)).Get<IStringReadOnlyValueAnnotation>().Value;
-                Assert.AreEqual("A, EnabledTest", col);
+                Assert.AreEqual("EnabledTest, A", col);
                 var elements = annotation.GetMember(nameof(SweepParameterStep.SweepValues))
                     .Get<ICollectionAnnotation>().AnnotatedElements
                     .Select(elem => elem.GetMember(nameof(ScopeTestStep.EnabledTest)))
@@ -395,7 +395,7 @@ namespace OpenTap.UnitTests
             Assert.IsTrue(((ScopeTestStep)sweep2.ChildTestSteps[0]).Collection.SequenceEqual(new[] {10, 20}));
 
             var name = sweep.GetFormattedName();
-            Assert.AreEqual("Sweep A, EnabledTest", name);
+            Assert.AreEqual("Sweep EnabledTest, A", name);
 
             { // Testing that sweep parameters are automatically removed after unparameterization.
                 var p = (ParameterMemberData) TypeData.GetTypeData(sweep2).GetMember("Parameters \\ A");

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -333,7 +333,8 @@ namespace OpenTap
         public static void AddDynamicMember(object target, IMemberData member)
         {
             var members = (ImmutableDictionary<string, IMemberData>) DynamicMemberTypeDataProvider.TestStepTypeData.DynamicMembers.GetValue(target);
-            DynamicMemberTypeDataProvider.TestStepTypeData.DynamicMembers.SetValue(target, members.SetItem(member.Name, member));
+            var newMembers = members.SetItem(member.Name, member);
+            DynamicMemberTypeDataProvider.TestStepTypeData.DynamicMembers.SetValue(target, newMembers);
         }
 
         public static void RemovedDynamicMember(object target, IMemberData member)

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -21,12 +21,6 @@ namespace OpenTap
         void SetValue(IMemberData member, object value);
     }
 
-    interface ITypeDataCacheMarker
-    {
-        object Marker { get; }
-    }
-    
-
     /// <summary>  Extensions for parameter operations. </summary>
     public static class ParameterExtensions
     {
@@ -536,7 +530,7 @@ namespace OpenTap
             }
         }
 
-        public class DynamicTestStepTypeData : ITypeData, ITypeDataCacheMarker
+        public class DynamicTestStepTypeData : ITypeData
         {
             public DynamicTestStepTypeData(TestStepTypeData innerType, object target)
             {
@@ -605,8 +599,6 @@ namespace OpenTap
                 // Random factors for hashing (primes to reduce the risk of collision).
                 return ((((BaseType?.GetHashCode() ?? 0) + 86533973) * 25714789 + (target?.GetHashCode() ?? 0) + 67186051) * 63349417);
             }
-            
-            public object Marker => TestStepTypeData.DynamicMembers.GetValue(target);
         }
 
         internal class TestStepTypeData : ITypeData

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -501,7 +501,9 @@ namespace OpenTap
         {
             if (resultListeners == null)
                 throw new ArgumentNullException("resultListeners");
-
+            
+            ResultParameters.ParameterCache.LoadCache();
+            
             if (PrintTestPlanRunSummary && !resultListeners.Contains(summaryListener))
                 resultListeners = resultListeners.Concat(new IResultListener[] { summaryListener });
             resultListeners = resultListeners.Where(r => r is IEnabledResource ? ((IEnabledResource)r).IsEnabled : true);


### PR DESCRIPTION
Tried to fix the issue by using immutable data structures.

I modified the cache so that it is only present during the test plan run.

Also a couple of the tests depended on the order of the members which has been reversed. In the cases where it made sense I ordered them, but in general the order does not matter.

Close #1183 