### PR TITLE
1544 fix result listener race condition

### DIFF
--- a/Engine.UnitTests/ResultListeners/PlanRunCollectorListener.cs
+++ b/Engine.UnitTests/ResultListeners/PlanRunCollectorListener.cs
@@ -13,6 +13,8 @@ namespace OpenTap.Engine.UnitTests
         public List<TestPlanRun> PlanRuns = new List<TestPlanRun>();
         [XmlIgnore]
         public List<TestStepRun> StepRuns = new List<TestStepRun>();
+        [XmlIgnore]
+        public List<TestStepRun> StepRunStartEvents = new List<TestStepRun>();
 
         public string LogString;
 
@@ -30,6 +32,7 @@ namespace OpenTap.Engine.UnitTests
 
         public override void OnTestStepRunStart(TestStepRun stepRun)
         {
+            StepRunStartEvents.Add(stepRun);
             base.OnTestStepRunStart(stepRun);
         }
 

--- a/Engine/TestPlanRun.cs
+++ b/Engine/TestPlanRun.cs
@@ -368,7 +368,8 @@ namespace OpenTap
             {
                 try
                 {
-                    listener.OnTestStepRunStart(clone);
+                    // A result listener may modify the parameter. This should not affect other result listeners.
+                    listener.OnTestStepRunStart(clone.Clone());
 
                     if (listener is IExecutionListener ex)
                         ex.OnTestStepExecutionChanged(stepRun.TestStepId, stepRun, StepState.Running, instant);


### PR DESCRIPTION
This adds a couple of steprun related unit tests and fixes the issue by cloning the stepRun object for each result listener.

Closes #1544