### PR TITLE
1400 fix multiple test plan reference giving duplicate warnings

### DIFF
--- a/Engine/SerializerPlugins/TestStepSerializer.cs
+++ b/Engine/SerializerPlugins/TestStepSerializer.cs
@@ -56,10 +56,19 @@ namespace OpenTap.Plugins
         {
             if (stepLookup.TryGetValue(step.Id, out ITestStep currentStep) && currentStep != step && !ignoredGuids.Contains(step.Id))
             {
+                ITestStepParent getTestPlanReferenceParent(ITestStep s) =>
+                    s.GetParents().FirstOrDefault(p => p.GetType().Name == "TestPlanReference");
+
                 step.Id = Guid.NewGuid();
                 if (step is IDynamicStep)
                 {   // if newStep is an IDynamicStep, we just print in debug.
                     Log.Debug("Duplicate test step ID found in dynamic step. The duplicate ID has been changed for step '{0}'.", step.Name);
+                }
+                else if (getTestPlanReferenceParent(step) is { } p1 &&
+                         getTestPlanReferenceParent(currentStep) is { } p2 &&
+                         p1 != p2)
+                { // If the steps are from two different test plan references, print in debug
+                    Log.Debug("Duplicate test step ID found in test plan reference step. The duplicate ID has been changed for step '{0}'.", step.Name);
                 }
                 else
                 {


### PR DESCRIPTION
This demotes warnings about duplicate step ids if the offending steps are from two different TestPlanReference steps.

Closes #1400 