### PR TITLE
1276 Hide Add Mixin

### DIFF
--- a/Engine.UnitTests/MixinTests.cs
+++ b/Engine.UnitTests/MixinTests.cs
@@ -134,6 +134,24 @@ namespace OpenTap.UnitTests
                 Assert.AreEqual(idx * 10 + 513, y);
             }
         }
+
+        [Test]
+        public void TestAddMixinRestrictions([Values] bool isLocked)
+        {
+            var plan = new TestPlan();
+            var step = new DelayStep();
+            plan.ChildTestSteps.Add(step);
+            plan.Locked = isLocked;
+            var memberAnnotation = AnnotationCollection.Annotate(step).GetMember(nameof(step.DelaySecs));
+            var menu = memberAnnotation.Get<MenuAnnotation>().MenuItems.ToArray();
+            var mixinItem = menu.FirstOrDefault(x => x.Get<IIconAnnotation>()?.IconName == IconNames.AddMixin);
+            var access = mixinItem.GetAll<IAccessAnnotation>();
+            var hidden = access.Any(x => x.IsVisible == false);
+            if (isLocked)
+                Assert.IsTrue(hidden);
+            else
+                Assert.IsFalse(hidden);
+        }
     }
 
     public class MixinTest : IMixin, ITestStepPostRunMixin, ITestStepPreRunMixin, IAssignOutputMixin

--- a/Engine/MixinMenuModel.cs
+++ b/Engine/MixinMenuModel.cs
@@ -6,9 +6,19 @@ namespace OpenTap
     {
         readonly ITypeData type;
 
+        public bool TestPlanLocked
+        {
+            get
+            {
+                var plan2 = source.OfType<ITestStep>()
+                    .Select(step => step is TestPlan plan ? plan : step.GetParent<TestPlan>()).FirstOrDefault();
+                return (plan2?.IsRunning ?? false) || (plan2?.Locked ?? false);
+            }
+        }
+        
         public MixinMenuModel(ITypeData type) => this.type = type;
         bool? showMixins;
-        public bool ShowMixins => showMixins ??= MixinFactory.GetMixinBuilders(type).Any();
+        public bool ShowMixins => (showMixins ??= (MixinFactory.GetMixinBuilders(type).Any()))&& !TestPlanLocked;
         
         [Display("Add Mixin...", "Add a new mixin.", Order: 2.0, Group: "Mixins")]
         [Browsable(true)]


### PR DESCRIPTION
- Hide the Add Mixin... menu item when the test plan is running or locked.

- Added unit test to verify the behavior.


Close #1276 