### PR TITLE
Fix mac resolution

### DIFF
--- a/Package/PackageActions/Download.cs
+++ b/Package/PackageActions/Download.cs
@@ -66,18 +66,7 @@ namespace OpenTap.Package
         public PackageDownloadAction()
         {
             Architecture = ArchitectureHelper.GuessBaseArchitecture;
-            switch (Environment.OSVersion.Platform)
-            {
-                case PlatformID.MacOSX:
-                    OS = "MacOS";
-                    break;
-                case PlatformID.Unix:
-                    OS = "Linux";
-                    break;
-                default:
-                    OS = "Windows";
-                    break;
-            }
+            OS = GuessHostOS();
         }
 
         protected override int LockedExecute(CancellationToken cancellationToken)

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using OpenTap.Cli;
@@ -99,18 +100,7 @@ namespace OpenTap.Package
         public PackageInstallAction()
         {
             Architecture = ArchitectureHelper.GuessBaseArchitecture;
-            switch (Environment.OSVersion.Platform)
-            {
-                case PlatformID.MacOSX:
-                    OS = "MacOS";
-                    break;
-                case PlatformID.Unix:
-                    OS = "Linux";
-                    break;
-                default:
-                    OS = "Windows";
-                    break;
-            }
+            OS = GuessHostOS();
 
             DefaultOs = OS;
         }

--- a/Package/PackageActions/List.cs
+++ b/Package/PackageActions/List.cs
@@ -47,21 +47,7 @@ namespace OpenTap.Package
         {
             // OS was explicitly specified. This is interpreted as: Show only packages compatible with that OS. 
             bool checkOs = OS != null;
-            if (OS == null)
-            {
-                switch (Environment.OSVersion.Platform)
-                {
-                    case PlatformID.MacOSX:
-                        OS = "MacOS";
-                        break;
-                    case PlatformID.Unix:
-                        OS = "Linux";
-                        break;
-                    default:
-                        OS = "Windows";
-                        break;
-                }
-            }
+            OS ??= GuessHostOS();
 
             if (NoCache) PackageManagerSettings.Current.UseLocalPackageCache = false;
             List<IPackageRepository> repositories = new List<IPackageRepository>();

--- a/Package/PackageActions/LockingPackageAction.cs
+++ b/Package/PackageActions/LockingPackageAction.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -55,6 +56,26 @@ namespace OpenTap.Package
         internal static string GetLocalInstallationDir()
         {
             return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        }
+
+        internal static string GuessHostOS()
+        {
+            // Environment.OSVersion is not very reliable. In some cases, it will return Unix for MacOSX, even
+            // in spite of the fact that MacOSX is a member of the returned enum.
+            // Check runtime version first, and then use OSVersion as a fallback.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return "Linux";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return "MacOS";
+            switch (Environment.OSVersion.Platform)
+            {
+                case PlatformID.MacOSX:
+                    return "MacOS";
+                case PlatformID.Unix:
+                    return "Linux";
+                default:
+                    return "Windows";
+            }
         }
 
         /// <summary>

--- a/Package/PackageActions/LockingPackageAction.cs
+++ b/Package/PackageActions/LockingPackageAction.cs
@@ -60,22 +60,7 @@ namespace OpenTap.Package
 
         internal static string GuessHostOS()
         {
-            // Environment.OSVersion is not very reliable. In some cases, it will return Unix for MacOSX, even
-            // in spite of the fact that MacOSX is a member of the returned enum.
-            // Check runtime version first, and then use OSVersion as a fallback.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                return "Linux";
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                return "MacOS";
-            switch (Environment.OSVersion.Platform)
-            {
-                case PlatformID.MacOSX:
-                    return "MacOS";
-                case PlatformID.Unix:
-                    return "Linux";
-                default:
-                    return "Windows";
-            }
+            return OperatingSystem.Current.Name;
         }
 
         /// <summary>

--- a/Tap.Upgrader/Tap.Upgrader.csproj
+++ b/Tap.Upgrader/Tap.Upgrader.csproj
@@ -15,13 +15,19 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PlatformEnv Condition=" '$(OS)' == 'OSX' ">MacOS</PlatformEnv>
-    <PlatformEnv Condition=" '$(OS)' == 'Unix' ">Linux</PlatformEnv>
-    <PlatformEnv Condition=" '$(OS)' == 'Windows' ">Windows</PlatformEnv>
+    <!--Detect platform-->
+    <PlatformEnv Condition="$([MSBuild]::IsOSPlatform('OSX'))">MacOS</PlatformEnv>
+    <PlatformEnv Condition="$([MSBuild]::IsOSPlatform('Linux'))">Linux</PlatformEnv>
+    <PlatformEnv Condition="$([MSBuild]::IsOSPlatform('Windows'))">Windows</PlatformEnv>
+    <!-- IsOsPlatform may not always be available on Windows -->
+    <PlatformEnv Condition="'$(OS)' == 'Windows_NT'">Windows</PlatformEnv>
+
+    <!--Detect architecture -->
+    <ArchEnv>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</ArchEnv> 
   </PropertyGroup>
   <!-- Install OpenTAP as a package - this is necessary for most of the package cli actions to function normally.  -->
   <!-- CopyFilesToOutputDirectory is required for libgit native DLLs -->
   <Target Name="InstallOpenTapAsPackage" AfterTargets="CopyFilesToOutputDirectory">
-    <Exec Command="$(OutDir)tap package create ../../package.xml -o $(OutDir)OpenTap.Debug.TapPackage --install" EnvironmentVariables="Debug=true;Sign=false;Platform=$(PlatformEnv)" WorkingDirectory="$(OutDir)" />
+    <Exec Command="$(OutDir)tap package create ../../package.xml -o $(OutDir)OpenTap.Debug.TapPackage --install" EnvironmentVariables="Debug=true;Sign=false;Platform=$(PlatformEnv);Architecture=$(ArchEnv.ToLower())" WorkingDirectory="$(OutDir)" />
   </Target>
 </Project>


### PR DESCRIPTION
This fixes several architecture and os related issues on MacOS:

* tap package list now only shows packages available for macos on mac
* tap package install now correctly resolves packages for macos on mac
* The debug package created when compiling OpenTAP will not be created for the correct OS and Architecture based on the host

Closes #1211 
Closes #817 