### PR TITLE
1430 instrument trailing space

### DIFF
--- a/Engine.UnitTests/SerializerTests.cs
+++ b/Engine.UnitTests/SerializerTests.cs
@@ -40,6 +40,31 @@ namespace OpenTap.Engine.UnitTests
         }
 
         [Test]
+        [TestCase("No Trailing Space")]
+        [TestCase("Yes Trailing Space ")]
+        public void TestSerializeInstrumentsWithTrailingSpaceInName(string name)
+        {
+            using var session = Session.Create(SessionOptions.OverlayComponentSettings);
+            var ins = new ScpiInstrument() { Name = name };
+            var scpiStep1 = new ScpiTestStep() { Instrument = ins };
+            InstrumentSettings.Current.Add(ins);
+            var plan = new TestPlan()
+            {
+                ChildTestSteps = { scpiStep1 }
+            };
+
+            { // Verify deserialization completed without errors
+                var str = plan.SerializeToString();
+                var ser = new TapSerializer();
+                var plan2 = ser.DeserializeFromString(str) as TestPlan;
+                var scpiStep2 = plan2.ChildTestSteps[0] as ScpiTestStep;
+
+                Assert.AreSame(scpiStep1.Instrument, scpiStep2.Instrument);
+                Assert.That(ser.Errors.Count(), Is.EqualTo(0));
+            }
+        }
+
+        [Test]
         public void TestPackageVersionLicenseSerializer()
         {
             var packageVersion = new PackageVersion("pkg", SemanticVersion.Parse("1.0.0"), "Linux", CpuArchitecture.AnyCPU, DateTime.Now, 

--- a/Engine/SerializerPlugins/ResourceSerializer.cs
+++ b/Engine/SerializerPlugins/ResourceSerializer.cs
@@ -88,7 +88,7 @@ namespace OpenTap.Plugins
                     var obj = fetchObject(t, propertyType ?? t, o => getName(o).Trim() == content, src);
                     if (obj != null)
                     {
-                        var name = getName(obj);
+                        var name = getName(obj).Trim();
                         if (name != content && !string.IsNullOrWhiteSpace(content))
                         {
                             TestPlanChanged = true;


### PR DESCRIPTION
This fixes an issue where a warning is given during serialization if a resource name has trailing whitespace.

This change should be safe since we are already trimming in the places where we do the actual lookup. The only place we don't trim is when we compare the names of what we found versus what we were looking for (and we also trimmed the value we were looking for)