### PR TITLE
1228 Optional Result Table Optimization: Implementation

### DIFF
--- a/Engine.UnitTests/Resources/RecordAllResultListener.cs
+++ b/Engine.UnitTests/Resources/RecordAllResultListener.cs
@@ -6,9 +6,8 @@ using System.Threading;
 
 namespace OpenTap.UnitTests
 {
-    public class RecordAllResultListener : ResultListener, IMergedTableResultListener
+    public class RecordAllResultListener : ResultListener
     {
-        public bool SupportsMergedResults { get; set; } = true;
         public Dictionary<Guid, TestRun> Runs { get; set; } = new Dictionary<Guid, TestRun>();
         public Dictionary<Guid, string> planLogs = new Dictionary<Guid, string>();
         public List<ResultTable> Results = new List<ResultTable>();
@@ -49,5 +48,10 @@ namespace OpenTap.UnitTests
             Results.Add(result);
             ResultTableGuids.Add(stepRunId);
         }
+    }
+
+    public class RecordAllMergedResultListener : RecordAllResultListener, IMergedTableResultListener
+    {
+        
     }
 }

--- a/Engine.UnitTests/Resources/RecordAllResultListener.cs
+++ b/Engine.UnitTests/Resources/RecordAllResultListener.cs
@@ -6,8 +6,9 @@ using System.Threading;
 
 namespace OpenTap.UnitTests
 {
-    public class RecordAllResultListener : ResultListener
+    public class RecordAllResultListener : ResultListener, IMergedTableResultListener
     {
+        public bool SupportsMergedResults { get; set; } = true;
         public Dictionary<Guid, TestRun> Runs { get; set; } = new Dictionary<Guid, TestRun>();
         public Dictionary<Guid, string> planLogs = new Dictionary<Guid, string>();
         public List<ResultTable> Results = new List<ResultTable>();

--- a/Engine.UnitTests/ResultTest.cs
+++ b/Engine.UnitTests/ResultTest.cs
@@ -120,10 +120,7 @@ namespace OpenTap.UnitTests
             plan.Steps.Add(step);
             plan.Steps.Add(actionStep);
 
-            var rl = new RecordAllResultListener()
-            {
-                SupportsMergedResults = mergeResults
-            };
+            RecordAllResultListener rl = mergeResults ? new RecordAllMergedResultListener() : new RecordAllResultListener();
             rl.OnTestStepRunStartAction = () => evt.WaitOne();
             
             plan.Execute(new []{rl});
@@ -253,7 +250,6 @@ namespace OpenTap.UnitTests
                 base.OnResultPublished(stepRunId, result);
                 TapThread.Sleep(100);
             }
-            public bool SupportsMergedResults => true;
         }
         
         [Test]

--- a/Engine/IMergedTableResultsListener.cs
+++ b/Engine/IMergedTableResultsListener.cs
@@ -3,10 +3,6 @@ namespace OpenTap
     /// <summary> This interface adds support for optimized/merged result tables. This can provide a performance boost in situations where many rows of the same kinds of results are published. </summary>
     public interface IMergedTableResultListener : IResultListener
     {
-        /// <summary>
-        /// Gets if the result table supports merged result tables. If false or if this interface is not implemented result tables will not be merged.
-        /// </summary>
-        public bool SupportsMergedResults { get; }
-    
+        
     }
 }

--- a/Engine/IMergedTableResultsListener.cs
+++ b/Engine/IMergedTableResultsListener.cs
@@ -1,0 +1,12 @@
+namespace OpenTap
+{
+    /// <summary> This interface adds support for optimized/merged result tables. This can provide a performance boost in situations where many rows of the same kinds of results are published. </summary>
+    public interface IMergedTableResultListener : IResultListener
+    {
+        /// <summary>
+        /// Gets if the result table supports merged result tables. If false or if this interface is not implemented result tables will not be merged.
+        /// </summary>
+        public bool SupportsMergedResults { get; }
+    
+    }
+}

--- a/Engine/Invokable/ISkippableInvokable.cs
+++ b/Engine/Invokable/ISkippableInvokable.cs
@@ -1,0 +1,10 @@
+namespace OpenTap
+{
+    /// <summary> Implements a check if an invocation can be skipped. This should only be implemented if it can be done very quickly. </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T2"></typeparam>
+    interface ISkippableInvokable<T, T2>
+    {
+        public bool Skip(T a, T2 b);
+    }
+}

