### PR TITLE
Allow the exit code dotnet runtime gives if dotnet sdk is not installed

### DIFF
--- a/Package.UnitTests/PackageDefLoadSaveCompare.cs
+++ b/Package.UnitTests/PackageDefLoadSaveCompare.cs
@@ -112,7 +112,7 @@ namespace OpenTap.Package.UnitTests
             </File>
         </Files>
         <PackageActionExtensions>
-            <ActionStep ExpectedExitCodes='0' ActionName='install' Arguments='+x tap' ExeFile='chmod' Optional='false'></ActionStep>
+            <ActionStep ExpectedExitCodes='0' ActionName='install' Quiet='false' Arguments='+x tap' ExeFile='chmod' Optional='false'></ActionStep>
         </PackageActionExtensions>
     </Package>";
                 LoadSaveCompare(input, input);

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -226,6 +226,13 @@ namespace OpenTap.Package
         public string ExpectedExitCodes { get; set; } = "0";
 
         /// <summary>
+        /// False; Action stdout and stderr will be forwarded
+        /// True; Action stdout and stderr will be suppressed
+        /// </summary>
+        [XmlAttribute("Quiet")]
+        public bool Quiet { get; set; } = false;
+
+        /// <summary>
         /// False; package installation should fail if the executable does not exist.
         /// True; package installation should continue if the executable does not exist.
         /// </summary>

--- a/Package/PluginInstaller.cs
+++ b/Package/PluginInstaller.cs
@@ -143,8 +143,8 @@ namespace OpenTap.Package
                     }
                     else
                     {
-                        pi.RedirectStandardOutput = true;
-                        pi.RedirectStandardError = true;
+                        pi.RedirectStandardOutput = step.Quiet == false;
+                        pi.RedirectStandardError = step.Quiet == false;
                         pi.UseShellExecute = false;
 
                         p = Process.Start(pi);

--- a/sdk/sdk.package.xml
+++ b/sdk/sdk.package.xml
@@ -61,7 +61,8 @@
       The template install will fail with various exit codes dependening on the dotnet version, and whether or not the templates are already installed:
       106        : .NET 7 or later if the template is already installed
       -2147352567: Earlier than .NET 7 if the template is already installed
+      -2147450735: The error code when .NET runtime is installed, but .NET SDK is not
     -->
-		<ActionStep ExpectedExitCodes="0,106,-2147352567" ExeFile="dotnet" Arguments='new --install Packages/SDK/OpenTap.Templates.$(GitLongVersion).nupkg --verbosity quiet' ActionName="install" Optional="true"/>
+		<ActionStep ExpectedExitCodes="0,106,-2147352567,-2147450735" ExeFile="dotnet" Arguments='new --install Packages/SDK/OpenTap.Templates.$(GitLongVersion).nupkg --verbosity quiet' ActionName="install" Optional="true"/>
 	</PackageActionExtensions>
 </Package>

--- a/sdk/sdk.package.xml
+++ b/sdk/sdk.package.xml
@@ -63,6 +63,6 @@
       -2147352567: Earlier than .NET 7 if the template is already installed
       -2147450735: The error code when .NET runtime is installed, but .NET SDK is not
     -->
-		<ActionStep ExpectedExitCodes="0,106,-2147352567,-2147450735" ExeFile="dotnet" Arguments='new --install Packages/SDK/OpenTap.Templates.$(GitLongVersion).nupkg --verbosity quiet' ActionName="install" Optional="true"/>
+		<ActionStep ExpectedExitCodes="0,106,-2147352567,-2147450735" Quiet="true" ExeFile="dotnet" Arguments='new --install Packages/SDK/OpenTap.Templates.$(GitLongVersion).nupkg' ActionName="install" Optional="true"/>
 	</PackageActionExtensions>
 </Package>


### PR DESCRIPTION
Closes #1309 