### PR TITLE
Added "disabled" annotation when parent child step lists are readonly

### DIFF
--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -2347,5 +2347,34 @@ namespace OpenTap.UnitTests
                 }
             }
         }
+
+        [AllowAnyChild]
+        public class ReadOnlyDelays : TestStep
+        {
+            public ReadOnlyDelays()
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    // TestStep.IsReadOnly does not cause the settings to be read-only, but if the ChildTetSteps.IsReadOnly is set this is the case. 
+                    ChildTestSteps.Add(new DelayStep() { IsReadOnly = true });
+                }
+
+                ChildTestSteps.IsReadOnly = true;
+            }
+            
+            public override void Run()
+            {
+                
+            }
+        }
+        
+        [Test]
+        public void TestReadOnlyStepSettings()
+        {
+            var step = new ReadOnlyDelays();
+            var a = AnnotationCollection.Annotate(step.ChildTestSteps[0]);
+            var member = a.GetMember(nameof(DelayStep.DelaySecs));
+            Assert.IsTrue(member.GetAll<IEnabledAnnotation>().Any(x => x.IsEnabled == false));
+        }
     }
 }

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -2746,6 +2746,16 @@ namespace OpenTap
                 }
             }
 
+            if (annotation.Source is ITestStep step)
+            {
+                // if any parent step has disabled their child steps list.
+                // then the settings of this step should be disabled.
+                // There is an overlap between it being "ReadOnly" and "Disabled"
+                // in this case we want it to be disabled, because e.g buttons should not be clickable.
+                if(step.GetParents().Any(parent => parent.ChildTestSteps.IsReadOnly))
+                    annotation.Add(DisabledSettingsAnnotation.Instance);
+            }
+
             if (mem != null)
             {
                 if (annotation.Get<IObjectValueAnnotation>() == null)
@@ -2994,6 +3004,13 @@ namespace OpenTap
                 }
             }
         }
+    }
+
+    
+    internal class DisabledSettingsAnnotation : IEnabledAnnotation
+    {
+        public bool IsEnabled => false;
+        public static DisabledSettingsAnnotation Instance { get; } = new DisabledSettingsAnnotation();
     }
 
     internal class DisplayAnnotationWrapper : IAnnotation, IDisplayAnnotation, IOwnedAnnotation


### PR DESCRIPTION
Added unit test to verify the behavior.

Close #1352

- I tested this on KS8400 by removing the special annotation there that made steps settings disabled.
- And tested using TUI.