### PR TITLE
Update README.md to state VS 2022 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For a guide on how to develop using OpenTAP, check out our __[Developer Guide](h
 Most users build plugins for OpenTAP but if you are interested in building OpenTAP yourself you can clone the git repository at https://github.com/opentap/opentap and build the OpenTAP.sln solution file.
 
 ### Microsoft Windows 10
-On Windows, Visual Studio 2017 or greater is needed to build. This can be done by opening the solution and pressing F5, or Ctrl-Shift-B.
+On Windows, Visual Studio 2022 or greater is needed to build. This can be done by opening the solution and pressing F5, or Ctrl-Shift-B.
 
 ### Linux
 On Linux you need [Microsoft .NET SDK 6.0](https://dotnet.microsoft.com/download) to build OpenTAP.
@@ -59,7 +59,7 @@ OpenTAP can be tested using NUnit.
 
 ### Windows
 
-Using Visual Studio 2017, open OpenTAP.sln and run the tests in the TestExplorer.
+Using Visual Studio 2022, open OpenTAP.sln and run the tests in the TestExplorer.
 
 ### Linux
 

--- a/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
+++ b/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
@@ -6,7 +6,7 @@ To make it easier to develop plugins we created two options you can choose from 
 
 - Using the OpenTAP NuGet Package - This is the recommended way to get OpenTAP if you are developing plugin projects. The NuGet package is available on [nuget.org](https://www.nuget.org/packages/OpenTAP/).
 - Using the OpenTAP SDK Package - This provides templates for many types of common OpenTAP plugins and can be used via:
-  - The **OpenTAP Visual Studio Integration** - This allows you to use Visual Studio to create your plugins. You need Visual Studio 2017 or newer. If you are using the KS8400A PathWave Test Automation Developer's System, this is already included. Otherwise, it can be downloaded from the the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=OpenTAP.opentapsdkce).
+  - The **OpenTAP Visual Studio Integration** - This allows you to use Visual Studio to create your plugins. You need Visual Studio 2022 or newer. If you are using the KS8400A PathWave Test Automation Developer's System, this is already included. Otherwise, it can be downloaded from the the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=OpenTAP.opentapsdkce).
   - The **Command Line** - This allows you to create project code templates from the command line. You can learn how in [The OpenTAP SDK Templates](#opentap-sdk-templates) section.
 
 ## NuGet Package


### PR DESCRIPTION
We no longer support building on VS 2017 since sinde 2022 is required for building .net 6 projects.

Close #1346