### PR TITLE
1280 Clone Mixins Using Serializers: fix

### DIFF
--- a/Engine/MixinMemberMenuModel.cs
+++ b/Engine/MixinMemberMenuModel.cs
@@ -24,6 +24,7 @@ namespace OpenTap
             var targetType = TypeData.GetTypeData(Source.First());
             var builders = MixinFactory.GetMixinBuilders(targetType).ToImmutableArray();
             builders = builders.Replace(builders.FirstOrDefault(x => x.GetType() == src.GetType()), src);
+            src.Initialize(targetType);
 
             var ui = new MixinBuilderUi(builders.ToArray(), src);
             UserInput.Request(ui);
@@ -32,9 +33,17 @@ namespace OpenTap
                 return; // cancel
 
             var selectedMixin = ui.SelectedItem;
+            TapSerializer serializer = null;
+            
+            bool first = true;
             foreach (var src2 in Source)
             {
-                var mem = selectedMixin.Clone().ToDynamicMember(targetType);
+                if (first)
+                    first = false;
+                else
+                    selectedMixin = Utils.Clone(selectedMixin, ref serializer);
+                
+                var mem = selectedMixin.ToDynamicMember(targetType);
                 
                 var remMember = member;
                 var currentValue = remMember.GetValue(src2);

--- a/Engine/MixinMemberMenuModel.cs
+++ b/Engine/MixinMemberMenuModel.cs
@@ -33,17 +33,11 @@ namespace OpenTap
                 return; // cancel
 
             var selectedMixin = ui.SelectedItem;
-            TapSerializer serializer = null;
+            var serializer = new TapSerializer();
             
-            bool first = true;
             foreach (var src2 in Source)
             {
-                if (first)
-                    first = false;
-                else
-                    selectedMixin = Utils.Clone(selectedMixin, ref serializer);
-                
-                var mem = selectedMixin.ToDynamicMember(targetType);
+                var mem = serializer.Clone(selectedMixin).ToDynamicMember(targetType);
                 
                 var remMember = member;
                 var currentValue = remMember.GetValue(src2);

--- a/Engine/MixinMenuModel.cs
+++ b/Engine/MixinMenuModel.cs
@@ -36,16 +36,10 @@ namespace OpenTap
 
             var selectedMixin = ui.SelectedItem;
     
-            bool first = true;
-            TapSerializer serializer = null;
+            var serializer = new TapSerializer();
             foreach (var src in source)
             {
-                if (first)
-                    first = false;
-                else
-                    selectedMixin = Utils.Clone(selectedMixin, ref serializer);
-                
-                MixinFactory.LoadMixin(src, selectedMixin);
+                MixinFactory.LoadMixin(src, serializer.Clone(selectedMixin));
             }
         }
 

--- a/Engine/MixinMenuModel.cs
+++ b/Engine/MixinMenuModel.cs
@@ -35,9 +35,18 @@ namespace OpenTap
                 return; // cancel
 
             var selectedMixin = ui.SelectedItem;
-            
+    
+            bool first = true;
+            TapSerializer serializer = null;
             foreach (var src in source)
-                MixinFactory.LoadMixin(src, selectedMixin.Clone());
+            {
+                if (first)
+                    first = false;
+                else
+                    selectedMixin = Utils.Clone(selectedMixin, ref serializer);
+                
+                MixinFactory.LoadMixin(src, selectedMixin);
+            }
         }
 
         object[] source;

--- a/Engine/Mixins/IMixinBuilder.cs
+++ b/Engine/Mixins/IMixinBuilder.cs
@@ -5,12 +5,8 @@ namespace OpenTap
     {
         /// <summary> Initializes the mixin, providing the type of object to provide a mixin for. </summary>
         void Initialize(ITypeData targetType);
+        
         /// <summary> Creates the member for the mixin. </summary>
-        /// <param name="targetType"></param>
-        /// <returns></returns>
         MixinMemberData ToDynamicMember(ITypeData targetType);
-
-        /// <summary> Clones an instance of mixin builder. </summary>
-        IMixinBuilder Clone();
     }
 }

--- a/Engine/TapSerialization.cs
+++ b/Engine/TapSerialization.cs
@@ -575,6 +575,8 @@ namespace OpenTap
             return Deserialize(doc);
         }
 
+        internal T Clone<T>(T obj) => (T)Clone((object)obj);
+
         /// <summary> for mapping object to serializer. </summary>
         static System.Runtime.CompilerServices.ConditionalWeakTable<object, TapSerializer> serializerSteps = 
             new System.Runtime.CompilerServices.ConditionalWeakTable<object, TapSerializer>();

--- a/Shared/ReflectionHelper.cs
+++ b/Shared/ReflectionHelper.cs
@@ -882,7 +882,16 @@ namespace OpenTap
             del += () => f(v); 
             return del;
         }
-
+        
+        /// <summary> Clones a object. creates a new serializer if needed, but reuses an existing one if possible.</summary>
+        public static T Clone<T>(T obj, ref TapSerializer cachedSerializer)
+        {
+            if (obj is ICloneable cloneable)
+                return (T)cloneable.Clone();
+            
+            return (T)(cachedSerializer ??= new TapSerializer()).Clone(obj);
+        }
+        
         /// <summary>
         /// Thread-safe and lock free value exchange. valueGen depends on the current value.
         /// </summary>
@@ -913,21 +922,10 @@ namespace OpenTap
         
         static public Action ActionDefault = () => { };
 
-        public static void Swap<T>(ref T a, ref T b)
-        {
-            T buffer = a;
-            a = b;
-            b = buffer;
-        }
-
-        /// <summary>
-        /// Clamps val to be between min and max, returning the result.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="val"></param>
-        /// <param name="min"></param>
-        /// <param name="max"></param>
-        /// <returns></returns>
+        /// <summary> Swaps two variables </summary>
+        public static void Swap<T>(ref T a, ref T b) => (a, b) = (b, a);
+        
+        /// <summary> Clamps val to be between min and max, returning the result. </summary>
         public static T Clamp<T>(this T val, T min, T max) where T : IComparable<T>
         {
             if (val.CompareTo(min) < 0) return min;
@@ -935,16 +933,8 @@ namespace OpenTap
             return val;
         }
 
-        /// <summary>
-        /// Returns arg.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="id"></param>
-        /// <returns></returns>
-        public static T Identity<T>(T id)
-        {
-            return id;
-        }
+        /// <summary> Returns arg. </summary>
+        public static T Identity<T>(T id) => id;
         
         /// <summary> Do nothing. </summary>
         public static void Noop () { }

--- a/Shared/ReflectionHelper.cs
+++ b/Shared/ReflectionHelper.cs
@@ -883,15 +883,6 @@ namespace OpenTap
             return del;
         }
         
-        /// <summary> Clones a object. creates a new serializer if needed, but reuses an existing one if possible.</summary>
-        public static T Clone<T>(T obj, ref TapSerializer cachedSerializer)
-        {
-            if (obj is ICloneable cloneable)
-                return (T)cloneable.Clone();
-            
-            return (T)(cachedSerializer ??= new TapSerializer()).Clone(obj);
-        }
-        
         /// <summary>
         /// Thread-safe and lock free value exchange. valueGen depends on the current value.
         /// </summary>


### PR DESCRIPTION
- Using TapSerializere to clone mixin builders instead of using their own implementation - if possible IClonable can be implemented.

- Removed Clone from IMixinBuilder (minor Breaking change from OpenTAP 9.22 RC).

- Added calling IMixinBuilder.Initialize also when modifying an existing mixin.