### PR TITLE
Perform image installation in target install

### DIFF
--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -140,6 +140,9 @@ namespace OpenTap.Package
                     return 0;
                 }
 
+                // this really sucks
+                if (this.HeldLock != null)
+                    this.HeldLock.Release();
                 image.Deploy(Target, cancellationToken);
                 return 0;
             }

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -140,9 +140,7 @@ namespace OpenTap.Package
                     return 0;
                 }
 
-                // this really sucks
-                if (this.HeldLock != null)
-                    this.HeldLock.Release();
+                image.InstallLock = HeldLock;
                 image.Deploy(Target, cancellationToken);
                 return 0;
             }

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -117,7 +117,7 @@ namespace OpenTap.Package
 
             bool installError = false;
             var installer = new Installer(Target, cancellationToken)
-            { DoSleep = false, ForceInstall = Force, UnpackOnly = UnpackOnly };
+            { DoSleep = false, ForceInstall = Force, UnpackOnly = UnpackOnly, InstallLock = HeldLock};
             installer.ProgressUpdate += RaiseProgressUpdate;
             installer.Error += RaiseError;
             installer.Error += ex => installError = true;

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -379,7 +379,6 @@ namespace OpenTap.Package
                         },
                         // The current install action is a locking package action.
                         // Setting this flag lets the child process bypass the lock on the installation.
-                        Unlocked = true,
                     };
 
                     var result = processRunner.Run(installStep, true, cancellationToken);

--- a/Package/PackageActions/LockingPackageAction.cs
+++ b/Package/PackageActions/LockingPackageAction.cs
@@ -130,7 +130,15 @@ namespace OpenTap.Package
                 }
             }
 
-            return LockedExecute(cancellationToken);
+            try
+            {
+                return LockedExecute(cancellationToken);
+            }
+            finally
+            {
+                // Since filelock was disposed, we should also unset HeldLock
+                HeldLock = null;
+            }
         }
 
         /// <summary>

--- a/Package/PackageActions/LockingPackageAction.cs
+++ b/Package/PackageActions/LockingPackageAction.cs
@@ -51,6 +51,8 @@ namespace OpenTap.Package
         /// </summary>
         [CommandLineArgument("target", Description = "Override the location where the command is applied.\nThe default is the OpenTAP installation directory.", ShortName = "t")]
         public string Target { get; set; }
+        
+        internal IFileLock HeldLock { get; set; }
 
 
         internal static string GetLocalInstallationDir()
@@ -103,6 +105,7 @@ namespace OpenTap.Package
             var lockfile = Path.Combine(Target, ".lock");
             FileSystemHelper.EnsureDirectoryOf(lockfile);
             using var fileLock = FileLock.Create(lockfile);
+            HeldLock = fileLock;
             bool useLocking = Unlocked == false;
             if (useLocking && !fileLock.WaitOne(0))
             {

--- a/Package/PackageActions/Uninstall.cs
+++ b/Package/PackageActions/Uninstall.cs
@@ -137,7 +137,6 @@ namespace OpenTap.Package
                     },
                     // The current install action is a locking package action.
                     // Setting this flag lets the child process bypass the lock on the installation.
-                    Unlocked = true,
                 };
                 
                 var result = processRunner.Run(installStep, true, cancellationToken);

--- a/Package/PackageInstallHelpers/PackageInstallStep.cs
+++ b/Package/PackageInstallHelpers/PackageInstallStep.cs
@@ -56,6 +56,7 @@ namespace OpenTap.Package.PackageInstallHelpers
                 Repository = Repositories,
                 SystemWideOnly = SystemWideOnly,
                 AlreadyElevated = true,
+                Unlocked = true,
             };
 
             try

--- a/Shared/SubProcessHost.cs
+++ b/Shared/SubProcessHost.cs
@@ -130,8 +130,9 @@ namespace OpenTap
         }
         
         public string TapExe { get; set; }
+        internal Dictionary<string, string> EnvironmentOverrides { get; set; } = new Dictionary<string, string>();
 
-        public Verdict Run(TestPlan step, bool elevate, CancellationToken token)
+        private Verdict Run(TestPlan step, bool elevate, CancellationToken token)
         {
             var handle = Guid.NewGuid().ToString();
             var tap = TapExe ?? GetTap();
@@ -146,6 +147,19 @@ namespace OpenTap
                 RedirectStandardError = true,
                 UseShellExecute = false,
             };
+
+            foreach (var kvp in EnvironmentOverrides)
+            {
+                if (kvp.Value == null)
+                {
+                    pInfo.EnvironmentVariables.Remove(kvp.Key);
+                    Environment.SetEnvironmentVariable(kvp.Key, null);
+                }
+                else
+                {
+                    pInfo.EnvironmentVariables[kvp.Key] = kvp.Value;
+                }
+            }
 
             if (elevate)
             {

--- a/Shared/SubProcessHost.cs
+++ b/Shared/SubProcessHost.cs
@@ -22,7 +22,6 @@ namespace OpenTap
     {
         public bool ForwardLogs { get; set; } 
         public string LogHeader { get; set; } = "";
-        public bool Unlocked { get; set; } = false;
         public HashSet<string> MutedSources { get; } = new HashSet<string>();
 
         public static bool IsAdmin()
@@ -129,13 +128,18 @@ namespace OpenTap
                 throw;
             }
         }
+        
+        public string TapExe { get; set; }
 
         public Verdict Run(TestPlan step, bool elevate, CancellationToken token)
         {
             var handle = Guid.NewGuid().ToString();
-            var pInfo = new ProcessStartInfo(GetTap())
+            var tap = TapExe ?? GetTap();
+            var tapdir = Path.GetDirectoryName(tap);
+            var pInfo = new ProcessStartInfo(tap)
             {
                 Arguments = $"{nameof(ProcessCliAction)} --PipeHandle \"{handle}\"",
+                WorkingDirectory = tapdir,
                 CreateNoWindow = true,
                 WindowStyle = ProcessWindowStyle.Hidden,
                 RedirectStandardOutput = true,


### PR DESCRIPTION
It would be great to implement this in a way so we can deploy an older version of OpenTAP (a version which does not contain this fix) and still have it run custom package actions.

This rules out adding e.g. a `--post-install` flag to the install action, since this would only solve the problem for OpenTAP 9.24+.

This solution passes the install lock into the action performing the installation so it can release the install mutex before starting the installation in a subprocess

Closes #1426 