### PR TITLE
Count actual number of commits since version change

### DIFF
--- a/Package.UnitTests/GitHelperTests.cs
+++ b/Package.UnitTests/GitHelperTests.cs
@@ -173,7 +173,7 @@ namespace OpenTap.Package.UnitTests
             // |/
             // *     (tag: v2.0, release2x) Bumped version to 2.0
             new GitVersionAction() { PrintLog = "10", RepoPath = repo.Info.WorkingDirectory }.Execute(new System.Threading.CancellationToken());
-            verifyVersion(repo, 2, 1, 0, "rc.3");
+            verifyVersion(repo, 2, 1, 0, "rc.2");
 
             // Now we will try to go back to a previous commit (not the HEAD):
             // This is what GitLab CI does, so important for us to support

--- a/Package.UnitTests/GitHelperTests.cs
+++ b/Package.UnitTests/GitHelperTests.cs
@@ -103,7 +103,7 @@ namespace OpenTap.Package.UnitTests
             Commands.Checkout(repo, "master");
             repo.Merge(featureBranch, me, noFastForward);
 
-            verifyVersion(repo, 1, 0, 0, "beta.2");
+            verifyVersion(repo, 1, 0, 0, "beta.3");
 
             commitChangesToReadme(repo, "Version 2", "Bumped version to 2.0");
             commitChangesToGitVersionFile(repo, "2.0.0", "Updated version to 2.0.0 in .gitversion file");
@@ -134,7 +134,7 @@ namespace OpenTap.Package.UnitTests
             verifyVersion(repo, 2, 1, 0, "alpha.1.1", featureBranch.FriendlyName);
             Commands.Checkout(repo, "master");
             repo.Merge(featureBranch, me, noFastForward);
-            verifyVersion(repo, 2, 1, 0, "beta.2");
+            verifyVersion(repo, 2, 1, 0, "beta.3");
             Commands.Checkout(repo, "release2x");
             repo.Merge("master", me, noFastForward);
 
@@ -173,13 +173,13 @@ namespace OpenTap.Package.UnitTests
             // |/
             // *     (tag: v2.0, release2x) Bumped version to 2.0
             new GitVersionAction() { PrintLog = "10", RepoPath = repo.Info.WorkingDirectory }.Execute(new System.Threading.CancellationToken());
-            verifyVersion(repo, 2, 1, 0, "rc.2");
+            verifyVersion(repo, 2, 1, 0, "rc.3");
 
             // Now we will try to go back to a previous commit (not the HEAD):
             // This is what GitLab CI does, so important for us to support
 
             //Commands.Checkout(repo, shortHash211alpha);
-            //verifyVersion(2, 1, 0, "alpha.1.1", shortHash211alpha + ".hotfix");   // TODO: This fails and we should try to improve. See TODO in GitVersionCalulator 
+            //verifyVersion(2, 1, 0, "alpha.1.1", shortHash211alpha + ".hotfix");   // TODO: This fails and we should try to improve. See TODO in GitVersionCalculator 
 
             Commands.Checkout(repo, commit210rc);
             verifyVersion(repo,commit210rc, 2, 1, 0, "rc.1");

