### PR TITLE
1507 Fix null parent annotation

### DIFF
--- a/Engine/ParameterMemberAnnotator.cs
+++ b/Engine/ParameterMemberAnnotator.cs
@@ -97,9 +97,9 @@ namespace OpenTap
             if (cache == null)
             {
                 cache = new AnnotationCache();
-                annotation.ParentAnnotation.Add(cache);
+                annotation.ParentAnnotation?.Add(cache);
             }
-            var subannotation = cache?.Annotate(items) ?? AnnotationCollection.Annotate(items.Length == 1 ? items[0] : items);
+            var subannotation = cache.Annotate(items) ?? AnnotationCollection.Annotate(items.Length == 1 ? items[0] : items);
             annotation.Add(new SubMember(subannotation, bigList, member));
             var subMembers = subannotation.Get<IMembersAnnotation>();
             var firstmem = parameterizedMembers.First().Item2;


### PR DESCRIPTION
This adds a null check preventing an unhandled exception when running e.g. `AnnotationCollection.Annotate` on a SweepLoop directly, which will not have a parent annotation in this instance.

This fixes a bug introduced in 9.16.1 when we added a cache in this particular annotator.

Closes #1507 