### PR TITLE
1330 install Editor X instead of Editor CE

### DIFF
--- a/sdk/Examples/Directory.Build.props
+++ b/sdk/Examples/Directory.Build.props
@@ -34,7 +34,7 @@
 	</PropertyGroup>
 	
 	<PropertyGroup>
-		<DevelopersSystem Condition="'$(Configuration)' == 'Debug CE'">Developer's System CE</DevelopersSystem>
+		<DevelopersSystem Condition="'$(Configuration)' == 'Debug CE'">Editor X</DevelopersSystem>
 		<DevelopersSystem Condition="'$(Configuration)' != 'Debug CE'">Developer's System</DevelopersSystem>
 	</PropertyGroup>
 


### PR DESCRIPTION
Editor CE is discontinued. Editor X is actively maintained and has support for community licensing and should be preferred.

Closes #1330 