### PR TITLE
Include group names in output selection dialog

### DIFF
--- a/Engine.UnitTests/InputOutputRelationTest.cs
+++ b/Engine.UnitTests/InputOutputRelationTest.cs
@@ -467,6 +467,31 @@ namespace OpenTap.UnitTests
         }
 
         [Test]
+        [TestCase("Iteration", "3 of 3")]
+        [TestCase("Outputs \\ Iteration", "3")]
+        public void TestInputOutputNameClash(string output, string expected)
+        {
+            var plan = new TestPlan();
+            var repeat = new RepeatStep();
+            var step = new InputOutputTypesStep();
+            plan.ChildTestSteps.Add(repeat);
+            plan.ChildTestSteps.Add(step);
+
+            var a = AnnotationCollection.Annotate(step);
+            var im = a.GetMember(nameof(step.StringInput));
+            var menu = im.Get<MenuAnnotation>();
+
+            var request = new SelectAssignmentFromAnnotationMenu();
+            UserInput.SetInterface(request);
+            request.SelectName = output;
+            menu.MenuItems.First(x => x.Get<IconAnnotationAttribute>()?.IconName == IconNames.AssignOutput)
+                .Get<IMethodAnnotation>().Invoke();
+
+            plan.Execute();
+            Assert.AreEqual(step.StringInput, expected);
+        }
+
+        [Test]
         public void TestInputOutputTypes()
         {
             var step1 = new InputOutputTypesStep();

--- a/Engine/AssignOutputDialog.cs
+++ b/Engine/AssignOutputDialog.cs
@@ -50,7 +50,7 @@ namespace OpenTap
                 return new SelectedOutputItem(testStepParent, mem);
             }
 
-            public override string ToString() => $"{Member.GetDisplayAttribute().Name} from {(Step as ITestStep).GetFormattedName() ?? "plan"}";
+            public override string ToString() => $"{Member.GetDisplayAttribute().GetFullName()} from {(Step as ITestStep).GetFormattedName() ?? "plan"}";
 
             public override bool Equals(object obj)
             {


### PR DESCRIPTION
This adds the group names to outputs to avoid confusion when duplicate names are used:

![image](https://github.com/opentap/opentap/assets/95965749/697349f5-1a70-4df2-9013-a14cefa1ee78)

I verified that this does not cause issues for serialization since we serialize the member name of the C# property, and not the display name.

Closes #1517