### PR TITLE
Add elevation when uninstalling system-wide packages

### DIFF
--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -390,7 +390,7 @@ namespace OpenTap.Package
                         RaiseError(ex);
                     }
 
-                    var pct = ((double)systemwidePackages.Length / systemwidePackages.Length + packagesToInstall.Count) * 100;
+                    var pct = ((double)systemwidePackages.Length / (systemwidePackages.Length + packagesToInstall.Count)) * 100;
                     RaiseProgressUpdate((int)pct, "Installed system-wide packages.");
                 }
                 // Otherwise if we are admin and we need to install system-wide packages, we can install them in the current process

--- a/Package/PackageInstallHelpers/PackageInstallStep.cs
+++ b/Package/PackageInstallHelpers/PackageInstallStep.cs
@@ -5,6 +5,36 @@ using System.Threading;
 namespace OpenTap.Package.PackageInstallHelpers
 {
     [Browsable(false)]
+    class PackageUninstallStep : TestStep
+    {
+        public string Target { get; set; }
+        public string[] Packages { get; set; }
+        public bool Force { get; set; }
+        public override void Run()
+        {
+            var action = new PackageUninstallAction()
+            {
+                NonInteractive = true,
+                Force = Force,
+                Packages = Packages,
+                Target = Target,
+                AlreadyElevated = true,
+            };
+            try
+            {
+                var result = action.Execute(CancellationToken.None);
+                UpgradeVerdict(result == 0 ? Verdict.Pass : Verdict.Fail);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e.Message);
+                Log.Debug(e);
+                UpgradeVerdict(Verdict.Error);
+            }
+        }
+    }
+
+    [Browsable(false)]
     class PackageInstallStep : TestStep
     {
         public string Target { get; set; }


### PR DESCRIPTION
This adds an elevation prompt like the one used for installing packages when uninstalling system-wide packages.

Closes #627