### PR TITLE
Adding instrument setting SendIDNOnConnect to ScpiInstrument

### DIFF
--- a/Engine/ScpiInstrument.cs
+++ b/Engine/ScpiInstrument.cs
@@ -230,6 +230,12 @@ namespace OpenTap
         [Display("Send *IDN? On Connect", Groups: new[] { "VISA", "Debug" }, Order: 4.3, Collapsed: true, Description: "Send *IDN? when opening the connection to the instrument.")]
         public bool SendIDNOnConnect { get; set; }
 
+        /// <summary>
+        /// When true, will send *CLS right after establishing a connection.
+        /// </summary>
+        [Display("Send *CLS On Connect", Groups: new[] { "VISA", "Debug" }, Order: 4.4, Collapsed: true, Description: "Send *CLS when opening the connection to the instrument.")]
+        public bool SendCLSOnConnect { get; set; }
+
         #endregion
 
         /// <summary>
@@ -270,6 +276,7 @@ namespace OpenTap
             // default value for settings:
             SendClearOnConnect = true;
             SendIDNOnConnect = true;
+            SendCLSOnConnect = true;
             Rules.Add(() => LockHoldoff >= 0, "Lock holdoff must be positive.", nameof(LockHoldoff));
             Rules.Add(() => IoTimeout >= 0, "I/O timeout must be positive.", nameof(IoTimeout));
             Rules.Add(visaAddrValid, "Invalid VISA address format.", nameof(VisaAddress));
@@ -381,7 +388,9 @@ namespace OpenTap
                             IdnString = QueryIdn();
                             IdnString = IdnString.Trim();
                             Log.Info("Now connected to: " + IdnString);
-
+                        }
+                        if (SendCLSOnConnect)
+                        {
                             CommandCls(); // Empty error log
                         }
 


### PR DESCRIPTION
This allows to bypass sending IDN query on Open() for instruments that do not support and/or multiple GPIB instruments that have the same visa address string

This PR adds an option on the Debug section of the ScpiInstrument Settings, which is enabled by default:

![image](https://github.com/opentap/opentap/assets/101351788/6b5d753b-a2f3-426e-a180-cbe5492ec4c1)

If the user disables this option for two GPIB instruments:

![image](https://github.com/opentap/opentap/assets/101351788/5bb56e0b-539b-4c55-84a0-172b65eba764)

![image](https://github.com/opentap/opentap/assets/101351788/d8c43a38-69c5-4da4-9e45-2c6686abb84f)

After running a test plan that uses SCPI to query *IDN? on both GPIB instruments, the test plan now completes successfully:

![image](https://github.com/opentap/opentap/assets/101351788/63c6f9bc-87ea-4856-b8a9-519275c2664a)

Close #1497 