### PR TITLE
1225 add installed packages to cache during image install

### DIFF
--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -94,6 +94,7 @@ namespace OpenTap.Package
                 }
                 else
                 {
+                    imageSpecifier.AdditionalPackages.AddRange(new Installation(Target).GetPackages());
                     image = imageSpecifier.Resolve(TapThread.Current.AbortToken);
                 }
 

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -94,6 +94,15 @@ namespace OpenTap.Package
                 }
                 else
                 {
+                    // Here we add the list of currently installed packages to 'AdditionalPackages'.
+                    // These packages will be added to the imageSpecifier's internal cache of known packages.
+                    // This fixes an edge case where an image fails to resolve because one of the specified
+                    // packages is already installed, but is not available in any of the specified repositories
+                    // (or the local cache). In that case, if the installed version is compatible with the image,
+                    // the image resolution will still succeed even if the package cannot be found.
+                    // This is possible e.g. with debug installs where the debug package does not exist in any repository,
+                    // or if the package cache has been cleared by the user, and an image install is attempted
+                    // without the original source repository of some package.
                     imageSpecifier.AdditionalPackages.AddRange(new Installation(Target).GetPackages());
                     image = imageSpecifier.Resolve(TapThread.Current.AbortToken);
                 }

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -104,6 +104,7 @@ namespace OpenTap.Package
                     // or if the package cache has been cleared by the user, and an image install is attempted
                     // without the original source repository of some package.
                     imageSpecifier.AdditionalPackages.AddRange(new Installation(Target).GetPackages());
+                    
                     image = imageSpecifier.Resolve(TapThread.Current.AbortToken);
                 }
 


### PR DESCRIPTION
This fixes an issue causing the image resolution to fail if an already installed package is not available in any of the specified repositories or the package cache.

This issue also reproduces for `tap package install...` under the same circumstances, but I decided to only fix this for image installs, since they behave slightly differently: `image install` succeed telling you the target installation is up to date if no changes would be made, but `package install` always tries to uninstall and reinstall packages, which is not possible if the package is not available.

Cloes #1225