### PR TITLE
1166 PackageReference to drive bug: Fix issue with paths being trimmed

### DIFF
--- a/Package.UnitTests/FilePackageRepoTest.cs
+++ b/Package.UnitTests/FilePackageRepoTest.cs
@@ -1,18 +1,24 @@
+using System.IO;
 using NUnit.Framework;
 namespace OpenTap.Package.UnitTests
 {
     [TestFixture]
     public class FilePackageRepoTest
     {
-        [TestCase("C:\\")]
-        [TestCase("C:")]
-        [TestCase("D:")]
-        [TestCase("D:/")]
-        [TestCase("/")]
-        public void TestRootFileSystemPath(string okPath)
+        [TestCase("C:\\", "C:\\")]
+        [TestCase("/", null)] // this might be C or D or ... depending on the current drive.
+        [TestCase("C:", "C:\\")]
+        [TestCase("D:", "D:\\")]
+        [TestCase("D:\\", "D:\\")]
+        [TestCase("/", null)]
+        public void TestRootFileSystemPath(string okPath, string expectedPath)
         {
+            
+            FilePackageRepository repo = null;
             // A bug previously caused this to crash.
-            Assert.DoesNotThrow(() => new FilePackageRepository(okPath));
+            Assert.DoesNotThrow(() => repo = new FilePackageRepository(okPath));
+            if(expectedPath != null)
+                Assert.AreEqual(repo.AbsolutePath, expectedPath);
             
         }
     }

--- a/Package.UnitTests/FilePackageRepoTest.cs
+++ b/Package.UnitTests/FilePackageRepoTest.cs
@@ -6,7 +6,7 @@ namespace OpenTap.Package.UnitTests
     public class FilePackageRepoTest
     {
         [TestCase("C:\\", "C:\\")]
-        [TestCase("/", null)] // this might be C or D or ... depending on the current drive.
+        [TestCase("\\", null)] // this might be C or D or ... depending on the current drive.
         [TestCase("C:", "C:\\")]
         [TestCase("D:", "D:\\")]
         [TestCase("D:\\", "D:\\")]

--- a/Package.UnitTests/FilePackageRepoTest.cs
+++ b/Package.UnitTests/FilePackageRepoTest.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+namespace OpenTap.Package.UnitTests
+{
+    [TestFixture]
+    public class FilePackageRepoTest
+    {
+        [TestCase("C:\\")]
+        [TestCase("C:")]
+        [TestCase("D:")]
+        [TestCase("D:/")]
+        [TestCase("/")]
+        public void TestRootFileSystemPath(string okPath)
+        {
+            // A bug previously caused this to crash.
+            Assert.DoesNotThrow(() => new FilePackageRepository(okPath));
+            
+        }
+    }
+}

--- a/Package.UnitTests/PackageManagerTests.cs
+++ b/Package.UnitTests/PackageManagerTests.cs
@@ -52,17 +52,17 @@ namespace OpenTap.Package.UnitTests
         }
 
         [TestCase("file:///C:/Packages", "file:///C:/Packages", "Windows")]
-        [TestCase("file:///C:/Packages/", "file:///C:/Packages", "Windows")]
-        [TestCase("file:///Packages/", "file:///{Drive}Packages", "Windows")]
+        [TestCase("file:///C:/Packages/", "file:///C:/Packages/", "Windows")]
+        [TestCase("file:///Packages/", "file:///{Drive}Packages/", "Windows")]
         [TestCase("file:///Packages", "file:///Packages", "Linux")]
-        [TestCase("file:///Packages/", "file:///Packages", "Linux")]
+        [TestCase("file:///Packages/", "file:///Packages/", "Linux")]
         [TestCase("C:/Packages", "file:///C:/Packages", "Windows")]
-        [TestCase("C:/Packages/", "file:///C:/Packages", "Windows")]
+        [TestCase("C:/Packages/", "file:///C:/Packages/", "Windows")]
         [TestCase("/Packages", "file:///Packages", "Linux")]
         [TestCase("/Packages/", "file:///Packages", "Linux")]
-        [TestCase("C:\\Packages/", "file:///C:/Packages", "Windows")]
+        [TestCase("C:\\Packages/", "file:///C:/Packages/", "Windows")]
         [TestCase("PackageCache", "file:///{CurrentDirectory}/PackageCache")]
-        [TestCase("PackageCache/", "file:///{CurrentDirectory}/PackageCache")]
+        [TestCase("PackageCache/", "file:///{CurrentDirectory}/PackageCache/")]
         [TestCase(@"\\wsl.localhost\arch\packages\", "file://wsl.localhost/arch/packages")]
         [TestCase(@"\\192.168.0.100\some\directory\", "file://192.168.0.100/some/directory")]
         public void FileRepositoryUrls(string input, string expectedUrl, string os = "Windows,Linux")

--- a/Package/Repositories/FilePackageRepository.cs
+++ b/Package/Repositories/FilePackageRepository.cs
@@ -44,7 +44,7 @@ namespace OpenTap.Package
             // On other systems (Linux, mac, .. where path == "/") we do nothing.
             if (Path.IsPathRooted(path) && path !="/" && Path.GetPathRoot(path) == path)
             {
-                path = Path.GetPathRoot(path) + Path.DirectorySeparatorChar;
+                path = Path.GetPathRoot(path).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
             }
             
             if (Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out Uri uri))

--- a/Package/Repositories/FilePackageRepository.cs
+++ b/Package/Repositories/FilePackageRepository.cs
@@ -39,6 +39,14 @@ namespace OpenTap.Package
         /// <exception cref="NotSupportedException">Path is not a valid file package repository</exception>
         public FilePackageRepository(string path)
         {
+            // if path is the path root, for example C: and the path is not "/".
+            // then we need to add a '\' so "C:" becomes "C:\".
+            // On other systems (Linux, mac, .. where path == "/") we do nothing.
+            if (Path.IsPathRooted(path) && path !="/" && Path.GetPathRoot(path) == path)
+            {
+                path = Path.GetPathRoot(path) + Path.DirectorySeparatorChar;
+            }
+            
             if (Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out Uri uri))
             {
                 // This is true for UNC paths on Windows
@@ -62,9 +70,9 @@ namespace OpenTap.Package
                     }
 
                     if (File.Exists(absolutePath))
-                        AbsolutePath = Path.GetFullPath(Path.GetDirectoryName(absolutePath)).TrimEnd('/', '\\');
+                        AbsolutePath = Path.GetFullPath(Path.GetDirectoryName(absolutePath));
                     else
-                        AbsolutePath = Path.GetFullPath(absolutePath).TrimEnd('/', '\\');
+                        AbsolutePath = Path.GetFullPath(absolutePath);
                     AbsolutePath = Uri.UnescapeDataString(AbsolutePath);
 
                     Url = new Uri(AbsolutePath).AbsoluteUri;
@@ -88,7 +96,7 @@ namespace OpenTap.Package
             {
                 allPackages = Array.Empty<PackageDef>();
 
-                if (AbsolutePath != PackageDef.SystemWideInstallationDirectory) // Let's ignore this error if the repo is the system wide directory.
+                if (AbsolutePath.TrimEnd('/', '\\') != PackageDef.SystemWideInstallationDirectory.TrimEnd('/', '\\')) // Let's ignore this error if the repo is the system wide directory.
                     throw new DirectoryNotFoundException($"File package repository directory not found at: {Url}");
 
                 return;


### PR DESCRIPTION
- Also added that drive-letter + '':' (D:) is a valid identifier on Windows. This could be useful for people storing packages on e.g USB or network drives.

Close #1166 