### PR TITLE
9.22.1-rc.4

### DIFF
--- a/Engine.UnitTests/ArtifactZipper.cs
+++ b/Engine.UnitTests/ArtifactZipper.cs
@@ -80,7 +80,7 @@ namespace OpenTap.Engine.UnitTests
             }
             this.Log.Debug("Wrote file: {0}", Path.GetFullPath(newName));
             
-            planRun.PublishArtifact(File.OpenRead(newName), Path.GetFileName(newName));
+            planRun.PublishArtifactAsync(File.OpenRead(newName), Path.GetFileName(newName));
         }
 
         readonly Dictionary<Guid, Guid> parentMap = new Dictionary<Guid, Guid>();

--- a/Engine.UnitTests/HttpArtifactStep.cs
+++ b/Engine.UnitTests/HttpArtifactStep.cs
@@ -1,0 +1,19 @@
+using System.Net.Http;
+namespace OpenTap.Engine.UnitTests
+{
+    [Display("HTTP Artifact Step", Group: "Test")]
+    public class HttpArtifactStep : TestStep
+    {
+        public string Url { get; set; }
+        public string FileName { get; set; } = "test.html";
+
+        public override void Run()
+        {
+            var response = new HttpClient().GetAsync(Url, HttpCompletionOption.ResponseHeadersRead).Result;
+            response.EnsureSuccessStatusCode();
+
+            StepRun.PublishArtifact(response.Content.ReadAsStreamAsync().Result, FileName);
+            response.Dispose();
+        }
+    }
+}

--- a/Engine/TeeStream.cs
+++ b/Engine/TeeStream.cs
@@ -62,7 +62,7 @@ namespace OpenTap
         }
 
         public long Length => mainStream.Length;
-        public long Position => mainStream.Position - blockLength;
+        public long Position => mainStreamPosition - blockLength;
         public long blockLength;
             
         readonly Stream mainStream;
@@ -89,12 +89,25 @@ namespace OpenTap
             return result;
         }
         bool done;
+        Exception readException = null;
         
         void ReadNextBlock()
         {
             // at this point everyone is waiting for the next block.
+            int len;
+            try
+            {
+                len = mainStream.Read(currentBlock, 0, currentBlock.Length);
+            }
+            catch(Exception exception)
+            {
+                this.readException = exception;
+                len = 0;
+            }
             
-            int len = mainStream.Read(currentBlock, 0, currentBlock.Length);
+            // user interlocked.add to ensure that other threads will get the updated value.
+            Interlocked.Add(ref mainStreamPosition, len);
+            
             if (len == 0)
             {
                 // We are done. let's stop.
@@ -103,25 +116,30 @@ namespace OpenTap
                 mainStream.Dispose();
             }
             blockLength = len;
+            
             var oldEvt = evt;
             var w2 = waiting;
             evt = new SemaphoreSlim(0);
+            Interlocked.Exchange(ref waiting, 0);
             oldEvt.Release(w2);
-            
-            waiting = 0;
         }
         
         SemaphoreSlim evt = new SemaphoreSlim(0);
         int waiting;
         int clientCount;
