### PR TITLE
1196 Open Close Order Lazy FIx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
     needs: Build-Win
     strategy:
       matrix:
-        retries: [ 0, 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20 ]
+        retries: [ 0, 1 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,12 +269,12 @@ jobs:
   ##############
   ### TESTS ###
   ##############
-  TestEngine:
+  TestEngine: 
     runs-on: windows-2022
     needs: Build-Win
     strategy:
       matrix:
-        retries: [ 0, 1 ]
+        retries: [ 0, 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Engine.UnitTests/UserCodeTest.cs
+++ b/Engine.UnitTests/UserCodeTest.cs
@@ -158,7 +158,7 @@ namespace OpenTap.Engine.UnitTests
         public IInstrument Instrument { get; set; }
         public override void Run()
         {
-
+            Assert.IsTrue(Instrument.IsConnected);
         }
     }
 

--- a/Engine/ResourceTaskManager.cs
+++ b/Engine/ResourceTaskManager.cs
@@ -175,7 +175,7 @@ namespace OpenTap
 
         class ResourceNodeCache : ICacheOptimizer
         {
-            public readonly static ThreadField<Dictionary<EnumerableKey, List<ResourceNode>>> Cache = new ThreadField<Dictionary<EnumerableKey, List<ResourceNode>>>();
+            public static readonly ThreadField<Dictionary<EnumerableKey, List<ResourceNode>>> Cache = new ThreadField<Dictionary<EnumerableKey, List<ResourceNode>>>();
             public void LoadCache() => Cache.Value = new Dictionary<EnumerableKey, List<ResourceNode>>();
 
             public void UnloadCache() => Cache.Value = null;
@@ -214,27 +214,18 @@ namespace OpenTap
     internal class ResourceTaskManager : IResourceManager
     {
         /// <summary> Prints a friendly name. </summary>
-        /// <returns></returns>
         public override string ToString() => "Default Resource Manager";
-        private static readonly TraceSource log = Log.CreateSource("Resources");
         
-        List<ResourceNode> openedResources = new List<ResourceNode>();
-        private LockManager lockManager;
-        ConcurrentDictionary<IResource, Task> openTasks;
+        static readonly TraceSource log = Log.CreateSource("Resources");
+        
+        readonly List<ResourceNode> openedResources = new List<ResourceNode>();
+        readonly LockManager lockManager = new LockManager();
+        readonly ConcurrentDictionary<IResource, Task> openTasks = new ConcurrentDictionary<IResource, Task>();
 
         /// <summary>
         /// This event is triggered when a resource is opened. The event may block in which case the resource will remain open for the entire call.
         /// </summary>
         public event Action<IResource> ResourceOpened;
-
-        /// <summary>
-        /// Instantiates a new ResourceOpenTaskManager.
-        /// </summary>
-        public ResourceTaskManager()
-        {
-            lockManager = new LockManager();
-            openTasks = new ConcurrentDictionary<IResource, Task>();
-        }
 
         internal static TraceSource GetLogSource(IResource res)
         {
@@ -247,16 +238,16 @@ namespace OpenTap
             var taskArray = node.StrongDependencies.Select(dep => openTasks[dep]).ToArray();
             Task.WaitAll(taskArray);
 
-            Stopwatch swatch = Stopwatch.StartNew();
+            var sw = Stopwatch.StartNew();
 
-            var reslog = GetLogSource(node.Resource);
+            var resourceLog = GetLogSource(node.Resource);
 
             try
             {
                 // start a new thread to do synchronous work
                 node.Resource.Open();
 
-                reslog.Info(swatch, "Resource \"{0}\" opened.", node.Resource);
+                resourceLog.Info(sw, "Resource \"{0}\" opened.", node.Resource);
 
                 var weakDeps = node.WeakDependencies.Select(dep => openTasks[dep]).ToArray();
                 Task.WaitAll(weakDeps);
@@ -265,7 +256,7 @@ namespace OpenTap
             }
             catch (Exception ex)
             {
-                string msg = string.Format("Error while opening resource \"{0}\"", node.Resource);
+                string msg = $"Error while opening resource \"{node.Resource}\"";
                 throw new ExceptionCustomStackTrace(msg, null, ex);
             }
         }
@@ -304,10 +295,10 @@ namespace OpenTap
         /// <summary>
         /// Get a snapshot of all currently opened resources.
         /// </summary>
-        public IEnumerable<IResource> Resources { get { return openTasks.Keys; } }
+        public IEnumerable<IResource> Resources => openTasks.Keys;
 
         /// <summary>
-        /// Sets the resources that should always be opened when the testplan is.
+        /// Sets the resources that should always be opened when the test plan is.
         /// </summary>
         public IEnumerable<IResource> StaticResources { get; set; }
         /// <summary>
@@ -318,7 +309,7 @@ namespace OpenTap
         /// <summary>
         /// Blocks the thread while closing all resources in parallel.
         /// </summary>
-        private void CloseAllResources()
+         void CloseAllResources()
         {
             Dictionary<IResource, List<IResource>> dependencies =
                 openedResources.ToDictionary(r => r.Resource,
@@ -347,7 +338,7 @@ namespace OpenTap
 
                     // wait for resources that depend on this resource (res) to close before closing this
                     Task.WaitAll(dependencies[res.Resource].Select(x => closeTasks[x]).ToArray());
-                    var reslog = GetLogSource(res.Resource);
+                    var resourceLog = GetLogSource(res.Resource);
                     Stopwatch timer = Stopwatch.StartNew();
                     try
                     {
@@ -361,8 +352,8 @@ namespace OpenTap
 
                     }
 
-                    if (reslog != null)
-                        reslog.Info(timer, "Resource \"{0}\" closed.", res.Resource);
+                    if (resourceLog != null)
+                        resourceLog.Info(timer, "Resource \"{0}\" closed.", res.Resource);
                 }, r);
 
             var closeTaskArray = closeTasks.Values.ToArray();
@@ -522,28 +513,30 @@ namespace OpenTap
         /// <summary> Prints a friendly name. </summary>
         /// <returns></returns>
         public override string ToString() => "Short Lived Connections";
-        private class ResourceInfo
+        
+        /// <summary> Manages the state for a single resource. For example an Instrument or Result Listener. </summary>
+        class ResourceInfo
         {
-            private enum ResourceState
+            enum ResourceState
             {
                 Reset,
-
                 Opening,
                 Open,
                 Closing
             }
 
-            private ResourceState state { get; set; } = ResourceState.Reset;
+            ResourceState state { get; set; } = ResourceState.Reset;
             
             // counts up on open and down on close. When it reaches 0, it can finally be closed. 
-            private int ReferenceCount { get; set; }
+            int referenceCount;
 
-            private readonly object LockObj = new object();
+            // lock used for managing local state. For example reference count.
+            readonly object lockObj = new object();
 
-            private Task OpenTask = Task.CompletedTask;
-            private Task CloseTask = Task.CompletedTask;
+            Task openTask = Task.CompletedTask;
+            Task closeTask = Task.CompletedTask;
 
-            public ResourceNode ResourceNode { get; set; }
+            public ResourceNode ResourceNode { get; }
 
             public ResourceInfo(ResourceNode resourceNode)
             {
@@ -552,11 +545,11 @@ namespace OpenTap
 
             public Task RequestSteady()
             {
-                lock (LockObj)
+                lock (lockObj)
                     switch(state)
                     {
                         case ResourceState.Opening:
-                            return OpenTask;
+                            return openTask;
                         default:
                             return Task.CompletedTask;
                     }
@@ -564,8 +557,8 @@ namespace OpenTap
 
             public bool ShouldBeOpen()
             {
-                lock (LockObj)
-                    return ReferenceCount > 0;
+                lock (lockObj)
+                    return referenceCount > 0;
             }
 
             void OpenResource(LazyResourceManager requester, CancellationToken cancellationToken)
@@ -577,20 +570,20 @@ namespace OpenTap
                     requester.RequestResourceOpen(dep, cancellationToken).Wait(cancellationToken);
                 }
 
-                Stopwatch swatch = Stopwatch.StartNew();
+                var sw = Stopwatch.StartNew();
 
-                var reslog = ResourceTaskManager.GetLogSource(node.Resource);
+                var resourceLog = ResourceTaskManager.GetLogSource(node.Resource);
 
                 try
                 {
                     try
                     {
                         node.Resource.Open();
-                        reslog.Info(swatch, "Resource \"{0}\" opened.", node.Resource);
+                        resourceLog.Info(sw, "Resource \"{0}\" opened.", node.Resource);
                     }
                     finally
                     {
-                        lock (LockObj)
+                        lock (lockObj)
                             if (state == ResourceState.Opening)
                                 state = ResourceState.Open;
                     }
@@ -603,7 +596,7 @@ namespace OpenTap
                 }
                 catch (Exception ex)
                 {
-                    string msg = string.Format("Error while opening resource \"{0}\"", node.Resource);
+                    string msg = $"Error while opening resource \"{node.Resource}\"";
                     throw new ExceptionCustomStackTrace(msg, null, ex);
                 }
                 requester.ResourceOpenedCallback(node.Resource);
@@ -611,23 +604,23 @@ namespace OpenTap
 
             public Task RequestOpen(LazyResourceManager requester, CancellationToken cancellationToken)
             {
-                lock (LockObj)
+                lock (lockObj)
                 {
-                    ReferenceCount++;
+                    referenceCount++;
 
                     switch (state)
                     {
                         case ResourceState.Reset:
                             state = ResourceState.Opening;
 
-                            return OpenTask =
+                            return openTask =
                                 TapThread.StartAwaitable(() => OpenResource(requester, cancellationToken));
                         case ResourceState.Opening:
-                            return OpenTask;
+                            return openTask;
                         case ResourceState.Open:
                             return Task.CompletedTask;
                         case ResourceState.Closing:
-                            return CloseTask.ContinueWith(t => RequestOpen(requester, cancellationToken).Wait());
+                            return closeTask.ContinueWith(t => RequestOpen(requester, cancellationToken).Wait());
                     }
 
                     return Task.CompletedTask;
@@ -636,11 +629,11 @@ namespace OpenTap
 
             public Task RequestClose(LazyResourceManager requester)
             {
-                lock (LockObj)
+                lock (lockObj)
                 {
-                    ReferenceCount--;
+                    referenceCount--;
 
-                    if (ReferenceCount == 0)
+                    if (referenceCount == 0)
                         switch (state)
                         {
                             case ResourceState.Reset:
@@ -651,12 +644,12 @@ namespace OpenTap
                                 {
                                     state = ResourceState.Closing;
 
-                                    return CloseTask = TapThread.StartAwaitable(() =>
+                                    return closeTask = TapThread.StartAwaitable(() =>
                                     {
                                         try
                                         {
                                             // wait for the resource to open before close.
-                                            requester.resources[ResourceNode.Resource].OpenTask?.Wait();
+                                            requester.resources[ResourceNode.Resource].openTask?.Wait();
                                         }
                                         catch
                                         {
@@ -689,23 +682,13 @@ namespace OpenTap
             }
         }
 
-        private readonly object resourceLock = new object();
-        private Dictionary<IResource, ResourceInfo> resources = new Dictionary<IResource, ResourceInfo>();
-        private Dictionary<ITestStep, List<IResource>> resourceDependencies = new Dictionary<ITestStep, List<IResource>>();
-       
-        private List<ResourceNode> resourceWithBeforeOpenCalled = new List<ResourceNode>();
+        readonly object resourceLock = new object();
+        readonly Dictionary<IResource, ResourceInfo> resources = new Dictionary<IResource, ResourceInfo>();
+        readonly Dictionary<ITestStep, List<IResource>> resourceDependencies = new Dictionary<ITestStep, List<IResource>>();
+        readonly List<ResourceNode> resourceWithBeforeOpenCalled = new List<ResourceNode>();
+        readonly LockManager lockManager = new LockManager();
 
-        private LockManager lockManager;
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public LazyResourceManager()
-        {
-            lockManager = new LockManager();
-        }
-
-        private void OpenResources(List<ResourceNode> toOpen, CancellationToken cancellationToken)
+        void OpenResources(List<ResourceNode> toOpen, CancellationToken cancellationToken)
         {
             toOpen.RemoveAll(x => x.Resource == null);
 
@@ -724,7 +707,7 @@ namespace OpenTap
             }
         }
 
-        private void CloseResources(IEnumerable<IResource> toClose)
+        void CloseResources(IEnumerable<IResource> toClose)
         {
             if (toClose.Any())
             {
@@ -740,7 +723,7 @@ namespace OpenTap
         }
 
         /// <summary>
-        /// This property should be set to all teststeps that are enabled to be run.
+        /// This property should be set to all test steps that are enabled to be run.
         /// </summary>
         public List<ITestStep> EnabledSteps { get; set; }
 

--- a/Engine/ResourceTaskManager.cs
+++ b/Engine/ResourceTaskManager.cs
@@ -692,9 +692,7 @@ namespace OpenTap
         private readonly object resourceLock = new object();
         private Dictionary<IResource, ResourceInfo> resources = new Dictionary<IResource, ResourceInfo>();
         private Dictionary<ITestStep, List<IResource>> resourceDependencies = new Dictionary<ITestStep, List<IResource>>();
-        private Dictionary<IResource, int> resourceReferenceCount = new Dictionary<IResource, int>(); // needed to make sure we don't close resources too early when something is running in parallel
-
-
+       
         private List<ResourceNode> resourceWithBeforeOpenCalled = new List<ResourceNode>();
 
         private LockManager lockManager;
@@ -866,15 +864,6 @@ namespace OpenTap
                                 lock (resourceLock)
                                 {
                                     resourceDependencies[step] = resources.Select(x => x.Resource).ToList();
-                                    foreach (ResourceNode n in resources)
-                                    {
-                                        if (n.Resource is IResource resource)
-                                        {
-                                            if (!resourceReferenceCount.ContainsKey(resource))
-                                                resourceReferenceCount[resource] = 0;
-                                            resourceReferenceCount[resource] += 1;
-                                        }
-                                    }
                                 }
 
                                 OpenResources(resources, cancellationToken);
@@ -910,10 +899,6 @@ namespace OpenTap
                             lock (resourceLock)
                             {
                                 resourceDependencies.Remove(step);
-                                foreach (IResource res in usedResources)
-                                {
-                                    resourceReferenceCount[res] -= 1;
-                                }
                             }
 
                             CloseResources(usedResources);


### PR DESCRIPTION
When the reference count of a resource is greater than 1, it fails to correctly decrement the reference count.

This only occur in test plans with steps running in parallel. And it may not be a problem for few counts since they are not guaranteed to run in parallel.

The problem is that two reference counts are maintained and both are counted up on open, but one is only counted down when the other becomes zero.