### PR TITLE
Catch exception when package cache is in use

### DIFF
--- a/Package/Repositories/FilePackageRepository.cs
+++ b/Package/Repositories/FilePackageRepository.cs
@@ -563,11 +563,21 @@ namespace OpenTap.Package
                     var sw = Stopwatch.StartNew();
                     allPackages = loadPackagesFromFile(allFileInfos).ToList();
                     cache.CachePackageCount = allFileInfos.Count;
-                    
 
                     // Create cache
-                    CreatePackageCache(allPackages, cache);
-                    log.Debug(sw, "Rebuilding cache: {0}", cache.CacheFileName);
+                    try
+                    {
+                        CreatePackageCache(allPackages, cache);
+                        log.Debug(sw, "Rebuilding cache: {0}", cache.CacheFileName);
+                    }
+                    catch (Exception ex)
+                    {
+                        // This can fail if the package cache is in use.
+                        // For example if another thread or process is loading the cache while we are trying to write it.
+                        // This is not that serious, as the cache will just be regenerated later.
+                        log.Debug($"Unable to update package cache: '{ex.Message}'");
+                        log.Debug(ex);
+                    }
                 }
             }
 


### PR DESCRIPTION
This fixes an unhandled exception when a package cache is saved while it is already in use

Close #1442