### PR TITLE
1542 Assign Enum To Number Bug: Fix

### DIFF
--- a/Engine.UnitTests/InputOutputRelationTest.cs
+++ b/Engine.UnitTests/InputOutputRelationTest.cs
@@ -588,6 +588,19 @@ namespace OpenTap.UnitTests
             }
         }
 
+        
+        [TestCase(typeof(Verdict), typeof(string), true)]
+        [TestCase(typeof(Verdict), typeof(double), false)]
+        [TestCase(typeof(double), typeof(Verdict), false)]
+        [TestCase(typeof(string), typeof(Verdict), false)]
+        public void TestCanConvertBehavior(Type from, Type to, bool canConvert)
+        {
+            var from2 = TypeData.FromType(from);
+            var to2 = TypeData.FromType(to);
+            var canConvertValue = InputOutputRelation.CanConvert(to2, from2);
+            Assert.AreEqual(canConvert, canConvertValue);
+        }
+
         [TestCase(true)]
         [TestCase(false)]
         public void TestInputAndOutputWithRemovedMixins(bool way)

--- a/Engine/InputOutputRelation.cs
+++ b/Engine/InputOutputRelation.cs
@@ -255,6 +255,14 @@ namespace OpenTap
                 return true;
             if (to is TypeData to2 && from is TypeData from2)
             {
+                if (from2.Type.IsEnum)
+                {
+                    // if from is an enum, it has TypeCode Int, but we dont allow assigning an enum to a int input.
+                    if (to2.IsString)
+                        return true;
+                    
+                    return false;
+                }
                 if (to2.IsNumeric || to2.IsString || to2.Type == typeof(bool))
                 {
                     switch (from2.TypeCode)


### PR DESCRIPTION
Fixed the issue by checking if the type is an enum in CanConvert. It is still allowed to assign the enum to a string.

Added unit test to verify the behavior.