### PR TITLE
1349 plugin type selector mixin

### DIFF
--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -1209,6 +1209,17 @@ namespace OpenTap
             this.AvailableMember = annotation;
         }
     }
+    
+    /// <summary>
+    /// This is interface is used for generating something from a string.
+    /// Currently it is used only for PluginTypeSelectorAttribute
+    /// </summary>
+    interface IAnnotationStringer : IAnnotation
+    {
+        /// <summary> Gets the string value of an object.  </summary>
+        string GetString(AnnotationCollection item);
+    }
+
 
     /// <summary> The default data annotator plugin. This normally forms the basis for annotation. </summary>
     public class DefaultDataAnnotator : IAnnotator
@@ -2556,8 +2567,15 @@ namespace OpenTap
             }
         }
 
-        class PluginTypeSelectAnnotation : IAvailableValuesAnnotation
+  
+        class PluginTypeSelectAnnotation : IAvailableValuesAnnotation, IAnnotationStringer
         {
+            /// <summary> This is used for generating strings for available and selected values. </summary>
+            public string GetString(AnnotationCollection item)
+            {
+                return item.Get<IDisplayAnnotation>()?.Name;
+            }
+            
             IEnumerable<object> selection;
             public IEnumerable AvailableValues {
                 get
@@ -2575,24 +2593,38 @@ namespace OpenTap
                     {
                         var currentType = TypeData.GetTypeData(currentValue);
                         List<object> selection = new List<object>();
-                        foreach (var type in PluginManager.GetPlugins(cst.Type))
+                        
+                        if (attrib.ObjectSourceProperty != null)
                         {
-                            try
+                            // if there is a source property, look for that. 
+                            var obj = annotation.ParentAnnotation.Source;
+                            var mem = TypeData.GetTypeData(obj).GetMember(attrib.ObjectSourceProperty);
+                            var src = mem.GetValue(obj) as IEnumerable;
+                            foreach (var item in src)
+                                selection.Add(item);
+                        }
+                        else
+                        {
+                            // there is no objects source, so just generate them from the plugins.
+                            foreach (var type in PluginManager.GetPlugins(cst.Type))
                             {
-                                var cstt = TypeData.FromType(type);
-                                if (cstt == currentType)
+                                try
                                 {
-                                    selection.Add(currentValue);
+                                    var cstt = TypeData.FromType(type);
+                                    if (cstt == currentType)
+                                    {
+                                        selection.Add(currentValue);
+                                    }
+                                    else
+                                    {
+                                        var obj = Activator.CreateInstance(type);
+                                        selection.Add(obj);
+                                    }
                                 }
-                                else
+                                catch
                                 {
-                                    var obj = Activator.CreateInstance(type);
-                                    selection.Add(obj);
-                                }
-                            }
-                            catch
-                            {
 
+                                }
                             }
                         }
                         this.selection = selection;
@@ -2985,6 +3017,7 @@ namespace OpenTap
             {
                 get
                 {
+                    var stringer = (a.Get<IAnnotationStringer>());
                     IEnumerable values;
                     if (annotations != null)
                     {
@@ -3051,6 +3084,12 @@ namespace OpenTap
                         {
                             var da2 = a.AnnotateSub(TypeData.GetTypeData(obj), obj, readOnly,
                                 new AvailableMemberAnnotation(a));
+                            
+                            // the annotation stringer is just used for PluginTypeSelector
+                            var annotationStringer = a.Get<IAnnotationStringer>();
+                            if (annotationStringer != null)
+                                da2.Add(new ConstStringAnnotation(annotationStringer.GetString(da2)));
+                            
                             lst.Add(da2);
                         }
                     }
@@ -3060,6 +3099,14 @@ namespace OpenTap
                     return annotations;
                 }
             }
+
+            /// <summary>  This is just a constant string shown in the UI. </summary>
+            class ConstStringAnnotation : IStringReadOnlyValueAnnotation
+            {
+                public ConstStringAnnotation(string str) => Value = str;
+                public string Value { get; }
+            }
+            
             public AnnotationCollection SelectedValue
             {
                 get
@@ -3080,7 +3127,14 @@ namespace OpenTap
                         }
                     }
 
-                    return a.AnnotateSub(TypeData.GetTypeData(current), current, new ReadOnlyMemberAnnotation(), new AvailableMemberAnnotation(a));
+                    var a3 = a.AnnotateSub(TypeData.GetTypeData(current), current, new ReadOnlyMemberAnnotation(), new AvailableMemberAnnotation(a));
+
+                    {   // the annotation stringer is just used for PluginTypeSelector
+                        var stringer = a.Get<IAnnotationStringer>();
+                        if (stringer != null) a3.Add(new ConstStringAnnotation(stringer.GetString(a3)));
+                    }
+
+                    return a3;
                 }
                 set
                 {

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -3017,7 +3017,6 @@ namespace OpenTap
             {
                 get
                 {
-                    var stringer = (a.Get<IAnnotationStringer>());
                     IEnumerable values;
                     if (annotations != null)
                     {

--- a/Engine/Mixins/MixinBuilderUi.cs
+++ b/Engine/Mixins/MixinBuilderUi.cs
@@ -7,43 +7,15 @@ namespace OpenTap
     
     internal class MixinBuilderUi : ValidatingObject, IDisplayAnnotation
     {
-        public class TypeDescriber : IDisplayAnnotation
-        {
-            public override string ToString() => Name;
-            public string Description { get; }
-            public string[] Group { get; }
-            public string Name { get; }
-            public double Order { get; }
-            public bool Collapsed
-            {
-                get;
-            }
-            public TypeDescriber(ITypeData type)
-            {
-                var display = type.GetDisplayAttribute();
-                Name = display.Name;
-                Description = display.Description;
-                Group = display.Group;
-                Order = display.Order;
-                Collapsed = display.Collapsed;
-            }
-        }
         
-        TypeDescriber selectedType;
         public IMixinBuilder[] Items { get; }
-        public TypeDescriber[] ItemTypes { get; }
 
-        [AvailableValues(nameof(ItemTypes))]
+        [PluginTypeSelector(ObjectSourceProperty = nameof(Items))]
         [Display("Mixin", Order: -10001)]
-        public TypeDescriber SelectedType
+        public IMixinBuilder SelectedType
         {
-            get => selectedType;
-            set
-            {
-                selectedType = value;
-                var idx = Array.IndexOf(ItemTypes, value);
-                SelectedItem = Items[idx];
-            }
+            get => SelectedItem;
+            set => SelectedItem = value;
         }
 
         public IMixinBuilder SelectedItem { get; private set; }
@@ -56,11 +28,11 @@ namespace OpenTap
         public MixinBuilderUi(IMixinBuilder[] items, IMixinBuilder selected = null)
         {
             Items = items;
-            ItemTypes = items.Select(x => new TypeDescriber(TypeData.GetTypeData(x))).ToArray();
-            SelectedType = ItemTypes.First();
-            if (selected != null)
-                SelectedType = ItemTypes[Array.IndexOf(items, selected)];
-            
+            SelectedItem = selected;
+            if (SelectedItem == null)
+            {
+                SelectedItem = Items.FirstOrDefault();
+            }
             
             { // redirect validation rules.
                 foreach (var mixinBuilder in items)

--- a/Engine/PluginTypeSelector.cs
+++ b/Engine/PluginTypeSelector.cs
@@ -3,10 +3,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OpenTap
 {
@@ -16,5 +12,9 @@ namespace OpenTap
     [AttributeUsage(AttributeTargets.Property)]
     public class PluginTypeSelectorAttribute : Attribute
     {
+        /// <summary>
+        /// Where to get the available objects. This may be null in this case any derived type will be used.
+        /// </summary>
+        public string ObjectSourceProperty { get; set; }
     }
 }


### PR DESCRIPTION
Close #1349 

This PR also includes the changes from #1335

## Testing
1. Verify that Engine Settings / Resource Strategy behave like in the previous version.
2. Mixins (select type, edit, add, remove) behave like before with regards to naming and functionality. 