--- a/Engine/ResultListener.cs
+++ b/Engine/ResultListener.cs
@@ -82,6 +82,20 @@ namespace OpenTap
         public virtual void OnResultPublished(Guid stepRunId, ResultTable result)
         {
         }
+        
+        // lookup keeping track of which result listeners implements OnResultPublished
+        static ImmutableDictionary<Type, bool> implementsOnResultsPublished = ImmutableDictionary<Type, bool>.Empty;
+        /// <summary> Returns true if the result listener has implemented OnResultPublished. This is used to optimize performance in situations where they don't. </summary>
+        internal static bool ImplementsOnResultsPublished(ResultListener resultListener)
+        {
+            var resultListenerType = resultListener.GetType();
+            if (!implementsOnResultsPublished.TryGetValue(resultListenerType, out bool doesImplement))
+            {
+                doesImplement = resultListenerType.MethodOverridden(typeof(ResultListener), nameof(OnResultPublished));
+                implementsOnResultsPublished = implementsOnResultsPublished.Add(resultListenerType, doesImplement);
+            }
+            return doesImplement;
+        }
     }
 
     /// <summary>

--- a/Engine/ResultProxy.cs
+++ b/Engine/ResultProxy.cs
@@ -567,7 +567,7 @@ namespace OpenTap
 
         internal bool WasDeferred => deferWorker != null;
 
-        class PublishResultTableInvokable : IInvokable<IResultListener, WorkQueue>
+        class PublishResultTableInvokable : IInvokable<IResultListener, WorkQueue>, ISkippableInvokable<IResultListener, WorkQueue>
         {
             readonly ResultTable table;
             readonly ResultSource proxy;
@@ -632,7 +632,15 @@ namespace OpenTap
             {
                 try
                 {
-                    a.OnResultPublished(proxy.stepRun.Id, CreateOptimizedTable(queue));
+                    // only merge result tables where it is explicitly supported by the result listener.
+                    if (a is IMergedTableResultListener m && m.SupportsMergedResults)
+                    {
+                        a.OnResultPublished(proxy.stepRun.Id, CreateOptimizedTable(queue));    
+                    }
+                    else
+                    {
+                        a.OnResultPublished(proxy.stepRun.Id, table);
+                    }
                 }
                 catch (Exception e)
                 {
@@ -642,7 +650,14 @@ namespace OpenTap
                 }
             }
 
-
+            // Skip the invocation if the result listener does not implement OnResultPublished.
+            public bool Skip(IResultListener a, WorkQueue b)
+            {
+                if (a is ResultListener r)
+                    return ResultListener.ImplementsOnResultsPublished(r) == false;
+                
+                return false;
+            }
         }
     }
 }

--- a/Engine/ResultProxy.cs
+++ b/Engine/ResultProxy.cs
@@ -633,7 +633,7 @@ namespace OpenTap
                 try
                 {
                     // only merge result tables where it is explicitly supported by the result listener.
-                    if (a is IMergedTableResultListener m && m.SupportsMergedResults)
+                    if (a is IMergedTableResultListener)
                     {
                         a.OnResultPublished(proxy.stepRun.Id, CreateOptimizedTable(queue));    
                     }

--- a/Engine/TestPlanRun.cs
+++ b/Engine/TestPlanRun.cs
@@ -285,6 +285,12 @@ namespace OpenTap
             {
                 if (item.Key is T x)
                 {
+                    if (r is ISkippableInvokable<T, WorkQueue> skippableInvokable)
+                    {
+                        // skip the work if possible.
+                        if (skippableInvokable.Skip(x, item.Value))
+                            continue;
+                    }
                     count++;
                     item.Value.EnqueueWork(r, x, item.Value);
                 }

--- a/Shared/ReflectionHelper.cs
+++ b/Shared/ReflectionHelper.cs
@@ -505,7 +505,12 @@ namespace OpenTap
             return getMethodsTap(type);
         }
 
-        
+        public static bool MethodOverridden(this Type t, Type baseType, string methodName)
+        {
+            var m1 = baseType.GetMethod(methodName).MethodHandle.Value;
+            var m2 = t.GetMethod(methodName).MethodHandle.Value;
+            return m1 != m2;
+        } 
 
         /// <summary> Get the base C# type of a given type. </summary>
         internal static T As<T>(this ITypeData type) where T: ITypeData


### PR DESCRIPTION
- Added an interface that can be implemented if merged result tables
- Added an optimization that if a given type does not override OnResultPublished (if its the default implementation of ResultListener), then we don't call it.
- Added unit tests to verify the behavior.

Close #1228