### PR TITLE
1521 improve resolver errors

### DIFF
--- a/Package.UnitTests/Image/Deploy.cs
+++ b/Package.UnitTests/Image/Deploy.cs
@@ -289,43 +289,6 @@ namespace OpenTap.Image.Tests
             }
         }
 
-
-        [Test]
-        public void DeployWithOfflineRepoNoErrors()
-        {
-            using var tempInstall = new TempInstall();
-            using var s = Session.Create();
-            var evt = new EventTraceListener();
-            var logs = new List<Event>();
-            evt.MessageLogged += events =>
-            {
-                logs.AddRange(events.Where(e => e.EventType == (int) LogEventType.Error));
-            };
-            Log.AddListener(evt);
-
-            try
-            {
-                var imageSpecifier = MockRepository.CreateSpecifier();
-                imageSpecifier.Packages.Add(new PackageSpecifier("REST-API", new VersionSpecifier(2, 6, 3, null, null, VersionMatchBehavior.Exact)));
-                imageSpecifier.Repositories.Add("http://some-non-existing-repo.opentap.io");
-                var identifier = imageSpecifier.Resolve(CancellationToken.None);
-
-                identifier.Deploy(tempInstall.Directory, CancellationToken.None);
-                Installation installation = tempInstall.Installation;
-                var nonSystemWidePackages = installation.GetPackages().Where(s => s.Class != "system-wide").ToList();
-                Assert.AreEqual(3, nonSystemWidePackages.Count);
-                Assert.IsTrue(nonSystemWidePackages.Any(s => s.Name == "REST-API" && s.Version.ToString().StartsWith("2.6.3")));
-                Assert.IsTrue(nonSystemWidePackages.Any(s => s.Name == "OpenTAP" && s.Version.ToString().StartsWith("9.16.0")));
-                Assert.IsTrue(nonSystemWidePackages.Any(s => s.Name == "Keysight Floating Licensing" && s.Version.ToString().StartsWith("1.0.44")));
-            }
-            catch
-            {
-                Assert.Fail();
-            }
-
-            CollectionAssert.IsEmpty(logs);
-        }
-
         [Test]
         public void Cache()
         {

--- a/Package/Image/PackageDependencyGraph.cs
+++ b/Package/Image/PackageDependencyGraph.cs
@@ -147,15 +147,12 @@ namespace OpenTap.Package
                 dependencies[(id, GetVersionId(version))] = deps;
             }
         }
-        
+
         /// <summary>
         /// This is only used in unittests. It works for respones from the 3.1/query API, but not the 4.0/query API.
         /// </summary>
