### PR TITLE
1459 Performance Improvements:

### DIFF
--- a/Engine.UnitTests/SerializerTests.cs
+++ b/Engine.UnitTests/SerializerTests.cs
@@ -326,7 +326,7 @@ namespace OpenTap.Engine.UnitTests
             public override bool Serialize(XElement node, object obj, ITypeData expectedType)
             {
                 if (visitedNodes.Add(node) == false) return false;
-                return Serializer.Serialize(node, obj, expectedType);
+                return Serializer.Serialize(node, obj, expectedType, true);
             }
             
             public bool NeededForDeserialization

--- a/Engine/Invokable/Invokable.cs
+++ b/Engine/Invokable/Invokable.cs
@@ -3,8 +3,7 @@
 namespace OpenTap
 {
     /// <summary> Action(T) IInvokable. </summary>
-    /// <typeparam name="T"></typeparam>
-    class Invokable<T> : IInvokable<T>
+    readonly struct Invokable<T> : IInvokable<T>
     {
         readonly Action<T> action;
         public Invokable(Action<T> action) => this.action = action;
@@ -14,12 +13,13 @@ namespace OpenTap
         /// <summary> Add an ignored argument. </summary>
         public Invokable<T, T2> AddArg<T2>()
         {
-            return new Invokable<T, T2>((a1, a2) => action(a1));
+            var act = action;
+            return new Invokable<T, T2>((a1, a2) => act(a1));
         }
     }
     
     /// <summary> Action(T) IInvokable. </summary>
-    class Invokable<T, T2> : IInvokable<T,T2>
+    readonly struct Invokable<T, T2> : IInvokable<T,T2>
     {
         readonly Action<T,T2> action;
         public Invokable(Action<T,T2> action) => this.action = action;

--- a/Engine/Log.cs
+++ b/Engine/Log.cs
@@ -449,7 +449,7 @@ namespace OpenTap
             var timespan = ShortTimeSpan.FromSeconds(elapsed.TotalSeconds);
 
             if (sb == null)
-                sb = new StringBuilder();
+                sb = StringBuilderCache.GetStringBuilder();
             sb.Clear();
             if (args.Length == 0)
             {
@@ -841,6 +841,19 @@ namespace OpenTap
                 ex.Rethrow();
             else
                 (ex.InnerException ?? ex).Rethrow();
+        }
+    }
+
+    static class StringBuilderCache
+    {
+        [ThreadStatic]
+        static StringBuilder sb;
+
+        public static StringBuilder GetStringBuilder()
+        {
+            var sb2 = sb ??= new StringBuilder();
+            sb2.Clear();
+            return sb2;   
         }
     }
 }

--- a/Engine/NumberParser.cs
+++ b/Engine/NumberParser.cs
@@ -766,15 +766,6 @@ namespace OpenTap
             return false;
         }
 
-        [ThreadStatic] static StringBuilder stringBuilder;
-
-        StringBuilder getStringBuilder()
-        {
-            var sb =stringBuilder ?? (stringBuilder = new StringBuilder());
-            sb.Clear();
-            return sb;
-        }
-        
         /// <summary>
         /// Parses a sequence of numbers back into a string.
         /// </summary>
