### PR TITLE
Update Linux smartinstaller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -790,7 +790,9 @@ jobs:
       - GetVersion
       - Package-Cross
     container:
-      image: ghcr.io/opentap/smartinstaller@sha256:f9cc89cce025be9b7dad011347a02b8c4304655f343aff1ac9396d22b148ec42
+      #This sha hash points to beta.7 (which was also force-overwritten). beta.7 contains a fix which allows the installer
+      #to run in quiet mode when webkit2gtk is not installed
+      image: ghcr.io/opentap/smartinstaller@sha256:a141bb74b33a29d5d224d23202b0dc1c630f7200805b28f5058941ea6d0eacb7
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This updates the Linux smartinstaller to a version which contains a fix for #1275 

Closes #1275 