+        long mainStreamPosition;
         public int Read(byte[] bytes, long subStreamPosition, int bufferOffset, int count)
         {
             if (done) return 0;
+            if (readException != null)
+                throw readException;
             
             // Offset into the current block.
-            long blockOffset = subStreamPosition - (mainStream.Position - blockLength);
+            long blockOffset = subStreamPosition - (mainStreamPosition - blockLength);
             if (blockOffset < 0) 
                 throw new InvalidOperationException("Unexpected position calculated");
+            
+            var waitEvent = evt;
             
             // if the block offset is greater than the size of the block, we need to get/wait for the next block. 
             if (blockOffset >= blockLength)
@@ -134,7 +152,7 @@ namespace OpenTap
                 else
                 {
                     // wait for a new block.
-                    evt.Wait();
+                    waitEvent.Wait();
                 }
                 // new blocks released. start over.
                 return Read(bytes, subStreamPosition, bufferOffset, count);
@@ -143,7 +161,7 @@ namespace OpenTap
             // read the block byte-by-byte.
             for (int i = 0; i < count; i++)
             {
-                long o2 = subStreamPosition - (mainStream.Position - blockLength) + i;
+                long o2 = subStreamPosition - (mainStreamPosition - blockLength) + i;
                 if (o2 >= blockLength)
                 {
                     // End of the block reached.

--- a/Engine/TestPlanRun.cs
+++ b/Engine/TestPlanRun.cs
@@ -30,7 +30,7 @@ namespace OpenTap
     {
         static readonly TraceSource log = Log.CreateSource("TestPlan");
         static readonly TraceSource resultLog = Log.CreateSource("Resources");
-        
+
         TestPlan plan;
         string planXml;
 
@@ -56,7 +56,8 @@ namespace OpenTap
 
         /// <summary> The SHA1 hash of XML of the test plan.</summary>
         //Note: for Hash the group must be Test Plan for backwards-compatibility.
-        public string Hash {
+        public string Hash
+        {
             get => Parameters[nameof(Hash), "Test Plan"]?.ToString();
             private set => Parameters[nameof(Hash), "Test Plan"] = value;
         }
@@ -66,7 +67,7 @@ namespace OpenTap
         [MetaData(macroName: nameof(TestPlanName))]
         public string TestPlanName
         {
-            get => Parameters[nameof(TestPlanName), GROUP].ToString(); 
+            get => Parameters[nameof(TestPlanName), GROUP].ToString();
             private set => Parameters[nameof(TestPlanName), GROUP] = value;
         }
 
@@ -75,10 +76,9 @@ namespace OpenTap
         public bool FailedToStart { get; set; }
 
         /// <summary> The thread that started the test plan. Use this to abort the plan thread. </summary>
-        public TapThread MainThread { get;  }
-        
-        #region Internal Members used by the TestPlan
+        public TapThread MainThread { get; }
 
+        #region Internal Members used by the TestPlan
         internal IEnumerable<IResultListener> ResultListeners => resultWorkers.Keys;
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace OpenTap
                 return;
             resultWorkers.Add(listener, new WorkQueue(WorkQueue.Options.LongRunning | WorkQueue.Options.TimeAveraging, listener.ToString()));
         }
-        
+
         /// <summary>
         /// Removes a result listener from the active result listeners in this run.
         /// Note this can only be done at specific times during test plan execution,
@@ -107,7 +107,7 @@ namespace OpenTap
                 throw new ArgumentNullException(nameof(listener));
             if (ResultListenersSealed)
                 throw new Exception("Test plan is running. ResultListeners cannot be removed at this point");
-            if (!resultWorkers.ContainsKey(listener)) 
+            if (!resultWorkers.ContainsKey(listener))
                 return;
             resultWorkers.Remove(listener);
         }
@@ -120,15 +120,14 @@ namespace OpenTap
         internal IResourceManager ResourceManager { get; private set; }
 
         internal bool IsCompositeRun { get; set; }
-        
+
         /// <summary> Set to true when result listeners cannot be added to the test plan run.</summary>
         internal bool ResultListenersSealed { get; set; }
 
         #region Result propagation dispatcher system
-        
         bool isBusy()
         {
-            foreach(var worker in resultWorkers.Values)
+            foreach (var worker in resultWorkers.Values)
             {
                 if (worker.QueueSize > 0) return true;
             }
@@ -136,7 +135,7 @@ namespace OpenTap
         }
 
         readonly Dictionary<IResultListener, WorkQueue> resultWorkers;
-        
+
         double resultLatencyLimit = EngineSettings.Current.ResultLatencyLimit;
         object workThrottleLock = new object();
         /// <summary> Wait for result queues to become processed if there is too much work in the buffer. The max workload size for any ResultListener is specified by resultLatencyLimit in seconds. </summary>
@@ -171,7 +170,7 @@ namespace OpenTap
                 }
             }
         }
-        
+
         /// <summary>
         /// Waits for result propagation thread to be idle.
         /// </summary>
@@ -187,10 +186,9 @@ namespace OpenTap
         {
             resultWorkers[rl].Wait();
         }
-
         #endregion
 
-        
+
         /// <summary>
         /// List of all TestSteps for which PrePlanRun has already been called.
         /// </summary>
@@ -199,14 +197,14 @@ namespace OpenTap
         private string GetHash(byte[] testPlanXml)
         {
             using (var algo = System.Security.Cryptography.SHA1.Create())
-                return BitConverter.ToString(algo.ComputeHash(testPlanXml),0,8).Replace("-",string.Empty);
+                return BitConverter.ToString(algo.ComputeHash(testPlanXml), 0, 8).Replace("-", string.Empty);
         }
 
         Task serializePlanTask;
