### PR TITLE
1411 Parameterization Breaks After PluginManager search: Fix

### DIFF
--- a/Engine.UnitTests/ExternalTestPlanParameterTest.cs
+++ b/Engine.UnitTests/ExternalTestPlanParameterTest.cs
@@ -494,5 +494,24 @@ namespace OpenTap.Engine.UnitTests
                 Assert.AreEqual(access.IsVisible, stepModel.Length == 1);
             }            
         }
+        
+        [Test]
+        public void ExternalParametersPlusReloadPlugins()
+        {
+            var plan = new TestPlan();
+            var delay = new DelayStep();
+            plan.ChildTestSteps.Add(delay);
+            
+            var preMember = TypeData.GetTypeData(delay).GetMember(nameof(DelayStep.DelaySecs))
+                .Parameterize(plan, delay, nameof(DelayStep.DelaySecs));
+            
+            var xmlPreSearch = plan.SerializeToString();
+            
+            // searching for plugins should not affect serialization.
+            PluginManager.Search();
+            var xmlPostSearch = plan.SerializeToString();
+            
+            Assert.AreEqual(xmlPreSearch, xmlPostSearch);
+        }
     }
 }

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -467,6 +467,7 @@ namespace OpenTap
             if (member == null) throw new ArgumentNullException(nameof(member));
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (name == null) throw new ArgumentNullException(nameof(name));
+            if (source == target) throw new InvalidOperationException("Source and target cannot be the same object.");
             if (name.Length == 0) throw new ArgumentException("Cannot be an empty string.", nameof(name));
             { // Verify that the member belongs to the type.   
                 var sourceType = TypeData.GetTypeData(source);

--- a/Engine/Reflection/DotNetTypeData.cs
+++ b/Engine/Reflection/DotNetTypeData.cs
@@ -184,5 +184,16 @@ namespace OpenTap
 
         /// <summary> Gets a string representation of this CSharpType. </summary>
         public override string ToString() => $"[{Name}]";
+
+        /// <summary> Equality for MemberData. Returns true if the other object is a MemberData and refers to same member object. </summary>
+        public override bool Equals(object obj)
+        {
+            if (obj is MemberData m && m.Member == Member)
+                return true;
+            return false;
+        }
+        /// <summary> GetHash for MemberData. </summary>
+        public override int GetHashCode() => Member.GetHashCode() * 32143211 + 88776366;
+        
     }
 }


### PR DESCRIPTION
Fixed the issue by implementing Equality for MemberData. This is required for a lookup table inside the ExternalParameterSerializer. Otherwise when serialization is done it will not recognize the new MemberData instance as the same one as in the parameter.

Added a unit test to verify the fix.


Close #1411