### PR TITLE
Use dotnet sdk in favor of old tap sdk new templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,9 @@ jobs:
 
   TestWindowsPlan:
     runs-on: windows-2022
-    needs: Build-Win
+    needs: 
+      - Build-Win
+      - Package-Templates
     strategy:
       matrix:
         retries: [ 0, 1 ]
@@ -339,6 +341,13 @@ jobs:
         with:
           name: win-x64-bin
           path: bin/Release/
+      - name: Download Template package
+        uses: actions/download-artifact@v3
+        with:
+          name: package-templates
+          path: sdk-template
+      - name: Install Templates
+        run: dotnet new --install ./sdk-template/*.nupkg
       - name: Test
         working-directory: bin/Release
         run: ./tap.exe run ../../tests/regression.TapPlan --verbose --color
@@ -351,7 +360,9 @@ jobs:
 
   TestLinuxPlan:
     runs-on: ubuntu-20.04
-    needs: Build-Linux
+    needs: 
+    - Build-Linux
+    - Package-Templates
     strategy:
       matrix:
         retries: [ 0, 1 ]
@@ -367,6 +378,13 @@ jobs:
         with:
           name: Linux-bin
           path: bin/Release/
+      - name: Download Template package
+        uses: actions/download-artifact@v3
+        with:
+          name: package-templates
+          path: sdk-template
+      - name: Install Templates
+        run: dotnet new --install ./sdk-template/*.nupkg
       - run: chmod +x bin/Release/tap
         # The .pdb files are in use for some reason during `tap package install`
       - run: rm ./bin/Release/*.pdb
@@ -375,7 +393,9 @@ jobs:
 
   TestMacPlan:
     runs-on: macos-11
-    needs: Build-MacOS
+    needs: 
+      - Build-MacOS
+      - Package-Templates
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -388,6 +408,11 @@ jobs:
         with:
           name: MacOS-bin
           path: bin/Release/
+      - name: Download Template package
+        uses: actions/download-artifact@v3
+        with:
+          name: package-templates
+          path: sdk-template
       - run: chmod +x bin/Release/tap
         # The .pdb files are in use for some reason during `tap package install`
       - run: rm ./bin/Release/*.pdb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
           name: win-x64-bin
           path: bin/Release/
       - name: Download Template package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: package-templates
           path: sdk-template
@@ -379,7 +379,7 @@ jobs:
           name: Linux-bin
           path: bin/Release/
       - name: Download Template package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: package-templates
           path: sdk-template
@@ -409,10 +409,12 @@ jobs:
           name: MacOS-bin
           path: bin/Release/
       - name: Download Template package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: package-templates
           path: sdk-template
+      - name: Install Templates
+        run: dotnet new --install ./sdk-template/*.nupkg
       - run: chmod +x bin/Release/tap
         # The .pdb files are in use for some reason during `tap package install`
       - run: rm ./bin/Release/*.pdb

--- a/sdk/OpenTap.Sdk.New/GenerateProject.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateProject.cs
@@ -246,7 +246,7 @@ namespace OpenTap.Sdk.New
 
             var si = new ProcessStartInfo("dotnet", $"new --install \"{fn}\"")
             {
-                UseShellExecute = true,
+                UseShellExecute = false,
             };
 
             var p = new Process() { StartInfo = si };
@@ -259,7 +259,7 @@ namespace OpenTap.Sdk.New
         {
             var si = new ProcessStartInfo("dotnet", args)
             {
-                UseShellExecute = true,
+                UseShellExecute = false,
             };
 
             log.Info($"Running dotnet {args}");

--- a/sdk/OpenTap.Sdk.New/GenerateProject.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateProject.cs
@@ -161,7 +161,7 @@ namespace OpenTap.Sdk.New
             
             // If no output directory was requested, or if we just created a new solution in the requested directory,
             // put the project in a directory of the same name in the solution directory
-            if (string.IsNullOrWhiteSpace(output) || newSolution)
+            if (string.IsNullOrWhiteSpace(output) || newSolution || sln.Directory.FullName.Equals(dest.FullName))
                 dest = sln.Directory.CreateSubdirectory(Name);
 
             // Create the new project

--- a/sdk/OpenTap.Sdk.New/GenerateProject.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateProject.cs
@@ -3,18 +3,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-using System;
-using Newtonsoft.Json.Linq;
 using OpenTap.Cli;
 using OpenTap.Package;
-using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace OpenTap.Sdk.New
@@ -22,63 +16,33 @@ namespace OpenTap.Sdk.New
     [Display("project", "OpenTAP C# Project (.csproj). Including a new TestStep, solution file (.sln) and package.xml.", Groups: new[] { "sdk", "new" })]
     public class GenerateProject : GenerateType
     {
+        enum InstallTemplateResponse
+        {
+            No,
+            Yes,
+        }
+
+        [Display("Install OpenTAP Dotnet Templates?")]
+        class InstallTemplateQuestion
+        {
+
+            [Browsable(true)]
+            [Layout(LayoutMode.FullRow)]
+            public string Message => "OpenTAP dotnet new templates are not installed. Do you wish to install the templates?";
+            [Layout(LayoutMode.FullRow | LayoutMode.FloatBottom)]
+            [Submit] public InstallTemplateResponse Response { get; set; } = InstallTemplateResponse.Yes;
+        }
+
+        #region ExitCodes
+        // Exit codes are documented here: https://github.com/dotnet/templating/wiki/Exit-Codes
+        private const int TemplateNotFound = 103;
+        #endregion
+
         [CommandLineArgument("out", ShortName = "o", Description = "Destination directory for generated files.")]
         public override string output { get => base.output; set => base.output = value; }
 
         [UnnamedCommandLineArgument("name", Required = true)]
         public string Name { get; set; }
-
-        private SemanticVersion GetOpenTapVersion()
-        {
-            var version = NugetInterop.GetLatestNugetVersion();
-            if(version == null)
-            {
-                log.Warning("Unable to get an OpenTAP version from Nuget, using the local version instead.");
-                // cannot get opentap version. Try something else..
-                var v2 = new Installation(Path.GetDirectoryName(typeof(ITestStep).Assembly.Location)).GetOpenTapPackage()?.Version;
-                if(v2 == null) // panic?
-                    v2 = new SemanticVersion(9, 8, 3, null, null);
-                version = new SemanticVersion(v2.Major, v2.Minor, v2.Patch, null, null);
-            }
-
-            return version;
-        }
-
-        private void CreateSolutionFile(DirectoryInfo dest)
-        {
-            var slnFile = dest.EnumerateFiles("*.sln").FirstOrDefault();
-            bool newProject = slnFile == null;
-            if (newProject)
-            {
-                var slnFileName = Path.Combine(dest.FullName, Name + ".sln");
-                using (var reader = new StreamReader(Assembly.GetExecutingAssembly().GetManifestResourceStream("OpenTap.Sdk.New.Resources.newProjectSlnTemplate.txt")))
-                {
-                    var content = ReplaceInTemplate(reader.ReadToEnd(), Name, Guid.NewGuid().ToString().ToUpper());
-                    WriteFile(slnFileName, content);
-                    log.Info("The solution file keeps track of all the projects in this directory.");
-                    log.Info("When you create new projects in this directory with the 'tap sdk new project' command, they are automatically added to the solution.\n");
-                }
-                
-                if (dest.EnumerateFiles("Directory.Build.props").Any() == false)
-                {
-                    using (var reader = new StreamReader(Assembly.GetExecutingAssembly()
-                        .GetManifestResourceStream("OpenTap.Sdk.New.Resources.Directory.Build.props.txt")))
-                    {
-                        var version = GetOpenTapVersion();
-                        var content = ReplaceInTemplate(reader.ReadToEnd(), version.ToString());
-                        WriteFile(Path.Combine(dest.FullName, "Directory.Build.props"), content);
-                        log.Info("'Directory.Build.props' contains solution-wide settings. " +
-                                 "Its primary purpose is to ensure that all your projects use the same version of OpenTAP, and build into the same directory.\n");
-                    }
-                }
-            }
-            else
-            {
-                AddProjectToSolutionFile(Name, slnFile);
-                log.Info($"Added project {Name} to solution {slnFile.FullName}");
-            }
-            
-        }
 
         public override int Execute(CancellationToken cancellationToken)
         {
@@ -87,212 +51,71 @@ namespace OpenTap.Sdk.New
                 return (int)ExitCodes.ArgumentError;
             }
 
-            var dest = string.IsNullOrWhiteSpace(output) ? new DirectoryInfo(WorkingDirectory) : new DirectoryInfo(output);
-            
-            if (!dest.Exists)
+            int exitCode = DotnetNew(Name, output, cancellationToken);
+            if (exitCode == TemplateNotFound)
             {
-                log.Debug($"Creating '{dest.FullName}' as it does not exist.");
-                dest = Directory.CreateDirectory(dest.FullName);
-            }
-
-            var newProject = dest.EnumerateFiles("*.sln").Any() == false;            
-
-            if (newProject && string.IsNullOrWhiteSpace(output))
-            {
-                var exists = dest.EnumerateDirectories().FirstOrDefault(x => x.Name == Name);
-                dest = exists ?? new DirectoryInfo(Path.Combine(dest.FullName, Name)); 
-            }
-            
-            log.Info($"Creating project in '{dest.FullName}'");
-
-            if (dest.Exists && dest.EnumerateDirectories().Any(x => x.Name == Name))
-            {
-                if (newProject)
-                    throw new Exception($"Cannot create solution directory {Name} because a directory with that name already exists.");
-                throw new Exception($"Project '{Name}' already exists in this solution.");
-            }
-
-            if (newProject)
-            {
-                var parentInstall = GetAncestorTapInstall(dest);
-                if (parentInstall != null)
+                var question = new InstallTemplateQuestion();
+                UserInput.Request(question, true);
+                if (question.Response == InstallTemplateResponse.Yes)
                 {
-                    // warn about potential issues and prompt to continue
-                    log.Warning($"OpenTAP installation detected in directory '{parentInstall.DirectoryName}'.\n" +
-                                $"Creating a project as a descendant of another OpenTAP installation can cause the installation to stop working correctly.\n");
+                    exitCode = InstallTemplate(cancellationToken);
+                    if (exitCode == 0)
+                        exitCode = DotnetNew(Name, output, cancellationToken);
+                }
+            }
+            return exitCode;
+        }
 
-                    log.Info("Are you sure you want to continue?");
-
-                    var request = new OverrideRequest();
-                    UserInput.Request(request, true);
-
-                    if (request.Override == RequestEnum.No)
+        private static void WaitForExit(Process p, CancellationToken token)
+        {
+            var evt = new ManualResetEventSlim(false);
+            var trd = TapThread.Start(() =>
                     {
-                        log.Info("Project creation cancelled.");
-                        return (int)ExitCodes.Success;
-                    }
-                }
-            }
+                        while (!p.WaitForExit(100) && !token.IsCancellationRequested)
+                        {
+                            // wait
+                        }
 
-            if (!dest.Exists)
-                dest.Create();
+                        evt.Set();
+                    });
 
-            CreateSolutionFile(dest);
-
-            dest = dest.CreateSubdirectory(Name);
-            
-            var csprojFile = Path.Combine(dest.FullName, Name + ".csproj");
-
-            using (var reader = new StreamReader(Assembly.GetExecutingAssembly()
-                .GetManifestResourceStream("OpenTap.Sdk.New.Resources.csprojTemplate.txt")))
-            {
-                var content = reader.ReadToEnd();
-                WriteFile(csprojFile, content);
-            }
-            log.Info("The '.csproj' file contains the configuration specific to this project.\n");
-
-            new GenerateTestStep() { Name = Name, WorkingDirectory = dest.FullName, output = Path.Combine(dest.FullName, $"{Name}.cs") }.Execute(cancellationToken);
-            log.Info("This is a basic TestStep.\n");
-
-            new GeneratePackageXml() { Name = Name, WorkingDirectory = dest.FullName, output = Path.Combine(dest.FullName, "package.xml") }.Execute(cancellationToken);
-            log.Info("The 'package.xml' file tells OpenTAP which files to package when creating a '.TapPackage'. ");
-            log.Info("When building in release mode, OpenTAP will attempt to build a TapPackage according to the contents of this file. ");
-            log.Info("Alternatively, you can build a package manually with 'tap package create path/to/package.xml'.\n");
-
-            if (newProject)
-            {
-                log.Info($"After you build this project, OpenTAP will be installed in '{(Path.Combine(dest.Parent.FullName, "bin", "Debug"))}'");
-            }
-
-            log.Info("Build the project and use an editor to create a test plan to use your new test step! See https://doc.opentap.io/User%20Guide/Editors/ for more info on the different editors!");
-            return (int)ExitCodes.Success;
+            WaitHandle.WaitAny(new[] { token.WaitHandle, evt.WaitHandle });
+            token.ThrowIfCancellationRequested();
         }
 
-        private FileInfo GetAncestorTapInstall(DirectoryInfo dest)
+        private static int InstallTemplate(CancellationToken token)
         {
-            if (dest == null)
-                return null;
-            
-            if (dest.Exists)
-            {
-                var ignore = dest.EnumerateFiles().FirstOrDefault(x => x.Name == ".OpenTapIgnore");
-                if (ignore != null) return null;
+            var sdk = Installation.Current.FindPackage("SDK");
+            var template = sdk.Files.First(f => Path.GetExtension(f.FileName) == ".nupkg");
+            var fn = Path.Combine(Installation.Current.Directory, template.FileName);
 
-                var file = dest.EnumerateFiles().FirstOrDefault(x => x.Name == "OpenTap.dll");
-                if (file != null)
-                {
-                    return file;
-                }
-            }
-            
-            return GetAncestorTapInstall(dest.Parent);
+            var si = new ProcessStartInfo("dotnet", $"new --install \"{fn}\"")
+            {
+                UseShellExecute = true,
+            };
+
+            var p = new Process() { StartInfo = si };
+            p.Start();
+            WaitForExit(p, token);
+            return p.ExitCode;
         }
 
-        private void AddProjectToSolutionFile(string name, FileInfo slnFile)
+        private static int DotnetNew(string projectName, string directory, CancellationToken token)
         {
-            var newGuid = Guid.NewGuid().ToString().ToUpper();
-            
-            string solution = "";
-                
-            using (var reader = new StreamReader(slnFile.FullName))
+            var args = $"new opentap --name \"{projectName}\"";
+            if (!string.IsNullOrWhiteSpace(directory))
+                args += $" --output \"{directory}\"";
+            var si = new ProcessStartInfo("dotnet", args)
             {
-                solution = reader.ReadToEnd();
-            }
-            
-            // First add the project to the solution
-            var projectLine =
-                $"Project(\"{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}\") = \"{Name}\", \"{Name}/{Name}.csproj\", \"{{{newGuid}}}\"\nEndProject\n";
+                UseShellExecute = true,
+            };
 
-            // Insert the new project before the EndProject tag
-            var lastProjectLoc = solution.IndexOf("Global");
-            solution = solution.Substring(0, lastProjectLoc) + projectLine + solution.Substring(lastProjectLoc, solution.Length - lastProjectLoc);
-            
-            // Then add the project to the existing build configurations
-            var configurationBlockRE = new Regex(@" +GlobalSection\(ProjectConfigurationPlatforms\) += +postSolution");
-            var lines = solution.Split('\n').Select(x => x.TrimEnd()).ToList();
-            int index = -1;
-            for (int i = 0; i < lines.Count; i++)
-            {
-                var line = lines[i];
-                if (configurationBlockRE.Match(line).Success)
-                {
-                    index = i + 1; // Configurations start on the next line
-                    break;
-                }
-            }
+            var p = new Process() { StartInfo = si };
+            p.Start();
 
-            // Skip configuration generation if no configuration block is found
-            if (index != -1)
-            {
-                var configurations = new List<string>();
+            WaitForExit(p, token);
 
-                while (lines[index].Contains("EndGlobalSection") == false && index < lines.Count)
-                {
-                    var line = lines[index];
-                    var configStart = line.IndexOf('}') + 1;
-                    var config = line.Substring(configStart);
-                    configurations.Add(config.Trim());
-                    index++;
-                }
-
-                configurations.Reverse();
-                
-                foreach (var configuration in configurations)
-                {
-                    var padding = lines[index - 1].IndexOf('{');
-                    
-                    lines.Insert(index, "".PadLeft(padding) + "{" + newGuid + "}" + configuration);
-                }
-
-                solution = string.Join(Environment.NewLine, lines);
-            }
-
-            using (var writer = new StreamWriter(slnFile.FullName))
-            {
-                writer.Write(solution);
-            }
+            return p.ExitCode;
         }
     }
-
-    class NugetInterop
-    {
-        /// <summary> Gets all the available OpenTAP versions from Nuget (api.nuget.org) or returns null on a failure (unable to connect). It never throws. </summary> 
-        public static SemanticVersion GetLatestNugetVersion()
-        {
-            var log = Log.CreateSource("Nuget");
-            
-            try
-            {
-                using (var http = new HttpClient())
-                {
-                    var sw = Stopwatch.StartNew();
-                    var stringTask = http.GetAsync("https://api-v2v3search-0.nuget.org/query?q=packageid:opentap&prerelease=false");
-                    log.Debug("Getting the latest OpenTAP Nuget package version. This can be changed in the project settings.");
-                    while (!stringTask.Wait(1000, TapThread.Current.AbortToken))
-                    {
-                        if (sw.ElapsedMilliseconds > 10000)
-                            return null;
-                        log.Debug("Waiting for response from nuget... ");
-                    }
-
-                    var str = stringTask.Result;
-
-                    log.Debug(sw, "Got response from server");
-                    var content = str.Content.ReadAsStringAsync().Result;
-                    
-                    var j = JObject.Parse(content);
-                    log.Debug("Parsed JSON content");
-                    if (SemanticVersion.TryParse(j["data"][0]["version"].Value<string>(), out SemanticVersion v))
-                        return v;
-                    return null;
-                }
-            }
-            catch
-            {
-                log.Warning("Failed to get a response from Nuget server.");
-                return null;
-            }
-        }
-    }
-
 }

--- a/sdk/OpenTap.Sdk.New/GenerateProject.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateProject.cs
@@ -234,8 +234,15 @@ namespace OpenTap.Sdk.New
         private static int InstallTemplate(CancellationToken token)
         {
             var sdk = Installation.Current.FindPackage("SDK");
-            var template = sdk.Files.First(f => Path.GetExtension(f.FileName) == ".nupkg");
+            if (sdk == null)
+                throw new ExitCodeException(1, "Package SDK is not installed.");
+            var template = sdk.Files.FirstOrDefault(f => Path.GetExtension(f.FileName) == ".nupkg");
+            if (template == null)
+                throw new ExitCodeException(2, "Unable to find template package. Is the SDK package installed?");
             var fn = Path.Combine(Installation.Current.Directory, template.FileName);
+            if (!File.Exists(fn))
+                throw new ExitCodeException(3,
+                    "Template package does not exist. The SDK package may be broken. Please reinstall SDK.");
 
             var si = new ProcessStartInfo("dotnet", $"new --install \"{fn}\"")
             {

--- a/sdk/OpenTap.Sdk.New/GenerateProject.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateProject.cs
@@ -9,7 +9,11 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Reflection;
 using System.Threading;
+using System.Xml.Linq;
+using Newtonsoft.Json.Linq;
 
 namespace OpenTap.Sdk.New
 {
@@ -28,21 +32,42 @@ namespace OpenTap.Sdk.New
 
             [Browsable(true)]
             [Layout(LayoutMode.FullRow)]
-            public string Message => "OpenTAP dotnet new templates are not installed. Do you wish to install the templates?";
+            public string Message =>
+                "OpenTAP dotnet new templates are not installed. Do you wish to install the templates?";
+
             [Layout(LayoutMode.FullRow | LayoutMode.FloatBottom)]
-            [Submit] public InstallTemplateResponse Response { get; set; } = InstallTemplateResponse.Yes;
+            [Submit]
+            public InstallTemplateResponse Response { get; set; } = InstallTemplateResponse.Yes;
         }
 
         #region ExitCodes
+
         // Exit codes are documented here: https://github.com/dotnet/templating/wiki/Exit-Codes
         private const int TemplateNotFound = 103;
+
         #endregion
 
         [CommandLineArgument("out", ShortName = "o", Description = "Destination directory for generated files.")]
-        public override string output { get => base.output; set => base.output = value; }
+        public override string output
+        {
+            get => base.output;
+            set => base.output = value;
+        }
 
         [UnnamedCommandLineArgument("name", Required = true)]
         public string Name { get; set; }
+
+        private static bool IsAncestor(DirectoryInfo root, DirectoryInfo dest)
+        {
+            while (dest != null)
+            {
+                if (root.FullName.Equals(dest.FullName))
+                    return true;
+                dest = dest.Parent;
+            }
+
+            return false;
+        }
 
         public override int Execute(CancellationToken cancellationToken)
         {
@@ -51,7 +76,59 @@ namespace OpenTap.Sdk.New
                 return (int)ExitCodes.ArgumentError;
             }
 
-            int exitCode = DotnetNew(Name, output, cancellationToken);
+            var dest = string.IsNullOrWhiteSpace(output)
+                ? new DirectoryInfo(WorkingDirectory)
+                : new DirectoryInfo(output);
+            if (!dest.Exists) dest.Create();
+            var sln = dest.EnumerateFiles("*.sln").FirstOrDefault();
+
+            if (sln == null)
+            {
+                // Check if there is a solution file in the working directory, and if the working directory is an ancestor of the destination
+                var workingDirectory = new DirectoryInfo(WorkingDirectory);
+                if (IsAncestor(workingDirectory, dest))
+                    sln = workingDirectory.EnumerateFiles("*.sln").FirstOrDefault();
+            }
+
+            bool newSolution = sln == null;
+            if (sln == null)
+            {
+                // create solution file.
+                // If an output folder was specified, put the solution file there.
+                // If no output folder was specified, create a directory and put the solution there.
+                if (string.IsNullOrWhiteSpace(output))
+                    dest = dest.CreateSubdirectory(Name);
+
+                int result = DotnetNew(Name, dest, "sln", cancellationToken);
+                sln = dest.EnumerateFiles("*.sln").FirstOrDefault();
+                if (result != 0 || sln == null || !sln.Exists)
+                {
+                    return result;
+                } 
+
+                // Create a Directory.Build.Props file for the new solution
+                if (dest.EnumerateFiles("Directory.Build.props").Any() == false)
+                {
+                    using var reader = new StreamReader(Assembly.GetExecutingAssembly()!
+                        .GetManifestResourceStream("OpenTap.Sdk.New.Resources.Directory.Build.props.txt")!);
+                    var version = GetOpenTapVersion();
+                    var content = ReplaceInTemplate(reader.ReadToEnd(), version.ToString());
+                    WriteFile(Path.Combine(dest.FullName, "Directory.Build.props"), content);
+                    log.Info("'Directory.Build.props' contains solution-wide settings. " +
+                             "Its primary purpose is to ensure that all your projects use the same version of OpenTAP, and build into the same directory.\n");
+                }
+            } 
+
+            // BUG: creating new project with --out location causes
+            // solution and project to be created in the same directory 
+            
+            // If no output directory was requested, or if we just created a new solution in the requested directory,
+            // put the project in a directory of the same name in the solution directory
+            if (string.IsNullOrWhiteSpace(output) || newSolution)
+                dest = sln.Directory.CreateSubdirectory(Name);
+
+            // Create the new project
+            int exitCode = DotnetNew(Name, dest, "opentap", cancellationToken);
             if (exitCode == TemplateNotFound)
             {
                 var question = new InstallTemplateQuestion();
@@ -60,24 +137,58 @@ namespace OpenTap.Sdk.New
                 {
                     exitCode = InstallTemplate(cancellationToken);
                     if (exitCode == 0)
-                        exitCode = DotnetNew(Name, output, cancellationToken);
+                        exitCode = DotnetNew(Name, dest, "opentap", cancellationToken);
                 }
             }
+
+            if (exitCode != 0)
+                return exitCode;
+
+            var csproj = dest.EnumerateFiles("*.csproj").First();
+            
+            // Update the OpenTAP version in the .csproj if a Directory.Build.props file exists.
+            if (sln.Directory.EnumerateFiles("Directory.Build.props").Any())
+                ReplaceVersion(csproj);
+            
+            
+            // add the new project to the solution
+            exitCode = DotnetSlnAdd(sln, csproj, cancellationToken);
+
             return exitCode;
+        }
+
+        private static void ReplaceVersion(FileInfo csproj)
+        {
+            // The nuget .csproj templates specify an OpenTAP version. The OpenTAP version is already controlled
+            // from the build props file. Update OpenTAP versions from the .csproj to use the variable instead.
+            var doc = XElement.Load(csproj.FullName);
+            var itemgroups = doc.Elements("ItemGroup").ToArray();
+            foreach (var grp in itemgroups)
+            {
+                var refs = grp.Elements("PackageReference").ToArray();
+                foreach (var r in refs)
+                {
+                    if (r?.Attribute("Include")?.Value == "OpenTAP")
+                    { 
+                        r.SetAttributeValue("Version", "$(OpenTapVersion)");
+                    }
+                }
+            }
+            doc.Save(csproj.FullName);
         }
 
         private static void WaitForExit(Process p, CancellationToken token)
         {
             var evt = new ManualResetEventSlim(false);
             var trd = TapThread.Start(() =>
-                    {
-                        while (!p.WaitForExit(100) && !token.IsCancellationRequested)
-                        {
-                            // wait
-                        }
+            {
+                while (!p.WaitForExit(100) && !token.IsCancellationRequested)
+                {
+                    // wait
+                }
 
-                        evt.Set();
-                    });
+                evt.Set();
+            });
 
             WaitHandle.WaitAny(new[] { token.WaitHandle, evt.WaitHandle });
             token.ThrowIfCancellationRequested();
@@ -100,15 +211,14 @@ namespace OpenTap.Sdk.New
             return p.ExitCode;
         }
 
-        private static int DotnetNew(string projectName, string directory, CancellationToken token)
+        private static int RunDotnet(string args, CancellationToken token)
         {
-            var args = $"new opentap --name \"{projectName}\"";
-            if (!string.IsNullOrWhiteSpace(directory))
-                args += $" --output \"{directory}\"";
             var si = new ProcessStartInfo("dotnet", args)
             {
                 UseShellExecute = true,
             };
+
+            log.Info($"Running dotnet {args}");
 
             var p = new Process() { StartInfo = si };
             p.Start();
@@ -116,6 +226,84 @@ namespace OpenTap.Sdk.New
             WaitForExit(p, token);
 
             return p.ExitCode;
+
+        }
+
+        private static int DotnetNew(string projectName, DirectoryInfo directory, string template,
+            CancellationToken token)
+        {
+            var args = $"new {template} --name \"{projectName}\" --output \"{directory.FullName}\"";
+            return RunDotnet(args, token);
+        }
+
+        private static int DotnetSlnAdd(FileInfo sln, FileInfo csproj, CancellationToken token)
+        {
+            // dotnet sln <SLN_FILE> add [<PROJECT_PATH>...] [options]
+            var args = $"sln \"{sln.FullName}\" add \"{csproj.FullName}\"";
+            return RunDotnet(args, token);
+        }
+
+        private static SemanticVersion _opentapVersion = null;
+        private SemanticVersion GetOpenTapVersion()
+        {
+            if (_opentapVersion == null)
+                _opentapVersion = NugetInterop.GetLatestNugetVersion();
+            
+            if (_opentapVersion == null)
+            {
+                log.Warning("Unable to get an OpenTAP version from Nuget, using the local version instead.");
+                // cannot get opentap version. Try something else..
+                var v2 = new Installation(Path.GetDirectoryName(typeof(ITestStep).Assembly.Location))
+                    .GetOpenTapPackage()?.Version;
+                if (v2 == null) // panic?
+                    v2 = new SemanticVersion(9, 24, 0, null, null);
+                _opentapVersion = new SemanticVersion(v2.Major, v2.Minor, v2.Patch, null, null);
+            }
+
+            return _opentapVersion;
+        }
+    }
+
+    class NugetInterop
+    {
+        /// <summary> Gets all the available OpenTAP versions from Nuget (api.nuget.org) or returns null on a failure (unable to connect). It never throws. </summary> 
+        public static SemanticVersion GetLatestNugetVersion()
+        {
+            var log = Log.CreateSource("Nuget");
+
+            try
+            {
+                using (var http = new HttpClient())
+                {
+                    var sw = Stopwatch.StartNew();
+                    var stringTask =
+                        http.GetAsync("https://api-v2v3search-0.nuget.org/query?q=packageid:opentap&prerelease=false");
+                    log.Debug(
+                        "Getting the latest OpenTAP Nuget package version. This can be changed in the project settings.");
+                    while (!stringTask.Wait(1000, TapThread.Current.AbortToken))
+                    {
+                        if (sw.ElapsedMilliseconds > 10000)
+                            return null;
+                        log.Debug("Waiting for response from nuget... ");
+                    }
+
+                    var str = stringTask.Result;
+
+                    log.Debug(sw, "Got response from server");
+                    var content = str.Content.ReadAsStringAsync().Result;
+
+                    var j = JObject.Parse(content);
+                    log.Debug("Parsed JSON content");
+                    if (SemanticVersion.TryParse(j["data"][0]["version"].Value<string>(), out SemanticVersion v))
+                        return v;
+                    return null;
+                }
+            }
+            catch
+            {
+                log.Warning("Failed to get a response from Nuget server.");
+                return null;
+            }
         }
     }
 }

--- a/sdk/OpenTap.Sdk.New/GenerateType.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateType.cs
@@ -55,7 +55,7 @@ namespace OpenTap.Sdk.New
             return false;
         }
 
-        public TraceSource log = Log.CreateSource("New");
+        public static TraceSource log = Log.CreateSource("New");
 
         [CommandLineArgument("out", ShortName = "o", Description = "Path to generated file.")]
         public virtual string output { get; set; }


### PR DESCRIPTION
Use the new `dotnet new` template in favor of the old `tap sdk new project` logic.

The dotnet template supports a bunch of configuration flags that I have not added, but should be pretty simple to add as CLI options if we want:

This is part of an ongoing effort to maintain fewer SDKs. We are currently maintaining 3 SDKs. We would like to maintain only one.

Closes #1319 