### PR TITLE
1117 add new run parameters

### DIFF
--- a/BasicSteps/SweepParam.cs
+++ b/BasicSteps/SweepParam.cs
@@ -58,7 +58,7 @@ namespace OpenTap.Plugins.BasicSteps
         /// <summary>
         /// Initializes a new instance of the SweepParam class. For use when programatically creating a <see cref="SweepLoop"/>
         /// </summary>
-        /// <param name="prop">Property to sweep. This should be one of the properties on one of the childsteps of the <see cref="SweepLoop"/>.</param>
+        /// <param name="props">Property to sweep. This should be one of the properties on one of the childsteps of the <see cref="SweepLoop"/>.</param>
         public SweepParam(IEnumerable<IMemberData> props) : this()
         {
             Members = props.Distinct().ToArray();

--- a/Engine.UnitTests/TestPlanTest.cs
+++ b/Engine.UnitTests/TestPlanTest.cs
@@ -161,8 +161,6 @@ namespace OpenTap.Engine.UnitTests
         [Test]
         public void TestRunSelectedResultParameter([Values(null, 1, 3)] int? runSelected)
         { 
-            const string stepsOverrideParameterName = "StepOverrideList"; 
-            
             var plan = new TestPlan();
             var steps = Enumerable.Range(0, 10).Select(_ => new VerdictStep()).ToArray();
             plan.ChildTestSteps.AddRange(steps);
@@ -171,7 +169,7 @@ namespace OpenTap.Engine.UnitTests
             if (runSelected.HasValue)
                 selectedSteps = new HashSet<ITestStep>(steps.Take(runSelected.Value));
             var results = plan.Execute( Array.Empty<IResultListener>(), Array.Empty<ResultParameter>(), selectedSteps).Parameters;
-            var result = results.FirstOrDefault(param => param.Name == stepsOverrideParameterName);
+            var result = results.FirstOrDefault(param => param.Name == TestPlan.stepsOverrideParameterName);
             if (runSelected.HasValue)
             {
                 Assert.That(result, Is.Not.Null);
@@ -192,7 +190,6 @@ namespace OpenTap.Engine.UnitTests
         [Test]
         public void TestBreakConditionResultParameter([Values(true, false)] bool doBreak)
         { 
-            const string breakConditionParameterName = "BreakIssuedFrom"; 
             var l = new PlanRunCollectorListener();
             var plan = new TestPlan();
 
@@ -205,7 +202,7 @@ namespace OpenTap.Engine.UnitTests
 
             var run = plan.Execute(new[] { l });
             
-            var breakResult = run.Parameters.FirstOrDefault(param => param.Name == breakConditionParameterName);
+            var breakResult = run.Parameters.FirstOrDefault(param => param.Name == TestPlan.breakConditionParameterName);
             if (doBreak)
             {
                 var stepRun = l.StepRuns.First(r => r.TestStepId == sequenceStep.Id);

--- a/Engine.UnitTests/TestPlanTest.cs
+++ b/Engine.UnitTests/TestPlanTest.cs
@@ -161,7 +161,7 @@ namespace OpenTap.Engine.UnitTests
         [Test]
         public void TestRunSelectedResultParameter([Values(null, 1, 3)] int? runSelected)
         { 
-            const string stepsOverrideParameterName = "StepsOverridden"; 
+            const string stepsOverrideParameterName = "StepOverrideList"; 
             
             var plan = new TestPlan();
             var steps = Enumerable.Range(0, 10).Select(_ => new VerdictStep()).ToArray();
@@ -192,7 +192,7 @@ namespace OpenTap.Engine.UnitTests
         [Test]
         public void TestBreakConditionResultParameter([Values(true, false)] bool doBreak)
         { 
-            const string breakConditionParameterName = "CancelledDueToBreakCondition"; 
+            const string breakConditionParameterName = "BreakIssuedFrom"; 
             var l = new PlanRunCollectorListener();
             var plan = new TestPlan();
 

--- a/Engine.UnitTests/TestPlanTest.cs
+++ b/Engine.UnitTests/TestPlanTest.cs
@@ -169,7 +169,7 @@ namespace OpenTap.Engine.UnitTests
             if (runSelected.HasValue)
                 selectedSteps = new HashSet<ITestStep>(steps.Take(runSelected.Value));
             var results = plan.Execute( Array.Empty<IResultListener>(), Array.Empty<ResultParameter>(), selectedSteps).Parameters;
-            var result = results.FirstOrDefault(param => param.Name == TestPlan.stepsOverrideParameterName);
+            var result = results.FirstOrDefault(param => param.Name == TestPlanRun.SpecialParameterNames.StepOverrideList);
             if (runSelected.HasValue)
             {
                 Assert.That(result, Is.Not.Null);
@@ -202,7 +202,7 @@ namespace OpenTap.Engine.UnitTests
 
             var run = plan.Execute(new[] { l });
             
-            var breakResult = run.Parameters.FirstOrDefault(param => param.Name == TestPlan.breakConditionParameterName);
+            var breakResult = run.Parameters.FirstOrDefault(param => param.Name == TestPlanRun.SpecialParameterNames.BreakIssuedFrom);
             if (doBreak)
             {
                 var stepRun = l.StepRuns.First(r => r.TestStepId == sequenceStep.Id);

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -185,7 +185,7 @@ namespace OpenTap
             {
                 if (didBreak) return;
                 didBreak = true;
-                execStage.Parameters.Add(new ResultParameter(breakConditionParameterName, run.Id.ToString())); 
+                execStage.Parameters.Add(new ResultParameter(TestPlanRun.SpecialParameterNames.BreakIssuedFrom, run.Id.ToString())); 
             }
 
             try
@@ -605,7 +605,7 @@ namespace OpenTap
                     // The order of the guids does not really matter. 
                     // Only that the order is the same across runs
                     Array.Sort(overrides); 
-                    execStage.Parameters.Add(new ResultParameter(stepsOverrideParameterName, string.Join(",", overrides)));
+                    execStage.Parameters.Add(new ResultParameter(TestPlanRun.SpecialParameterNames.StepOverrideList, string.Join(",", overrides)));
                 }
 
                 execStage.Start();
@@ -719,10 +719,7 @@ namespace OpenTap
             return Execute(resultListeners, metaDataParameters, null);
         }
 
-        TestPlanRun currentExecutionState = null;
-        internal const string breakConditionParameterName = "BreakIssuedFrom";
-        internal const string stepsOverrideParameterName = "StepOverrideList";
-
+        TestPlanRun currentExecutionState = null; 
 
         /// <summary> true if the plan is in its open state. </summary>
         [AnnotationIgnore]

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -720,8 +720,8 @@ namespace OpenTap
         }
 
         TestPlanRun currentExecutionState = null;
-        private const string breakConditionParameterName = "CancelledDueToBreakCondition";
-        private const string stepsOverrideParameterName = "StepsOverridden";
+        private const string breakConditionParameterName = "BreakIssuedFrom";
+        private const string stepsOverrideParameterName = "StepOverrideList";
 
 
         /// <summary> true if the plan is in its open state. </summary>

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -720,8 +720,8 @@ namespace OpenTap
         }
 
         TestPlanRun currentExecutionState = null;
-        private const string breakConditionParameterName = "BreakIssuedFrom";
-        private const string stepsOverrideParameterName = "StepOverrideList";
+        internal const string breakConditionParameterName = "BreakIssuedFrom";
+        internal const string stepsOverrideParameterName = "StepOverrideList";
 
 
         /// <summary> true if the plan is in its open state. </summary>

--- a/Engine/TestPlanRun.cs
+++ b/Engine/TestPlanRun.cs
@@ -28,6 +28,25 @@ namespace OpenTap
     [DebuggerDisplay("TestPlanRun {TestPlanName}")]
     public class TestPlanRun : TestRun
     {
+        /// <summary>
+        /// Special Parameters refer to result parameters on a test plan run that describe relevant metadata about the run.
+        /// They can be extracted with e.g. 'Run.Parameters.FirstOrDefault(p => p.Name == SpecialParameterNames.Property)'
+        /// </summary>
+        public class SpecialParameterNames
+        {
+            /// <summary>
+            /// The GUID of the test step run that triggered the break condition that terminated the test plan run.
+            /// If the run was not terminated due to a break condition being satisfied, this parameter will
+            /// not be present.
+            /// </summary>
+            public const string BreakIssuedFrom = "BreakIssuedFrom";
+            /// <summary>
+            /// A comma-separated list of GUIDs of the test steps that were specified in the Step Override set.
+            /// If the Step Override feature was not used, this parameter will not be present.
+            /// </summary>
+            public const string StepOverrideList = "StepOverrideList"; 
+        }
+        
         static readonly TraceSource log = Log.CreateSource("TestPlan");
         static readonly TraceSource resultLog = Log.CreateSource("Resources");
 

--- a/Engine/TestPlanRun.cs
+++ b/Engine/TestPlanRun.cs
@@ -39,12 +39,12 @@ namespace OpenTap
             /// If the run was not terminated due to a break condition being satisfied, this parameter will
             /// not be present.
             /// </summary>
-            public const string BreakIssuedFrom = "BreakIssuedFrom";
+            public const string BreakIssuedFrom = "Break Issued From";
             /// <summary>
             /// A comma-separated list of GUIDs of the test steps that were specified in the Step Override set.
             /// If the Step Override feature was not used, this parameter will not be present.
             /// </summary>
-            public const string StepOverrideList = "StepOverrideList"; 
+            public const string StepOverrideList = "Step Override List"; 
         }
         
         static readonly TraceSource log = Log.CreateSource("TestPlan");

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -267,9 +267,11 @@ namespace OpenTap
         }
 
         ITypeData stepTypeData;
+        private ITestStep _step;
         
         TestStepRun(ITestStep step)
         {
+            _step = step;
             TestStepId = step.Id;
             TestStepName = step.GetFormattedName();
             stepTypeData = TypeData.GetTypeData(step);
@@ -337,7 +339,7 @@ namespace OpenTap
 
         internal void ThrowDueToBreakConditions()
         {
-            throw new TestStepBreakException(TestStepName, Verdict);
+            throw new TestStepBreakException(_step, this);
         }
 
         internal bool IsStepChildOf(ITestStep step, ITestStep possibleParent)
@@ -547,13 +549,15 @@ namespace OpenTap
 
     class TestStepBreakException : OperationCanceledException
     {
-        public string TestStepName { get; set; }
-        public Verdict Verdict { get; set; }
+        public string TestStepName => Step.GetFormattedName();
+        public Verdict Verdict => Run.Verdict;
+        public ITestStep Step { get; set; }
+        public TestStepRun Run { get; set; }
 
-        public TestStepBreakException(string testStepName, Verdict verdict)
+        public TestStepBreakException(ITestStep step, TestStepRun run)
         {
-            TestStepName = testStepName;
-            Verdict = verdict;
+            Step = step;
+            Run = run;
         }
 
         public override string Message =>


### PR DESCRIPTION
This adds some run parameters to provide additional details about a test plan run

1. CancelledDueToBreakCondition to indicate whether a test plan run finished normally, or was terminated early due to a break condition being satisfied
2. StepListOverridden to indicate that only a portion of the test plan was run

Closes #1117