--- a/Package/CreatePackage/GitVersionCalculator.cs
+++ b/Package/CreatePackage/GitVersionCalculator.cs
@@ -359,14 +359,14 @@ namespace OpenTap.Package
             {
                 Commit cfgCommit = getLatestConfigVersionChange(targetCommit);
                 Commit commonAncestor = findFirstCommonAncestor(defaultBranch, targetCommit);
-                int commitsFromDefaultBranch = countCommitsBetween(commonAncestor, targetCommit, true);
+                int commitsFromDefaultBranch = countCommitsBetween(commonAncestor, targetCommit, false);
                 log.Debug("Found {0} commits since branchout from beta branch in commit {1}.", commitsFromDefaultBranch, commonAncestor.Sha.Substring(0, 8));
-                int commitsSinceVersionUpdate = countCommitsBetween(cfgCommit, targetCommit, true)+1;
+                int commitsSinceVersionUpdate = countCommitsBetween(cfgCommit, targetCommit, false) + 1;
                 log.Debug("Found {0} commits since last version bump in commit {1}.", commitsSinceVersionUpdate, cfgCommit.Sha.Substring(0, 8));
                 int alphaVersion = Math.Min(commitsFromDefaultBranch, commitsSinceVersionUpdate);
                 if (!preRelease.StartsWith("rc", true, CultureInfo.InvariantCulture))
                 {
-                    int betaVersion = countCommitsBetween(cfgCommit, commonAncestor, true) + 1;
+                    int betaVersion = countCommitsBetween(cfgCommit, commonAncestor, false) + 1;
                     if (betaVersion > 0)
                     {
                         preRelease += "." + betaVersion;

--- a/Package/CreatePackage/GitVersionCalculator.cs
+++ b/Package/CreatePackage/GitVersionCalculator.cs
@@ -357,14 +357,22 @@ namespace OpenTap.Package
             }
             if (!String.IsNullOrEmpty(preRelease))
             {
+                // The version calculation is slightly different for RC versions
+                // For an RC, we want to count merge commits as a single commit
+                // For other branches, we want to count the literal number of commits
+                // Historically, we have counted merge commits as single commits for all branches,
+                // but this causes issues in scenarios where merge commits are fast-forwarded onto e.g. the main branch.
+                // See here: https://github.com/opentap/opentap/pull/1384
+                // And here: https://github.com/opentap/opentap/issues/1321#issuecomment-1895749385
+                bool isRc = preRelease.StartsWith("rc", StringComparison.InvariantCultureIgnoreCase);
                 Commit cfgCommit = getLatestConfigVersionChange(targetCommit);
                 Commit commonAncestor = findFirstCommonAncestor(defaultBranch, targetCommit);
-                int commitsFromDefaultBranch = countCommitsBetween(commonAncestor, targetCommit, false);
+                int commitsFromDefaultBranch = countCommitsBetween(commonAncestor, targetCommit, firstParentOnly: isRc);
                 log.Debug("Found {0} commits since branchout from beta branch in commit {1}.", commitsFromDefaultBranch, commonAncestor.Sha.Substring(0, 8));
-                int commitsSinceVersionUpdate = countCommitsBetween(cfgCommit, targetCommit, false) + 1;
+                int commitsSinceVersionUpdate = countCommitsBetween(cfgCommit, targetCommit, firstParentOnly: isRc) + 1;
                 log.Debug("Found {0} commits since last version bump in commit {1}.", commitsSinceVersionUpdate, cfgCommit.Sha.Substring(0, 8));
                 int alphaVersion = Math.Min(commitsFromDefaultBranch, commitsSinceVersionUpdate);
-                if (!preRelease.StartsWith("rc", true, CultureInfo.InvariantCulture))
+                if (isRc == false)
                 {
                     int betaVersion = countCommitsBetween(cfgCommit, commonAncestor, false) + 1;
                     if (betaVersion > 0)


### PR DESCRIPTION
This solves an issue where the version number of a branch can be reset in some circumstances after a merge. This can happen in the following scenario:

1. A feature branch is created branching off from the current main branch
2. Some some commits are added to main
3. Some commits are added to feature branch
4. main is merged into the feature branch with a merge commit (`git merge --no-ff`)
5. The feature branch is fast-forwarded into main (`git merge --ff-only`)

Because the merge commit from merging main into the feature branch was fast forwarded back onto main without creating a new merge commit, the gitversion calculation would now skip all commits from between that merge commit, and the first parent of that merge commit. This would cause the prerelease counter to potentially rewind.

Instead, with this commit, we count the actual number of commits. This has a couple of side effects. For example, when a feature branch is merged into main with a merge commit, the prerelease counter of the main branch will increment once for each commit that was merged, and once for the merge commit. Previously, the prerelease counter would have only incremented once.

There is no way for us to detect if a problematic merge commit was fast forwarded onto main because a merge commit only contains the following information:
1. The head of the branch being merged
2. The head of the branch being merged into

In other words, there is no way to know what branches are actually being merged. Only what the head of each branch was when the merge commit was created.

This is a bit unfortunate, but unavoidable. But at least the prerelease counter is now guaranteed to be monotonically increasing, except when force pushing to a detached head.

See the changes I made to the unit tests for more details about the expected behavior change

Closes #1321 