### PR TITLE
Add currently installed packages to the list of additional packages in image resolver

### DIFF
--- a/Package/Image/ImageSpecifier.cs
+++ b/Package/Image/ImageSpecifier.cs
@@ -49,11 +49,16 @@ namespace OpenTap.Package
         {
             var toInstall = new List<PackageSpecifier>();
             var installed = installation.GetPackages().ToList();
+            var additionalPackages = new List<PackageDef>();
+
             foreach (var package in newPackages)
             {
                 var ext = installed.FirstOrDefault(x => x.Name == package.Name);
                 if (ext != null)
+                { 
                     installed.Remove(ext);
+                    additionalPackages.Add(ext);
+                }
 
                 if (File.Exists(package.Name))
                 {
@@ -74,6 +79,7 @@ namespace OpenTap.Package
             return new ImageSpecifier
             {
                 Packages = toInstall,
+                AdditionalPackages = additionalPackages,
                 InstalledPackages = installed.ToImmutableArray(),
                 FixedPackages = fixedPackages
             };


### PR DESCRIPTION
This fixes an issue where image resolutions will sometimes fail while offline, even if the required packages are available in the target installation.

Closes #1469 