### PR TITLE
1282-GetSettingsLookupRaceFix: Test

### DIFF
--- a/Shared/Cache.cs
+++ b/Shared/Cache.cs
@@ -51,7 +51,7 @@ namespace OpenTap
         public V AddValue(K key, V value)
         {
             CheckClear();
-            dict = dict.Add(key, value);
+            dict = dict.SetItem(key, value);
             return value;
         }
     }


### PR DESCRIPTION
- Fixed the issue by using ImmutableDictionary.SetItem instead of ImmutableDictionary.Add.
   The difference is that SetItem updates values of existing keys while Add throws an exception if the key exists in the dictionary.

- Added unit test to show the issue.


Close #1282 

