### PR TITLE
Disable gui sdk example in CE and add editorx launch options

### DIFF
--- a/sdk/Examples/ExamplePlugin/Properties/launchSettings.json
+++ b/sdk/Examples/ExamplePlugin/Properties/launchSettings.json
@@ -4,6 +4,11 @@
       "commandName": "Executable",
       "executablePath": "./editor.exe"
     },
+    "Editor X": {
+      "commandName": "Executable",
+      "executablePath": "./tap.exe",
+      "commandLineArgs": "editorx"
+    },
     "Terminal Editor": {
       "commandName": "Executable",
       "executablePath": "./tap.exe",

--- a/sdk/Examples/Examples.sln
+++ b/sdk/Examples/Examples.sln
@@ -83,7 +83,6 @@ Global
 		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.LinuxDebug|Any CPU.ActiveCfg = Debug|Any CPU
 		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.LinuxRelease|Any CPU.ActiveCfg = Release|Any CPU
 		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.Debug CE|Any CPU.ActiveCfg = Debug CE|Any CPU
-		{68D30DA3-7F51-449D-A5F0-B1B2E3F59EDD}.Debug CE|Any CPU.Build.0 = Debug CE|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/Examples/PluginDevelopment/Properties/launchSettings.json
+++ b/sdk/Examples/PluginDevelopment/Properties/launchSettings.json
@@ -3,6 +3,11 @@
     "WPF Editor": {
       "commandName": "Executable",
       "executablePath": "./editor.exe"
+    },    
+    "Editor X": {
+      "commandName": "Executable",
+      "executablePath": "./tap.exe",
+      "commandLineArgs": "editorx"
     },
     "Terminal Editor": {
       "commandName": "Executable",


### PR DESCRIPTION
This fixes a build error that occurred when selecting the Debug CE configuration. It also adds launch options for editor x

Closes #1437