### PR TITLE
dotnet new ... --verbosity quiet

### DIFF
--- a/sdk/sdk.package.xml
+++ b/sdk/sdk.package.xml
@@ -62,6 +62,6 @@
       106        : .NET 7 or later if the template is already installed
       -2147352567: Earlier than .NET 7 if the template is already installed
     -->
-		<ActionStep ExpectedExitCodes="0,106,-2147352567" ExeFile="dotnet" Arguments='new --install Packages/SDK/OpenTap.Templates.$(GitLongVersion).nupkg' ActionName="install" Optional="true"/>
+		<ActionStep ExpectedExitCodes="0,106,-2147352567" ExeFile="dotnet" Arguments='new --install Packages/SDK/OpenTap.Templates.$(GitLongVersion).nupkg --verbosity quiet' ActionName="install" Optional="true"/>
 	</PackageActionExtensions>
 </Package>


### PR DESCRIPTION
Set verbosity quiet when installing the nuget package with sdk. Otherwise it will generate warnings when installing on top of an existing nuget installation.