### PR TITLE
Flip arguments to CanConvert

### DIFF
--- a/Engine/AssignOutputDialog.cs
+++ b/Engine/AssignOutputDialog.cs
@@ -69,7 +69,7 @@ namespace OpenTap
                 .SelectMany(childStep =>
                 {
                     return TypeData.GetTypeData(childStep).GetMembers()
-                        .Where(y => y.HasAttribute<OutputAttribute>() && InputOutputRelation.CanConvert(y.TypeDescriptor, outputType))
+                        .Where(y => y.HasAttribute<OutputAttribute>() && InputOutputRelation.CanConvert(outputType,y.TypeDescriptor ))
                         .Select(mem => SelectedOutputItem.Create(childStep, mem));
                 })
                 .Where(item => steps.Contains(item.Step) == false)
@@ -77,7 +77,7 @@ namespace OpenTap
             
             // Add the current scope
             list.AddRange(TypeData.GetTypeData(scope).GetMembers()
-                .Where(y => y.HasAttribute<OutputAttribute>() && InputOutputRelation.CanConvert(y.TypeDescriptor, outputType))
+                .Where(y => y.HasAttribute<OutputAttribute>() && InputOutputRelation.CanConvert(outputType, y.TypeDescriptor))
                 .Select(mem => SelectedOutputItem.Create(scope, mem)));
 
             return list.ToArray();


### PR DESCRIPTION
Arguments to CanConvert are now in the correct order. This did not cause issues before because CanConvert was reflexive for primitive types (but not for complex types).