### PR TITLE
1230 Expressions are not always a dependency: fix

### DIFF
--- a/Engine/AssemblyData.cs
+++ b/Engine/AssemblyData.cs
@@ -109,6 +109,9 @@ namespace OpenTap
         Assembly assembly;
 
         bool failedLoad;
+
+        /// <summary> Gets the assembly without loading it.</summary>
+        internal Assembly GetCached() => assembly ?? preloadedAssembly;
         
         /// <summary>
         /// Returns the System.Reflection.Assembly corresponding to this. 

--- a/Engine/SerializerPlugins/ObjectSerializer.cs
+++ b/Engine/SerializerPlugins/ObjectSerializer.cs
@@ -828,9 +828,13 @@ namespace OpenTap.Plugins
                                         }
                                     }
                                     
-                                    SetHasDefaultValueAttribute(subProp, val, elem2);
+                                    // if the setting has the default value, then don't notify that the type has been used, 
+                                    // because it will probably not have been used in the end.
+                                    bool hasDefaultValue =  SetHasDefaultValueAttribute(subProp, val, elem2);
+                                    
                                     elem.Add(elem2);
-                                    Serializer.Serialize(elem2, val, subProp.TypeDescriptor);
+                                    
+                                    Serializer.Serialize(elem2, val, subProp.TypeDescriptor, notifyTypeUsed: !hasDefaultValue);
                                 }
                             }
                             catch (Exception e)
@@ -857,12 +861,16 @@ namespace OpenTap.Plugins
             }
         }
 
-        private void SetHasDefaultValueAttribute(IMemberData subProp, object val, XElement elem2)
+        bool SetHasDefaultValueAttribute(IMemberData subProp, object val, XElement elem2)
         {
             
             var attr = subProp.GetAttribute<DefaultValueAttribute>();
             if (attr != null && !(subProp is IParameterMemberData))
+            {
                 Serializer.GetSerializer<DefaultValueSerializer>().RegisterDefaultValue(elem2, attr.Value);
+                return val == attr.Value;
+            }
+            return false;
         }
     }
 }

--- a/Engine/TapSerialization.cs
+++ b/Engine/TapSerialization.cs
@@ -449,24 +449,23 @@ namespace OpenTap
             }
         }
 
-        /// <summary>
-        /// Serializes an object to XML.
-        /// </summary>
-        /// <param name="elem"></param>
-        /// <param name="obj"></param>
-        /// <param name="expectedType"></param>
-        /// <returns></returns>
-        public bool Serialize(XElement elem, object obj, ITypeData expectedType = null)
+        /// <summary> Serializes an object to XML. </summary>
+        public bool Serialize(XElement elem, object obj, ITypeData expectedType = null) => 
+            Serialize(elem, obj, expectedType, true);
+
+        /// <summary> Serializes an object to XML. Includes an argument whether the serializer should be notified about the type being used.</summary>
+        internal bool Serialize(XElement elem, object obj, ITypeData expectedType, bool notifyTypeUsed)
         {
             ITypeData type = null;
             if(obj != null)
             {
                 type = TypeData.GetTypeData(obj);
-                NotifyTypeUsed(type);
+                if(notifyTypeUsed)
+                    NotifyTypeUsed(type);
             }
             if (Object.Equals(type, expectedType) == false && type != null)
                 elem.SetAttributeValue("type", type.Name);
-            else if (expectedType != null)
+            else if (expectedType != null && notifyTypeUsed)
                 NotifyTypeUsed(expectedType);
 
             foreach (var serializer in serializers)

--- a/Engine/TypeData.cs
+++ b/Engine/TypeData.cs
@@ -241,6 +241,9 @@ namespace OpenTap
         TypeData elementType;
         ITypeData baseTypeCache;
 
+        // this value is used to mark a type code that has not been loaded
+        // all the normal values of TypeCode means something specifically
+        // so this value is used as something that does not have other meaning.
         const int UnloadedTypeCode = 100;
         
         TypeCode typeCode = (TypeCode)(UnloadedTypeCode);

--- a/Engine/TypeData.cs
+++ b/Engine/TypeData.cs
@@ -240,7 +240,10 @@ namespace OpenTap
         bool failedLoad;
         TypeData elementType;
         ITypeData baseTypeCache;
-        TypeCode typeCode = TypeCode.Object;
+
+        const int UnloadedTypeCode = 100;
+        
+        TypeCode typeCode = (TypeCode)(UnloadedTypeCode);
         object[] attributes = null;
         bool postLoaded = false;
         readonly object loadLock = new object();
@@ -298,12 +301,19 @@ namespace OpenTap
             IsBrowsable = true;
         }
 
-        TypeData(Type type): this(type.FullName)
+        TypeData(Type type, PluginSearcher searcher): this(type.FullName)
         {
             this.type = type;
+            if(type.Assembly.IsDynamic == false)
+                this.Assembly = searcher.GetAssemblyData(type.Assembly);
+            else
+            {
+                this.Assembly = new AssemblyData(null, type.Assembly);
+            }
             PostLoad();
             IsBrowsable = this.GetAttribute<BrowsableAttribute>()?.Browsable ?? true;
         }
+        
 
         /// <summary>
         /// Returns the System.Type corresponding to this. 
@@ -312,11 +322,16 @@ namespace OpenTap
         public Type Load()
         {
             if (failedLoad) return null;
-            if (type != null) return type;
+            if (type != null && UnloadedTypeCode != (int)typeCode)
+            {
+                return type;
+            }
+            // if UnloadedTypeCode == typeCode, it means it has not been fully loaded. 
 
             try
             {
-                var asm = Assembly.Load();
+                
+                var asm = Assembly?.Load();
                 if (asm == null)
                 {
                     failedLoad = true;
@@ -324,6 +339,7 @@ namespace OpenTap
                 }
 
                 type = asm.GetType(this.Name, true);
+                typeCode = Type.GetTypeCode(type);
                 typeToTypeDataCache.GetValue(type, t => this);
             }
             catch (Exception ex)
@@ -731,7 +747,7 @@ namespace OpenTap
                     {
                     }
 
-                    td = new TypeData(type);
+                    td = new TypeData(type, searcher);
                 }
                 else
                 {
@@ -741,7 +757,7 @@ namespace OpenTap
                     // is a type mismatch, we instantiate a new typedata from the correct type.
                     if (td == null || td.Type != type)
                     {
-                        td = new TypeData(type);
+                        td = new TypeData(type, searcher);
                     }
                 }
             }


### PR DESCRIPTION
Two things were wrong:

1. If the default value for a property was used - for example null in the case of ExpressionCollection. Then the XML would still be marked as having a dependency.
2. The ExpressionMember did not get marked as a dependency from the Expressions package because the ExpressionCollection type did not get loaded the normal way and hence TypeData.FromType(typeof(ExpressionObject)).Assembly was null and it did not recognize that it came from that package.

 1 was fixed in the serializer by checking if the property had default value and if so the type was not marked as being used.

2 was fixed by adding the Assembly reference when loading a TypeData 'FromType'. To do this the assembly searcher had to be modified a bit to make it possible to search for an assembly.