### PR TITLE
Remove Package step from workflow

### DIFF
--- a/doc/Developer Guide/Continuous Integration/Readme.md
+++ b/doc/Developer Guide/Continuous Integration/Readme.md
@@ -151,10 +151,6 @@ jobs:
       # Build your project
       - name: Build
         run: dotnet build -c Release
-      # Create the tap package
-      - name: Package
-        working-directory: bin/Release
-        run: ./tap package create package.xml
       # Upload the package so it can be downloaded from GitHub, 
       # and consumed by other steps in this workflow
       - name: Upload binaries


### PR DESCRIPTION
This step is not needed anymore because the package is already created during the Build process.

At least if next is added in the VS project file (which by default is if I'm correct):
```
<PropertyGroup Condition="'$(Configuration)' == 'Release'">
    <CreateOpenTapPackage>true</CreateOpenTapPackage>
</PropertyGroup>
```