### PR TITLE
Run custom package actions in subprocess

### DIFF
--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -25,6 +25,7 @@ namespace OpenTap.Package
     /// Represents a plugin (type that derives from ITapPlugin) in a payload file of an OpenTAP package.
     /// </summary>
     [XmlType("Plugin")]
+    [DebuggerDisplay("{BaseType} \\ {Type}")]
     public class PluginFile
     {
         /// <summary>

--- a/Package/PluginInstaller.cs
+++ b/Package/PluginInstaller.cs
@@ -8,11 +8,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using System.Diagnostics;
-using System.Reflection;
 using System.IO.Compression;
-using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Runtime.InteropServices;
 using System.ComponentModel;
 
 namespace OpenTap.Package
@@ -356,9 +353,6 @@ namespace OpenTap.Package
                 tryUninstall(path, package, target);
                 throw new Exception($"Failed to install package '{path}'.");
             }
-
-            CustomPackageActionHelper.RunCustomActions(package, PackageActionStage.Install,
-                new CustomPackageActionArgs(null, false));
 
             return package;
         }

--- a/Shared/SubProcessHost.cs
+++ b/Shared/SubProcessHost.cs
@@ -24,6 +24,11 @@ namespace OpenTap
         public string LogHeader { get; set; } = "";
         public bool Unlocked { get; set; } = false;
         public HashSet<string> MutedSources { get; } = new HashSet<string>();
+        
+        /// <summary>
+        /// Override the environment in the subprocess
+        /// </summary>
+        public Dictionary<string, string> EnvironmentOverride { get; set; } = new Dictionary<string, string>();
 
         public static bool IsAdmin()
         {
@@ -142,6 +147,14 @@ namespace OpenTap
                 RedirectStandardError = true,
                 UseShellExecute = false,
             };
+
+            foreach (var o in EnvironmentOverride)
+            {
+                if (o.Value == null && pInfo.Environment.ContainsKey(o.Key))
+                    pInfo.Environment.Remove(o.Key);
+                else
+                    pInfo.Environment[o.Key] = o.Value;
+            }
 
             if (elevate)
             {


### PR DESCRIPTION
This allows us to load plugins from the target installation even if we are not running isolated. This is needed to run custom package actions when deploying a new installation from an existing one