-        /// <param name="json"></param>
-        public void LoadFromJson(JsonDocument json)
+        public void LoadFromJson(JsonElement packages)
         {
-            var packages = json.RootElement.GetProperty("packages");
-
             int addPackages = 0;
             foreach (var elem in packages.EnumerateArray())
             {

--- a/Package/Image/PackageDependencyQuery.cs
+++ b/Package/Image/PackageDependencyQuery.cs
@@ -1,15 +1,13 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-using OpenTap.Authentication;
-using OpenTap.Repository.Client;
 
 namespace OpenTap.Package
 {
@@ -34,17 +32,78 @@ namespace OpenTap.Package
             CpuArchitecture deploymentInstallationArchitecture, string preRelease = "", string name = null)
         {
             var sw = Stopwatch.StartNew();
-            var repoClient = HttpPackageRepository.GetAuthenticatedClient(new Uri(repoUrl, UriKind.Absolute));
-            
-            var parameters = HttpPackageRepository.GetQueryParameters(version: VersionSpecifier.TryParse(preRelease, out var spec) ? spec : VersionSpecifier.AnyRelease, os: os,
+            var httpClient = HttpPackageRepository.GetAuthenticatedClient(new Uri(repoUrl, UriKind.Absolute)).HttpClient;
+            httpClient.DefaultRequestHeaders.Add("WWW-Authenticate", "token");
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            var parameters = HttpPackageRepository.GetQueryParameters(
+                version: VersionSpecifier.TryParse(preRelease, out var spec) ? spec : VersionSpecifier.AnyRelease,
+                os: os,
                 architecture: deploymentInstallationArchitecture, name: name);
-            
-            var result = repoClient.Query(parameters, CancellationToken.None, "name", "version",
-                new QuerySelection("dependencies", new List<QuerySelection>() { "name", "version" }));
-            var graph = new PackageDependencyGraph();
-            graph.LoadFromDictionaries(result);
-            log.Debug(sw, "{1} -> found {0} packages.", graph.Count, JsonSerializer.Serialize(parameters));
-            return graph;
+
+            string maybeQuote(object o)
+            {
+                if (o is string s)
+                    return $"\"{s}\"";
+                return o.ToString();
+            }
+
+            var parameterString = string.Join(", ", parameters.Select(kvp => $"{kvp.Key}: {maybeQuote(kvp.Value)}"));
+
+            var graphqlQuery = $@"query Query {{ 
+    objects({parameterString}) {{
+        name
+        version
+        dependencies {{
+            name
+            version
+        }}
+    }}
+}}";
+            var postTo = repoUrl.TrimEnd('/') + "/4.0/query";
+            var req = new HttpRequestMessage(HttpMethod.Post, postTo);
+            req.Content = new StringContent(graphqlQuery, Encoding.UTF8, "application/json");
+            req.Headers.Add("Accept", "application/json");
+            var res = httpClient.SendAsync(req).Result;
+            if (res.IsSuccessStatusCode)
+            {
+                var graph = new PackageDependencyGraph();
+                var packages = res.Content.ReadAsStringAsync().Result;
+                {
+                    var json = JsonDocument.Parse(packages);
+                    var data = json.RootElement.GetProperty("data");
+                    var objects = data.GetProperty("objects");
+                    // The result will be wrapped in { "data": { "objects": ... } }
+                    // We need to unwrap it a bit
+                    // json = json.RootElement.GetProperty()
+                    graph.LoadFromJson(objects);
+                }
+                log.Debug(sw, "{1} -> found {0} packages.", graph.Count, JsonSerializer.Serialize(parameters));
+                return graph;
+            }
+
+            if (res.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                if (res.Headers.TryGetValues("WWW-Authenticate", out var authErrors))
+                {
+                    // This is usually a single value similar to:
+                    // Token error=invalid_token, error_description=Invalid User Token.
+                    var errors = authErrors.ToArray();
+                    foreach (var err in errors)
+                    {
+                        if (err.Contains("error_description="))
+                        {
+                            var errstring = err.Split('=').LastOrDefault();
+                            if (errstring != null) throw new Exception($"Unauthorized: {errstring}");
+                        }
+                    }
+
+                    // This should not happen, but to be safe
+                    var fallback = string.Join("\n", errors);
+                    throw new Exception($"Unauthorized: {fallback}");
+                }
+            } 
+            throw new Exception($"{(int)res.StatusCode} {res.StatusCode}.");
         }
 
         /// <summary>
@@ -60,7 +119,8 @@ namespace OpenTap.Package
             
             var graph = new PackageDependencyGraph();
             var doc = JsonDocument.Parse(stream);
-            graph.LoadFromJson(doc);
+            var packages = doc.RootElement.GetProperty("packages");
+            graph.LoadFromJson(packages);
             if (compressed)
                 stream.Dispose();
             return graph;

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -46,6 +46,7 @@ namespace OpenTap.Package
 
         protected override int LockedExecute(CancellationToken cancellationToken)
         {
+            Repositories = ExtractRepositoryTokens(Repositories, true);
             if (NonInteractive)
                 UserInput.SetInterface(new NonInteractiveUserInputInterface());
 

--- a/Package/Repositories/HttpPackageRepository.cs
+++ b/Package/Repositories/HttpPackageRepository.cs
@@ -175,7 +175,11 @@ namespace OpenTap.Package
             catch (Exception ex)
             {
                 if (ex is WebException)
+                {
                     CheckRepoApiVersion();
+                    if (IsInError())
+                        log.Warning("Unable to connect to: {0}", Url); 
+                }
 
                 var exception = new WebException("Error communicating with repository at '" + defaultUrl + "'.", ex);
 
@@ -209,7 +213,7 @@ namespace OpenTap.Package
                 }
                 catch
                 {
-                    log.Warning("Unable to connect to: {0}", Url);
+                    // suppress
                 }
                 nextUpdateAt = DateTime.Now + updateRepoVersionHoldOff;
             }
@@ -417,7 +421,11 @@ namespace OpenTap.Package
         {
             // force update version to check for errors.
             CheckRepoApiVersion();
-            if (IsInError()) return Array.Empty<PackageVersion>();
+            if (IsInError())
+            {
+                log.Warning("Unable to connect to: {0}", Url); 
+                return Array.Empty<PackageVersion>();
+            }
 
             var parameters = GetQueryParameters(name: packageName);
 


### PR DESCRIPTION
Fix bug causing tokens not to be extracted in image installs.
Also adds nice error messages when resolution goes wrong due error response from repository.
Closes #1521