### PR TITLE
1416 fix flaky tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,8 +288,8 @@ jobs:
           path: bin/
       - name: Test
         run: |
-          $ErrorActionPreference = "Stop"
-          dotnet vstest bin/OpenTap.UnitTests.dll --logger:"console;verbosity=detailed" -- RunConfiguration.TestSessionTimeout=1200000 RunConfiguration.TreatNoTestsAsError=true
+          $ErrorActionPreference = "Stop"                                                  # Timeout: 5 minutes (normally takes 2 minutes to run) 
+          dotnet vstest bin/OpenTap.UnitTests.dll --logger:"console;verbosity=detailed" -- RunConfiguration.TestSessionTimeout=300000 RunConfiguration.TreatNoTestsAsError=true
 
   TestPackage:
     runs-on: windows-2022
@@ -311,8 +311,8 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           #Copy-Item .\bin\Release\runtimes\win-x64\native\git2-b7bad55.dll .\bin\Release
-          cd bin/Release
-          dotnet vstest /framework:.NETFramework,Version=v4.62 /Platform:x64 OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" -- RunConfiguration.TreatNoTestsAsError=true
+          cd bin/Release                                                                                                                            # Timeout: 10 minutes (normally takes 5 minutes to run)
+          dotnet vstest /framework:.NETFramework,Version=v4.62 /Platform:x64 OpenTap.Package.UnitTests.dll --logger:"console;verbosity=detailed" -- RunConfiguration.TestSessionTimeout=600000 RunConfiguration.TreatNoTestsAsError=true
 
   TestWindowsPlan:
     runs-on: windows-2022

--- a/Engine.UnitTests/TestStepTests.cs
+++ b/Engine.UnitTests/TestStepTests.cs
@@ -59,7 +59,6 @@ namespace OpenTap.Engine.UnitTests
                 new DialogStep(), new BusyStep(), new ArtifactStep(), new SerializeEnumTest.Step1(), new SerializeEnumTest.Step2(),
                 new MemberDataProviderTests.Delay2Step(), new ResultTest.ActionStep(), new DutStep2(), new IfStep()
             };
-            HashSet<object> values = new HashSet<object>();
             int threadCount = 2;
             var threadWaitSem = new Semaphore(0, threadCount);
             var mainWaitSem = new Semaphore(0, threadCount);
@@ -74,7 +73,7 @@ namespace OpenTap.Engine.UnitTests
                     threadWaitSem.WaitOne();
                     try
                     {
-                        TestStepExtensions.GetObjectSettings<object, ITestStep, object>(steps, false, (t, data) => t, values);
+                        TestStepExtensions.GetObjectSettings<object, ITestStep, object>(steps, false, (t, data) => t, new HashSet<object>());
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
This fixes flaky unittests

1. The timeout for engine / package unittests was shortened significantly
2. A deadlock in Engine unittests was fixed
3. Minor cleanups

I was unable to reproduce the issue with `CyclicDependenciesTest`, even in the pipeline after repeating it over 100 times. It may have been fixed, or just hiding well. I rearranged the asserts so we should get logs if it fails again

I also looked for a way to get information from vstest/nunit about which test actually timed out, but it does not seem to be possible. However, since tests currently run sequentially, I was able to find the offending tests by cross referencing a successful run and checking the test after the final test in the run that timed out.

Closes #1416 