@@ -789,7 +780,7 @@ namespace OpenTap
                 var seqs = values as _ICombinedNumberSequence;
                 if (seqs != null)
                 {
-                    StringBuilder sb = getStringBuilder();
+                    StringBuilder sb = StringBuilderCache.GetStringBuilder();
                     foreach (var subseq in seqs.Sequences)
                     {
                         var range = subseq as Range;
@@ -814,7 +805,7 @@ namespace OpenTap
             }
             if (UseRanges)
             { // Parse the slow way.
-                StringBuilder sb = getStringBuilder();
+                StringBuilder sb = StringBuilderCache.GetStringBuilder();
                 List<BigFloat> sequence = new List<BigFloat>();
                 BigFloat seq_step = 0;
                 foreach (var _val in values)
@@ -855,7 +846,7 @@ namespace OpenTap
             if (!UsePrefix)
             {
                 // this ca be done really fast since we dont have to use BigFloat.
-                var sb = getStringBuilder();
+                var sb = StringBuilderCache.GetStringBuilder();
                 foreach (var _val in values)
                 {
                     if (sb.Length != 0)
@@ -887,7 +878,7 @@ namespace OpenTap
             }
             
             {
-                StringBuilder sb = getStringBuilder();
+                StringBuilder sb = StringBuilderCache.GetStringBuilder();
                 foreach (var _val in values)
                 {
                     var val = BigFloat.Convert(_val);

--- a/Engine/SerializerPlugins/DefaultValueSerializer.cs
+++ b/Engine/SerializerPlugins/DefaultValueSerializer.cs
@@ -45,7 +45,7 @@ namespace OpenTap.Plugins
             try
             {
                 elems.Add(elem);
-                bool ok = Serializer.Serialize(elem, obj, expectedType);
+                bool ok = Serializer.Serialize(elem, obj, expectedType, true);
 
                 if (defaultValueLookup.TryGetValue(elem, out var defaultValue))
                 {

--- a/Engine/SerializerPlugins/ObjectSerializer.cs
+++ b/Engine/SerializerPlugins/ObjectSerializer.cs
@@ -599,7 +599,8 @@ namespace OpenTap.Plugins
                 char c = str[i];
                 if (c == '\r') // special case. Somehow deserialization turns \n into \r.
                     return false;
-                
+                if (char.IsLetter(c))
+                    continue;
                 if (XmlConvert.IsXmlChar(c))
                     continue;
                 if(i < len - 1)

--- a/Engine/SerializerPlugins/TestStepListSerializer.cs
+++ b/Engine/SerializerPlugins/TestStepListSerializer.cs
@@ -57,7 +57,7 @@ namespace OpenTap.Plugins
                 {
                     var item = list[i];
                     var newelem = new XElement(testStepName);
-                    Serializer.Serialize(newelem, item);
+                    Serializer.Serialize(newelem, item, null, true);
                     elem.Add(newelem);
                 }
                 return true;

--- a/Engine/TapSerialization.cs
+++ b/Engine/TapSerialization.cs
@@ -259,7 +259,12 @@ namespace OpenTap
         /// <returns></returns>
         public T GetSerializer<T>() where T : ITapSerializerPlugin
         {
-            return serializers.OfType<T>().FirstOrDefault();
+            foreach (var item in serializers)
+            {
+                if (item is T found)
+                    return found;
+            }
+            return default;
         }
 
         /// <summary> Adds new serializers to the serializer. Will insert them based on the order property. </summary>

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -15,7 +15,7 @@ namespace OpenTap
 {
     partial class TestPlan
     {
-        bool runPrePlanRunMethods(IEnumerable<ITestStep> steps, TestPlanRun planRun)
+        bool runPrePlanRunMethods(IList<ITestStep> steps, TestPlanRun planRun)
         {
             Stopwatch preTimer = Stopwatch.StartNew(); // try to avoid calling Stopwatch.StartNew too often.
             TimeSpan elaps = preTimer.Elapsed;

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -872,7 +872,7 @@ namespace OpenTap
         {
             var name = Step.GetFormattedName();
 
-            StringBuilder sb = new StringBuilder();
+            StringBuilder sb = StringBuilderCache.GetStringBuilder();
             sb.Append('"');
 
             void getParentNames(ITestStep step)

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -459,13 +460,13 @@ namespace OpenTap
                 ResultSource.Defer(() =>
                 {
                     deferDone.Set();
-                    stepRuns = null;
+                    stepRuns = ImmutableDictionary<Guid, TestStepRun>.Empty;
                 });
             }
             else
             {
                 deferDone.Set();
-                stepRuns = null;
+                stepRuns = ImmutableDictionary<Guid, TestStepRun>.Empty;
             }
         }
 
@@ -516,11 +517,11 @@ namespace OpenTap
         
         // we keep a mapping of the most recent run of any child step. This is important to be able to update inputs.
         // the guid is the ID of a step.
-        ConcurrentDictionary<Guid, TestStepRun> stepRuns = new ConcurrentDictionary<Guid, TestStepRun>(); 
+        ImmutableDictionary<Guid, TestStepRun> stepRuns = ImmutableDictionary<Guid, TestStepRun>.Empty; 
         internal override void ChildStarted(TestStepRun stepRun)
         {
             base.ChildStarted(stepRun);
-            stepRuns[stepRun.TestStepId] = stepRun;
+            stepRuns = stepRuns.SetItem(stepRun.TestStepId, stepRun);
             childStarted?.Invoke(stepRun);
         }
         

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -521,7 +521,7 @@ namespace OpenTap
         internal override void ChildStarted(TestStepRun stepRun)
         {
             base.ChildStarted(stepRun);
-            stepRuns = stepRuns.SetItem(stepRun.TestStepId, stepRun);
+            Utils.InterlockedSwap(ref stepRuns, () => stepRuns.SetItem(stepRun.TestStepId, stepRun));
             childStarted?.Invoke(stepRun);
         }
         


### PR DESCRIPTION
- Added serializer improvements by
  - Reducing call stack nesting
  - Object serializer is faster at checking if chars are reversible.

  - Less GC overhead by using struct for results.
  - Added caching for StringBuilders
  - caching of the stepTypeData in TestStepRun

The improvements are not super signficant:

Optimized:
Benchmark completed 1000 iterations in 00:00:31.4616057
Benchmark completed 1000 iterations in 00:00:31.4179905

Unoptimized
Benchmark completed 1000 iterations in 00:00:32.7385727
Benchmark completed 1000 iterations in 00:00:32.5542978
Benchmark completed 1000 iterations in 00:00:31.9740189

Measured using the OpenTAP benchmark plugin:
`tap benchmark test-plan --quiet`


Test 2: It is easier to see the improvement when using sweep or repeat.
tap benchmark test-plan --repeat-step --steps=10 --iterations 20 --quiet

Optimized:
Benchmark   completed 20 iterations in 00:00:28.5856391 |  
Benchmark   completed 20 iterations in 00:00:28.9745928 |  

Unoptimized:
Benchmark completed 20 iterations in 00:00:31.5099263
Benchmark completed 20 iterations in 00:00:31.0806921

Close #1459