### PR TITLE
1322 Missing Enabled Rule For TestPlan Context

### DIFF
--- a/Engine/MixinMenuModel.cs
+++ b/Engine/MixinMenuModel.cs
@@ -10,7 +10,7 @@ namespace OpenTap
         {
             get
             {
-                var plan2 = source.OfType<ITestStep>()
+                var plan2 = source.OfType<ITestStepParent>()
                     .Select(step => step is TestPlan plan ? plan : step.GetParent<TestPlan>()).FirstOrDefault();
                 return (plan2?.IsRunning ?? false) || (plan2?.Locked ?? false);
             }


### PR DESCRIPTION
AddMixin never got disabled for the test plan because the code did not support it directly on the test plan.

Also added a unit test which verifies that the enabled/disabled rule works for AddMixin in general.

Note, there was also another part to issue #1322, but that was fixed in KS8400 itself.

Close #1322
