### PR TITLE
1329 Modify Mixin Not Working Fix

### DIFF
--- a/Engine.UnitTests/MixinTests.cs
+++ b/Engine.UnitTests/MixinTests.cs
@@ -307,6 +307,27 @@ namespace OpenTap.UnitTests
             Assert.IsFalse(isDisabled2);
 
         }
+
+
+        [Test]
+        public void CannotModifyMixinTest()
+        {
+
+            var plan1 = new TestPlan();
+            var step1 = new DelayStep();
+            plan1.ChildTestSteps.Add(step1);
+            MixinFactory.LoadMixin(step1, new MixinTestBuilder()
+            {
+                TestMember = nameof(step1.DelaySecs)
+            });
+
+            var memberAnnotation = AnnotationCollection.Annotate(step1).GetMember("TestMixin.MixinLoadValue");
+            var menuItems = memberAnnotation.Get<MenuAnnotation>().MenuItems.ToArray();
+            var menuModel = menuItems.Select(x => x.Source).OfType<MixinMemberMenuModel>().First() as IMemberMenuModel;
+            Assert.IsNotNull(menuModel.Member);
+
+        }
+
     }
 
     public class MixinTest : IMixin, ITestStepPostRunMixin, ITestStepPreRunMixin, IAssignOutputMixin

--- a/Engine/MixinMemberMenuModel.cs
+++ b/Engine/MixinMemberMenuModel.cs
@@ -13,7 +13,7 @@ namespace OpenTap
 
         public object[] Source { get; set; }
 
-        IMemberData IMemberMenuModel.Member { get; }
+        IMemberData IMemberMenuModel.Member => member;
         
         public bool TestPlanLocked
         {


### PR DESCRIPTION
This is hard to reproduce without installing the Expressions package.

The expressions wants to hide modify mixin if an expression is already assigned to that member. To do this, it has to get the member of the mixin member in the menu model. In this case the member was null, which meant that the expressions plugin just checked if any property of the step had an expression rather than the specific property.

Close #1329 