### PR TITLE
Ensure innermost step id is used in break result

### DIFF
--- a/Engine.UnitTests/TestPlanTest.cs
+++ b/Engine.UnitTests/TestPlanTest.cs
@@ -214,6 +214,45 @@ namespace OpenTap.Engine.UnitTests
         }
 
         [Test]
+        public void TestCaughtBreakConditionNotPropagated([Values(true, false)] bool doCatch)
+        {
+            var l = new PlanRunCollectorListener();
+            var plan = new TestPlan();
+
+            var sequenceStep = new SequenceStep();
+            plan.ChildTestSteps.Add(sequenceStep);
+
+            var verdictStep = new VerdictStep() { VerdictOutput = Verdict.Fail };
+            sequenceStep.ChildTestSteps.Add(verdictStep);
+
+            BreakConditionProperty.SetBreakCondition(verdictStep, BreakCondition.BreakOnFail);
+            BreakConditionProperty.SetBreakCondition(plan, BreakCondition.BreakOnFail);
+            if (doCatch)
+            {
+                // Since sequence step breaks on error, it will 'catch' the break issued from verdictstep
+                BreakConditionProperty.SetBreakCondition(sequenceStep, BreakCondition.BreakOnError); 
+            }
+            else
+            {
+                BreakConditionProperty.SetBreakCondition(sequenceStep, BreakCondition.BreakOnFail); 
+            }
+            
+            var run = plan.Execute(new[] { l });
+
+            var breakResult = run.Parameters.FirstOrDefault(param => param.Name == TestPlanRun.SpecialParameterNames.BreakIssuedFrom);
+            if (doCatch)
+            {
+                Assert.That(breakResult, Is.Null);
+            }
+            else
+            { 
+                var stepRun = l.StepRuns.First(r => r.TestStepId == verdictStep.Id);
+                Assert.That(breakResult, Is.Not.Null);
+                Assert.That(breakResult.Value.ToString(), Is.EqualTo(stepRun.Id.ToString()));
+            }
+        }
+
+        [Test]
         public void TestPlanStepExceptionTest()
         {
             var preAbortTestPlan = EngineSettings.Current.AbortTestPlan;

--- a/Engine.UnitTests/TestPlanTest.cs
+++ b/Engine.UnitTests/TestPlanTest.cs
@@ -205,7 +205,7 @@ namespace OpenTap.Engine.UnitTests
             var breakResult = run.Parameters.FirstOrDefault(param => param.Name == TestPlanRun.SpecialParameterNames.BreakIssuedFrom);
             if (doBreak)
             {
-                var stepRun = l.StepRuns.First(r => r.TestStepId == sequenceStep.Id);
+                var stepRun = l.StepRuns.First(r => r.TestStepId == verdictStep.Id);
                 Assert.That(breakResult, Is.Not.Null);
                 Assert.That(breakResult.Value.ToString(), Is.EqualTo(stepRun.Id.ToString()));
             }

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -188,6 +188,13 @@ namespace OpenTap
                 execStage.Parameters.Add(new ResultParameter(TestPlanRun.SpecialParameterNames.BreakIssuedFrom, run.Id.ToString())); 
             }
 
+            TestStepRun getBreakingRun(TestStepRun first)
+            {
+                while ((first.Exception as TestStepBreakException)?.Run is { } inner)
+                    first = inner;
+                return first;
+            }
+
             try
             {
                 for (int i = 0; i < steps.Count; i++)
@@ -199,7 +206,8 @@ namespace OpenTap
                         runs.Add(run);
                     if (run.BreakConditionsSatisfied())
                     {
-                        addBreakResult(run);
+                        var breakingRun = getBreakingRun(run);
+                        addBreakResult(breakingRun);
                         run.LogBreakCondition();
                         break;
                     }
@@ -216,7 +224,8 @@ namespace OpenTap
             }
             catch(TestStepBreakException breakEx)
             {
-                addBreakResult(breakEx.Run);
+                var breakingRun = getBreakingRun(breakEx.Run);
+                addBreakResult(breakingRun);
                 Log.Info("{0}", breakEx.Message);
             }
             finally
@@ -228,8 +237,6 @@ namespace OpenTap
                     execStage.UpgradeVerdict(run.Verdict);
                 }    
             }
-
-            
            
             Log.Debug(planRunOnlyTimer, "Test step runs finished.");
             

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -1000,6 +1000,7 @@ namespace OpenTap
             {
                 TestPlan.Log.Info(e.Message);
                 Step.UpgradeVerdict(e.Verdict);
+                stepRun.Exception = e;
             }
             catch (Exception e)
             {

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -1030,13 +1030,12 @@ namespace OpenTap
                     {
                         runTask.Wait();
                     }
-                    catch (TestStepBreakException e)
-                    {
-                        TestPlan.Log.Info(e.Message);
-                        Step.Verdict = Verdict.Error;
-                    }
                     catch (Exception e)
                     {
+                        // Tasks wrap exceptions in AggregateExceptions with a single exception
+                        while (e is AggregateException aex && aex.InnerExceptions.Count == 1)
+                            e = aex.InnerException;
+                        
                         if (e is ThreadAbortException || (e is OperationCanceledException && TapThread.Current.AbortToken.IsCancellationRequested) )
                         {
                             if (TapThread.Current.AbortToken.IsCancellationRequested && Step.Verdict < Verdict.Aborted)
@@ -1045,6 +1044,11 @@ namespace OpenTap
                                 TestPlan.Log.Warning("Test step {0} was canceled.", stepRun.TestStepPath);
                             else
                                 TestPlan.Log.Warning("Test step {0} was canceled with message '{1}'.", stepRun.TestStepPath, e.Message);
+                        }
+                        else if (e is TestStepBreakException brk)
+                        {
+                            TestPlan.Log.Info(brk.Message);
+                            Step.UpgradeVerdict(brk.Verdict);
                         }
                         else
                         {


### PR DESCRIPTION
* Add a unit test verifying the break condition step id is propagated correctly
* Unwrap exceptions thrown in deferred runs
* Correctly propagate stepRun break exceptions