### PR TITLE
1191: Result proxy test fails intermittently

### DIFF
--- a/Engine.UnitTests/Results2.cs
+++ b/Engine.UnitTests/Results2.cs
@@ -52,7 +52,8 @@ namespace OpenTap.UnitTests
         [TestCase(typeof(PublishResultsSameValues2))]
         public void TestManyResults(Type stepType)
         {
-            for (int i = 0; i < 100; i++)
+            // this test has been a bit unstable. Repeat a few times to make sure it works.
+            for (int i = 0; i < 5; i++) 
             {
                 var record = new RecordAllResultListener();
                 var plan = new TestPlan();

--- a/Engine.UnitTests/Results2.cs
+++ b/Engine.UnitTests/Results2.cs
@@ -52,28 +52,37 @@ namespace OpenTap.UnitTests
         [TestCase(typeof(PublishResultsSameValues2))]
         public void TestManyResults(Type stepType)
         {
-            var record = new RecordAllResultListener();
-            var plan = new TestPlan();
-            var repeat = new RepeatStep { Count = 10 };
-            var parallel = new ParallelStep();
-            
-            plan.ChildTestSteps.Add(repeat);
-
-            var results1 = (TestStep)Activator.CreateInstance(stepType);
-            var results2 = (TestStep)Activator.CreateInstance(stepType);
-            parallel.ChildTestSteps.Add(results1);
-            parallel.ChildTestSteps.Add(results2);
-            
-            repeat.ChildTestSteps.Add(parallel);
-
-            var run = plan.Execute(new IResultListener[] { record });
-            Assert.AreEqual(Verdict.NotSet, run.Verdict);
-            foreach (var table in record.Results)
+            for (int i = 0; i < 100; i++)
             {
-                foreach (var column in table.Columns)
+                var record = new RecordAllResultListener();
+                var plan = new TestPlan();
+                var repeat = new RepeatStep
                 {
-                    var distinctCount = column.Data.Cast<object>().Distinct().Count();
-                    Assert.AreEqual(1, distinctCount);
+                    Count = 10
+                };
+                var parallel = new ParallelStep();
+
+                plan.ChildTestSteps.Add(repeat);
+
+                var results1 = (TestStep)Activator.CreateInstance(stepType);
+                var results2 = (TestStep)Activator.CreateInstance(stepType);
+                parallel.ChildTestSteps.Add(results1);
+                parallel.ChildTestSteps.Add(results2);
+
+                repeat.ChildTestSteps.Add(parallel);
+
+                var run = plan.Execute(new IResultListener[]
+                {
+                    record
+                });
+                Assert.AreEqual(Verdict.NotSet, run.Verdict);
+                foreach (var table in record.Results)
+                {
+                    foreach (var column in table.Columns)
+                    {
+                        var distinctCount = column.Data.Cast<object>().Distinct().Count();
+                        Assert.AreEqual(1, distinctCount);
+                    }
                 }
             }
         }

--- a/Engine/ResultProxy.cs
+++ b/Engine/ResultProxy.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -602,10 +603,16 @@ namespace OpenTap
                         break;
                     
                     // pop the peeked object
-                    if (workQueue.Dequeue() != p)
+                    var dq = workQueue.Dequeue();
+                    if (dq != p)
                     {
-                        // this should never happen.
+                        if (dq == null)
+                            // we weren't able to dequeue the object - just give up on the optimization.
+                            break; 
+                        
+                        // This should never happen.
                         // If it did, something went really wrong.
+                        Debug.Fail("Peeked object not in front of queue.");
                         throw new InvalidOperationException("Peeked object not in front of queue.");
                     }
 

--- a/Engine/WorkQueue.cs
+++ b/Engine/WorkQueue.cs
@@ -207,6 +207,8 @@ namespace OpenTap
             {
                 Thread.Sleep(5);
             }
+            if (countdown < 0)
+                throw new InvalidOperationException("!!");
         }
 
         internal object Dequeue()
@@ -216,7 +218,7 @@ namespace OpenTap
                 return null;
             if (workItems.TryDequeue(out var inv))
             {
-                // when taking an item from the workqueue the countdown and the semaphore must be decremented
+                // when taking an item from the work queue the countdown and the semaphore must be decremented
                 Interlocked.Decrement(ref countdown);
                 
                 if (inv is IWrappedInvokable wrap)


### PR DESCRIPTION
Fixed a data race that occurs very rarely for workqueues where objects gets dequeued.

Close #1191