### PR TITLE
1159 relax constraints when installing bundles

### DIFF
--- a/Engine/ThreadManager.cs
+++ b/Engine/ThreadManager.cs
@@ -693,10 +693,7 @@ namespace OpenTap
         }
 
         private static TraceSource _log;
-        private static TraceSource log
-        {
-            get => (_log ?? (_log = Log.CreateSource("thread")));
-        }
+        private static TraceSource log => _log ??= Log.CreateSource("thread");
 
         /// <summary> Disposes the ThreadManager. This can optionally be done at program exit.</summary>
         public void Dispose()

--- a/Package/Image/ImageSpecifier.cs
+++ b/Package/Image/ImageSpecifier.cs
@@ -113,6 +113,15 @@ namespace OpenTap.Package
             cache.AddPackages(InstalledPackages);
             cache.AddPackages(AdditionalPackages);
             var sw = Stopwatch.StartNew();
+
+            var packageNames = this.Packages.Select(p => p.Name).ToArray();
+            foreach (var pn in packageNames)
+            {
+                foreach (var bundlePackage in cache.Graph.GetBundlePackages(pn))
+                {
+                    this.Packages.RemoveAll(p => p.Name == bundlePackage);
+                }
+            }
             
             var resolver = new ImageResolver(cancellationToken);
             

--- a/Package/Image/PackageDependencyQuery.cs
+++ b/Package/Image/PackageDependencyQuery.cs
@@ -39,7 +39,7 @@ namespace OpenTap.Package
             var parameters = HttpPackageRepository.GetQueryParameters(version: VersionSpecifier.TryParse(preRelease, out var spec) ? spec : VersionSpecifier.AnyRelease, os: os,
                 architecture: deploymentInstallationArchitecture, name: name);
             
-            var result = repoClient.Query(parameters, CancellationToken.None, "name", "version",
+            var result = repoClient.Query(parameters, CancellationToken.None, "name", "version", "class",
                 new QuerySelection("dependencies", new List<QuerySelection>() { "name", "version" }));
             var graph = new PackageDependencyGraph();
             graph.LoadFromDictionaries(result);


### PR DESCRIPTION
I think this is the right approach, but there are still a couple of issues:

1. If a bundle is installed like "tap image install 'DMM:2.1.2,DMM API:2.1.3'", the DMM API request is ignored. The image should fail to resolve, but will instead resolve to something the user did not ask for
2. If a bundle has a dependency on OpenTAP, the current OpenTAP installation might be downgraded, even if `--merge` is specified
3. If a new bundle member is added, downgrading to an older version will uninstall the new bundle member

These are a couple of strange behaviors I can think of off the top of my head. We should resolve these issues before merging this

Closes #1159