-        
+
         internal void AddTestPlanCompleted(HybridStream logStream, bool openCompleted)
         {
-       
+
             void onTestPlanCompleted(IResultListener r)
             {
                 var reslog = ResourceTaskManager.GetLogSource(r);
@@ -236,27 +234,28 @@ namespace OpenTap
                         reslog.Warning("Run Completed was not called for '{0}' as it failed to open.", r);
                 }
             }
-            
+
             ScheduleInResultProcessingThread<IResultListener>(r =>
             {
                 if (r is IArtifactListener) return;
                 onTestPlanCompleted(r);
             }, blocking: true);
-            
-            foreach(var kw in resultWorkers)
+
+            foreach (var kw in resultWorkers)
             {
                 kw.Value.Wait();
             }
-            
+
             ScheduleInResultProcessingThread<IResultListener>(r =>
             {
-                if (r is IArtifactListener) { 
+                if (r is IArtifactListener)
+                {
                     onTestPlanCompleted(r);
                 }
             }, blocking: true);
 
             // now clean up the result listener workers and wait for them to end.
-            foreach(var kw in resultWorkers)
+            foreach (var kw in resultWorkers)
             {
                 kw.Value.Dispose();
             }
@@ -310,12 +309,12 @@ namespace OpenTap
         /// <param name="r"></param>
         /// <param name="blocking"></param>
         /// <returns></returns>
-        int ScheduleInResultProcessingThread<T>(IInvokable<T,WorkQueue> r, bool blocking)
+        int ScheduleInResultProcessingThread<T>(IInvokable<T, WorkQueue> r, bool blocking)
         {
             if (!blocking)
                 return ScheduleInResultProcessingThread(r);
             if (resultWorkers.Count == 0) return 0;
-       
+
             using (var sem = new SemaphoreSlim(0, resultWorkers.Count))
             {
                 int count = ScheduleInResultProcessingThread<T>(l =>
@@ -382,9 +381,9 @@ namespace OpenTap
 
         internal void AddTestStepRunCompleted(TestStepRun stepRun)
         {
-            
+
             var instant = Stopwatch.GetTimestamp();
-            
+
             ScheduleInResultProcessingThread<IResultListener>(listener =>
             {
                 try
@@ -416,7 +415,6 @@ namespace OpenTap
             resultWorkers.Remove(resultListener);
             log.Warning("Removing faulty ResultListener '{0}'", resultListener);
         }
-
         #endregion
 
         /// <summary>
@@ -450,10 +448,10 @@ namespace OpenTap
             public string Hash { get; set; }
             public byte[] Bytes { get; set; }
         }
-        
+
         /// <summary> Memorizer for storing pairs of Xml and hash. </summary>
         static ConditionalWeakTable<TestPlan, StringHashPair> testPlanHashMemory = new ConditionalWeakTable<TestPlan, StringHashPair>();
-        
+
         /// <summary>
         /// Starts tasks to open resources. All referenced instruments and duts as well as supplied resultListeners to the plan.
         /// </summary>
@@ -476,7 +474,7 @@ namespace OpenTap
             {
                 BreakCondition = breakCondition;
             }
-            
+
             this.IsCompositeRun = isCompositeRun;
             Parameters = ResultParameters.GetComponentSettingsMetadata();
             // Add metadata from the plan itself.
@@ -484,7 +482,7 @@ namespace OpenTap
 
             this.Verdict = Verdict.NotSet; // set Parameters before setting Verdict.
 
-            if (resultListeners !=  null)
+            if (resultListeners != null)
             {
                 foreach (var res in resultListeners)
                 {
@@ -506,17 +504,17 @@ namespace OpenTap
 
                 if (plan.GetCachedXml() is byte[] xml)
                 {
-                    
-                    if(!testPlanHashMemory.TryGetValue(this.plan, out var pair))
+
+                    if (!testPlanHashMemory.TryGetValue(this.plan, out var pair))
                     {
                         if (pair == null)
                         {
                             pair = new StringHashPair();
-                            testPlanHashMemory.Add(plan, pair);    
+                            testPlanHashMemory.Add(plan, pair);
                         }
                     }
 
-                    
+
                     if (Equals(pair.Bytes, xml) == false)
                     {
                         pair.Xml = Encoding.UTF8.GetString(xml);
@@ -551,10 +549,10 @@ namespace OpenTap
                     }
                 }
             });
-            
-            
+
+
             TestPlanName = plan.Name;
-            if(plan.Path != null)
+            if (plan.Path != null)
                 Parameters["TestPlanPath", ""] = plan.Path;
             this.plan = plan;
         }
@@ -568,7 +566,7 @@ namespace OpenTap
                     ResourceManager = new ResourceTaskManager();
                 else
                     ResourceManager =
-                        (IResourceManager) EngineSettings.Current.ResourceManagerType.GetType().CreateInstance();
+                        (IResourceManager)EngineSettings.Current.ResourceManagerType.GetType().CreateInstance();
             }
 
             if (planRunStarted)
@@ -576,19 +574,19 @@ namespace OpenTap
 
             // waits for prompt before loading the parameters.
             planRunStarted = true;
-            ResourceManager.ResourceOpened += 
+            ResourceManager.ResourceOpened +=
                 res => Parameters.AddRange(ResultParameters.GetMetadataFromObject(res));
-            
+
         }
 
-        internal TestPlanRun() 
+        internal TestPlanRun()
         {
             MainThread = TapThread.Current;
             FailedToStart = false;
             resultWorkers = new Dictionary<IResultListener, WorkQueue>();
-            
-            {   // AbortCondition
-                
+
+            { // AbortCondition
+
                 var abort2 = EngineSettings.Current.AbortTestPlan;
                 BreakCondition = default;
                 if (abort2.HasFlag(EngineSettings.AbortTestPlanType.Step_Fail))
@@ -608,7 +606,7 @@ namespace OpenTap
 
             this.Parameters = original.Parameters; // set Parameters before setting Verdict.
             this.Verdict = Verdict.NotSet;
-            
+
             foreach (var res in ResultListeners)
             {
                 AddResultListener(res);
@@ -644,28 +642,32 @@ namespace OpenTap
 
         static readonly TraceSource artifactsLog = Log.CreateSource("Artifacts");
 
-        internal void PublishArtifactWithRun(string file, TestRun run)
+        internal Task PublishArtifactWithRunAsync(string file, TestRun run)
         {
-            PublishArtifactWithRun(new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Write | FileShare.Delete), Path.GetFileName(file), run);
+            return PublishArtifactWithRunAsync(new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Write | FileShare.Delete), Path.GetFileName(file), run);
         }
-        
-        internal void PublishArtifactWithRun(Stream s, string filename, TestRun run)
+
+        internal Task PublishArtifactWithRunAsync(Stream inStream, string filename, TestRun run)
         {
             // multiple threads might be publishing artifacts at the same time, so this add needs to be done safely.
             Utils.InterlockedSwap(ref artifacts, () => artifacts.Add(filename));
-           
+
             var streamGetters = new BlockingCollection<Stream>();
-            
+
             int readerRefCount = 0;
-            TeeStream tee = s is FileStream ? null : new TeeStream(s);
+            TeeStream tee = inStream is FileStream ? null : new TeeStream(inStream);
             ManualResetEventSlim go = new ManualResetEventSlim(false);
+            
+            // The result type does not matter.
+            TaskCompletionSource<bool> finishedSignal = new TaskCompletionSource<bool>();
+            
             readerRefCount = ScheduleInResultProcessingThread<IArtifactListener>(l =>
             {
                 go.Wait();
                 Stream s2;
-                if (s is FileStream fileStream)
+                if (inStream is FileStream fileStream)
                 {
-                    s2 = new FileStream(fileStream.Name, FileMode.Open, FileAccess.Read, FileShare.Read |FileShare.Write | FileShare.Delete);   
+                    s2 = new FileStream(fileStream.Name, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Write | FileShare.Delete);
                 }
                 else
                 {
@@ -687,8 +689,12 @@ namespace OpenTap
                 finally
                 {
                     Interlocked.Decrement(ref readerRefCount);
-                    if(readerRefCount == 0)
-                        s.Dispose();
+                    if (readerRefCount == 0)
+                    {
+                        inStream.Dispose();
+                        finishedSignal.SetResult(true);
+                    }
+
                 }
             });
             if (tee != null)
@@ -701,22 +707,30 @@ namespace OpenTap
             }
             if (readerRefCount == 0)
             {
-                s.Dispose();
+                inStream.Dispose();
+                return Task.FromResult(0);
             }
-            else
-            {
-                go.Set();
-            }
+            
+            go.Set();
+            return finishedSignal.Task;
         }
-        
+
         /// <summary> Publishes an artifact for the test plan run. </summary>
         /// <param name="stream"> The artifact data as a stream. When publishing an artifact stream, the stream will be disposed by the callee and does not have to be disposed by the caller.</param>
         /// <param name="artifactName"> The name of the published artifact. </param>
-        public void PublishArtifact(Stream stream, string artifactName) => PublishArtifactWithRun(stream, artifactName, this);
+        public void PublishArtifact(Stream stream, string artifactName) => PublishArtifactWithRunAsync(stream, artifactName, this).Wait();
         
-        /// <summary> Publishes an artifact for the test plan run. </summary>
-        public void PublishArtifact(string file) => PublishArtifactWithRun(file, this);
+        /// <summary> Publishes an artifact for the test plan run asynchronously. </summary>
+        /// <param name="stream"> The artifact data as a stream. When publishing an artifact stream, the stream will be disposed by the callee and does not have to be disposed by the caller.</param>
+        /// <param name="artifactName"> The name of the published artifact. </param>
+        public Task PublishArtifactAsync(Stream stream, string artifactName) => PublishArtifactWithRunAsync(stream, artifactName, this);
 
+        /// <summary> Publishes an artifact for the test plan run. </summary>
+        public void PublishArtifact(string file) => PublishArtifactWithRunAsync(file, this).Wait();
+
+        /// <summary> Publishes an artifact for the test plan run asynchronously. </summary>
+        public Task PublishArtifactAsync(string file) => PublishArtifactWithRunAsync(file, this);
+        
         /// <summary> Returns a list of all published artifacts. This list will get updated as the test plan progresses.</summary>
         public IEnumerable<string> Artifacts => artifacts;
         ImmutableHashSet<string> artifacts = ImmutableHashSet<string>.Empty;

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Xml.Serialization;
 
 namespace OpenTap
@@ -525,10 +526,20 @@ namespace OpenTap
         /// <param name="stream"> The artifact data as a stream. When publishing an artifact stream, the stream will be disposed by the callee and does not have to be disposed by the caller.</param>
         /// <param name="artifactName"> The name of the published artifact. </param>
         public void PublishArtifact(Stream stream, string artifactName) 
-            => testPlanRun.PublishArtifactWithRun(stream, artifactName, this);
+            => testPlanRun.PublishArtifactWithRunAsync(stream, artifactName, this).Wait();
+        
+        /// <summary> Publishes an artifact for the test plan run. </summary>
+        /// <param name="stream"> The artifact data as a stream. When publishing an artifact stream, the stream will be disposed by the callee and does not have to be disposed by the caller.</param>
+        /// <param name="artifactName"> The name of the published artifact. </param>
+        public Task PublishArtifactAsync(Stream stream, string artifactName) 
+            => testPlanRun.PublishArtifactWithRunAsync(stream, artifactName, this);
+
         
         /// <summary> Publishes an artifact file for the test plan run. </summary>
-        public void PublishArtifact(string file) => testPlanRun.PublishArtifactWithRun(file, this); 
+        public void PublishArtifact(string file) => testPlanRun.PublishArtifactWithRunAsync(file, this).Wait(); 
+        
+        /// <summary> Publishes an artifact file for the test plan run. </summary>
+        public Task PublishArtifactAsync(string file) => testPlanRun.PublishArtifactWithRunAsync(file, this);
     }
 
     class TestStepBreakException : OperationCanceledException

--- a/sdk/Examples/PluginDevelopment/ResultListeners/ZipArtifactsResultListener.cs
+++ b/sdk/Examples/PluginDevelopment/ResultListeners/ZipArtifactsResultListener.cs
@@ -107,7 +107,8 @@ namespace OpenTap.Plugins.PluginDevelopment
             this.Log.Debug("Wrote file: {0}", Path.GetFullPath(finalName));
 
             // finally publish the artifact.
-            planRun.PublishArtifact(File.OpenRead(finalName), Path.GetFileName(finalName));
+            // This must be done asynchronously as we are currently inside a result processing thread.
+            planRun.PublishArtifactAsync(File.OpenRead(finalName), Path.GetFileName(finalName));
         }
 
         // this map is used to keep track of the parent-child association between step runs and plan runs.


### PR DESCRIPTION
* 1313 Artifact Position Bug: Fix

- Removed the use of position from teeStream since this is not always supported.
- Publish artifact is blocking unless the Async versions gets used.
- ArtifactZipper now needs use the async call. Otherwise a deadlock occurs.
- Added HttpArtifactStep as a test

* Improved publish async with TaskCompletionSource.

* Use Interlocked.Add to avoid dataraces with the local data from TeeStream.

* Fixed race condition in TeeStream.