### PR TITLE
1464 fix empty logs rollover

### DIFF
--- a/Engine/FileTraceListener.cs
+++ b/Engine/FileTraceListener.cs
@@ -79,22 +79,22 @@ namespace OpenTap
         }
         
         long first_timestamp = -1;
-        static ThreadLocal<System.Text.StringBuilder> _sb = new ThreadLocal<System.Text.StringBuilder>(() => new System.Text.StringBuilder());
+        static readonly ThreadLocal<StringBuilder> _sb = new ThreadLocal<StringBuilder>(() => new StringBuilder());
         public override void TraceEvents(IEnumerable<Event> events)
         {
             // Note, this function is heavily optimized.
             // profile carefully after doing any changes!!
 
             if (events == null)
-                throw new ArgumentNullException("events");
+                throw new ArgumentNullException(nameof(events));
 
             base.TraceEvents(events);
 
-            System.Text.StringBuilder sb = _sb.Value;
+            var sb = _sb.Value;
             
             sb.Clear();
             long lastTick = 0;
-            string tickmsg = "";
+            string tickmsg = string.Empty;
             foreach (var evt in events)
             {
                 if (first_timestamp == -1)
@@ -143,18 +143,15 @@ namespace OpenTap
                 sb.Append(" ; ");
                 if (evt.Message != null)
                 {
-                    sb.Append(evt.Message.Replace("\n", "").Replace("\r", ""));
+                    sb.Append(evt.Message.Replace("\n", string.Empty).Replace("\r", string.Empty));
                 }
                 sb.AppendLine();
             }
-            this.Write(sb.ToString());
+            Write(sb.ToString());
 
-            var streamWriter = Writer as StreamWriter;
-
-            if (streamWriter != null && (ulong)streamWriter.BaseStream.Length > FileSizeLimit)
+            if (FileSizeLimitReached != null && Writer is StreamWriter sw && (ulong)sw.BaseStream.Length > FileSizeLimit)
             {
-                if(FileSizeLimitReached != null)
-                    FileSizeLimitReached(this, new EventArgs());
+                FileSizeLimitReached(this, EventArgs.Empty);
             }
         }
     }

--- a/Engine/FileTraceListener.cs
+++ b/Engine/FileTraceListener.cs
@@ -159,7 +159,9 @@ namespace OpenTap
                 string newname = _fileName.Replace("__" + logCount, "");
                 logCount += 1;
                 var nextFile = addLogRotateNumber(newname, logCount);
+                var prevWriter = Writer;
                 Writer = new StreamWriter(new FileStream(nextFile, FileMode.Append));
+                prevWriter.Close();
             }
             finally
             {

--- a/Engine/Log.cs
+++ b/Engine/Log.cs
@@ -175,16 +175,16 @@ namespace OpenTap
     /// </summary>
     class TextWriterTraceListener : TraceListener, IDisposable
     {
-        private TextWriter writer;
+        private StreamWriter writer;
 
         private Mutex LockObject = new Mutex(false);
 
-        private void LockOutput()
+        protected void LockOutput()
         {
             LockObject.WaitOne();
         }
 
-        private void UnlockOutput()
+        protected void UnlockOutput()
         {
             LockObject.ReleaseMutex();
         }
@@ -192,12 +192,9 @@ namespace OpenTap
         /// <summary>
         /// The writer that is used as the output.
         /// </summary>
-        public System.IO.TextWriter Writer
+        public StreamWriter Writer
         {
-            get
-            {
-                return writer;
-            }
+            get => writer;
             set
             {
                 if (writer != value)
@@ -226,9 +223,9 @@ namespace OpenTap
         /// <summary>
         /// Creates a new TextWriterTraceListener writing to the given stream.
         /// </summary>
-        public TextWriterTraceListener(System.IO.Stream stream)
+        public TextWriterTraceListener(Stream stream)
         {
-            Writer = new System.IO.StreamWriter(stream);
+            Writer = new StreamWriter(stream);
         }
 
         /// <summary>

--- a/Engine/Logging/diag_impl.cs
+++ b/Engine/Logging/diag_impl.cs
@@ -75,7 +75,7 @@ namespace OpenTap.Diagnostic
         void ProcessLog()
         {
             var copy = new List<ILogListener>();
-            Event[] bunch = new Event[0];
+            Event[] bunch = Array.Empty<Event>();
             while (isDisposed == false)
             {
                 newEventOccured.WaitOne();

--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -384,7 +384,6 @@ namespace OpenTap
                         }
                         
                         traceListener.FileSizeLimit = 100_000_000; // max size for log files is 100MB.
-                        traceListener.FileSizeLimitReached += TraceListener_FileSizeLimitReached;
                         Log.AddListener(traceListener);
                     }
                     else
@@ -421,47 +420,7 @@ namespace OpenTap
             {
                 // Ignore in case of race conditions.
             }
-        }
-
-        static int sessionLogCount = 0;
-        static object sessionLogRotateLock = new object();
-        static void TraceListener_FileSizeLimitReached(object sender, EventArgs e)
-        {
-            traceListener.FileSizeLimitReached -= TraceListener_FileSizeLimitReached;
-            
-            Task.Factory.StartNew(() =>
-            {
-                lock (sessionLogRotateLock)
-                {
-                    string newname = currentLogFile.Replace("__" + sessionLogCount.ToString(), "");
-
-                    sessionLogCount += 1;
-                    var nextFile = addLogRotateNumber(newname, sessionLogCount);
-
-                    log.Info("Switching log to the file {0}", nextFile);
-
-                    Log.RemoveListener((FileTraceListener)sender);
-
-                    rename(nextFile, newFile: true);
-                }
-            });
-        }
-
-        static string addLogRotateNumber(string fullname, int cnt)
-        {
-            if (cnt == 0) return fullname;
-            var dir = Path.GetDirectoryName(fullname);
-            var filename = Path.GetFileNameWithoutExtension(fullname);
-            if (Path.HasExtension(fullname))
-            {
-                var ext = Path.GetExtension(fullname);
-                return Path.Combine(dir, filename + "__" + cnt.ToString() + ext);
-            }
-            else
-            {
-                return Path.Combine(dir, filename + "__" + cnt.ToString());
-            }
-        }
+        } 
 
         /// <summary>
         /// Renames a previously initialized temporary log file.

--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -383,7 +383,7 @@ namespace OpenTap
                             traceListener = new FileTraceListener(path);
                         }
                         
-                        traceListener.FileSizeLimit = 100000000; // max size for log files is 100MB.
+                        traceListener.FileSizeLimit = 100_000_000; // max size for log files is 100MB.
                         traceListener.FileSizeLimitReached += TraceListener_FileSizeLimitReached;
                         Log.AddListener(traceListener);
                     }


### PR DESCRIPTION
This fixes an issue causing session logs not to roll if messages are produced faster than FileTraceListener can flush.

This happens because `FileTraceListener` attempts to flush pending messages before detaching itself from the set of LogListeners, and then attaching a new log listener with a new file name.
Flushing the pending messages will never finish while new messages are being produced faster than the messages can be written to disk.

Moving the renaming logic into the FileTraceListener implementation was significantly simpler than any other solution I was able to come up with, and the previous implementation seemed a bit overengineered. 

This of course affects the session log, but also the test plan log. But the test plan log does not set a max file size, so the default size of `ulong.MaxValue` is used, so the renaming logic is unlikely to be triggered for test plans (in this universe).


Closes #1464 
Closes #1471