### PR TITLE
Look for system-wide files in system-wide directory

### DIFF
--- a/Package/CreatePackage/FileHashPackageAction.cs
+++ b/Package/CreatePackage/FileHashPackageAction.cs
@@ -139,7 +139,11 @@ namespace OpenTap.Package
                         log.Debug("Replacing '\\' with '/' in {0}", file.FileName);
                         file.FileName = repl;
                     }
-                    string fullpath = Path.Combine(Target, file.FileName);
+
+                    string fullpath =
+                        Path.Combine(pkg.IsSystemWide() ? PackageDef.SystemWideInstallationDirectory : Target,
+                            file.FileName);
+                    
                     var hash2 = new FileHashPackageAction.Hash(FileHashPackageAction.hashFile(fullpath));
                     if (false == hash2.Equals(hash))
                     {

--- a/Tap.Upgrader/Program.cs
+++ b/Tap.Upgrader/Program.cs
@@ -115,10 +115,10 @@ namespace Tap.Upgrader
         /// </summary>
         internal static readonly UpgradePair[] UpgradePairs =
         {
-            // this file is written when installing any version of OpenTAP with OpenTAP 9.17 or later
-            new UpgradePair("../../tap.exe.new", "../../tap.exe", true),
             // this file is part of the payload for OpenTAP 9.17 and later
             new UpgradePair("tap.exe.new", "../../tap.exe", false),
+            // this file is written when installing any version of OpenTAP with OpenTAP 9.17 or later
+            new UpgradePair("../../tap.exe.new", "../../tap.exe", true),
             // .net462 no tap.dll exists.
             //// this file is written when installing any version of OpenTAP with OpenTAP 9.17 or later
             //new UpgradePair("../../tap.dll.new", "../../tap.dll", true),
@@ -146,7 +146,7 @@ namespace Tap.Upgrader
             }, TimeSpan.FromMinutes(10));
         }
 
-        private static bool DeleteTapDll()
+        private static bool ShouldDeleteTapDll()
         {
             try
             {
@@ -227,7 +227,7 @@ namespace Tap.Upgrader
                         p.Install();
                 }
 
-                if (DeleteTapDll())
+                if (ShouldDeleteTapDll())
                 {
                     var tapDllLoc = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "../../tap.dll"));
                     RetryUntilSuccess(() =>


### PR DESCRIPTION
This fixes a couple of `tap package verify` issues:

* It tried looking for system-wide files in the current installation. Now it looks in the system-wide directory
* The `Tap.Upgrader` logic tried to replace `tap.exe.new` first, and then `Packages/OpenTAP/tap.exe.new` afterwards, which has a non-matching checksum because `tap.exe` and `tap.exe.new` are signed separately although they are copies of each other.
By swapping the order, we prefer `./tap.exe.new` over `./Packages/OpenTAP/tap.exe.new` if it is present (this is the case when upgrading from OpenTAP 9.17 or later)

Closes #1237
Closes #1083 