### PR TITLE
1375 fix stray tap file bricking install

### DIFF
--- a/Cli/TapEntry.cs
+++ b/Cli/TapEntry.cs
@@ -84,8 +84,9 @@ namespace OpenTap.Cli
 
             string arguments = new CommandLineSplit(Environment.CommandLine).Args;
             string message = null;
-            
-            using (ExecutorSubProcess subproc = ExecutorSubProcess.Create(Path.Combine(ExecutorClient.ExeDir, "tap"), arguments))
+
+            string tapCommand = OperatingSystem.Current == OperatingSystem.Windows ? "tap.exe" : "tap";
+            using (ExecutorSubProcess subproc = ExecutorSubProcess.Create(Path.Combine(ExecutorClient.ExeDir, tapCommand), arguments))
             {
                 subproc.MessageReceived += (s, msg) =>
                 {


### PR DESCRIPTION
This fixes an issue which causes `tap package install` to break on Windows if a file named `tap` is placed in the installation directory.

Closes #1375 