### PR TITLE
1465 Publish Artifact Summary Size: Fix

### DIFF
--- a/Engine.UnitTests/TestStepTest.cs
+++ b/Engine.UnitTests/TestStepTest.cs
@@ -46,6 +46,7 @@ namespace OpenTap.Engine.UnitTests
         {
             public override void Run() { }
         }
+        public string PublishArtifact;
         /// <summary>
         /// Initializes a new instance of the TestStepTest class.
         /// </summary>
@@ -57,6 +58,10 @@ namespace OpenTap.Engine.UnitTests
         {
             Results.Publish("UnitTest", new List<string>() { "Channel", "Power [dBm]" }, 27, 1.11, 2, 0);
             Verdict = Verdict.Pass;
+            if (string.IsNullOrEmpty(PublishArtifact) == false)
+            {
+                StepRun.PublishArtifact(PublishArtifact);
+            }
         }
 
         public static TestPlan CreateGenericTestPlan()

--- a/Engine/TestPlanRunSummaryListener.cs
+++ b/Engine/TestPlanRunSummaryListener.cs
@@ -134,6 +134,18 @@ namespace OpenTap
 
         private readonly string separator = new string('-', 44);
 
+        static string FormatSize(long size)
+        {
+            
+            if (size < 1000)
+                return $"{size} B";
+            
+            if (size < 1000000)
+                return $"{Math.Round(((double)size) / 1000, 1)} kB";
+            
+            return $"{Math.Round(((double)size) / 1000_000, 1)} MB";
+        } 
+        
         /// <summary> Prints the artifact summary. </summary>
         public void PrintArtifactsSummary()
         {
@@ -151,7 +163,8 @@ namespace OpenTap
                 summaryLog.Info(formatSummary($" {artifacts.Count} artifacts registered. "));
                 foreach (var artifact in artifacts)
                 {
-                    summaryLog.Info($" - {Path.GetFullPath(artifact)}  [{new FileInfo(artifact).Length} B]");
+                    var artifactSize = new FileInfo(artifact).Length;
+                    summaryLog.Info($" - {Path.GetFullPath(artifact)}  [{FormatSize(artifactSize)}]");
                 }
             }
             else


### PR DESCRIPTION
- Added artifact summary size with improved names e.g 1.5 kB, 1.5 MB 
- Added unit test to prove the artifact summary and the new unit text.

Close #1465 