### PR TITLE
Improve resolver errors again

### DIFF
--- a/Package/Image/ImageResolution.cs
+++ b/Package/Image/ImageResolution.cs
@@ -14,6 +14,7 @@ namespace OpenTap.Package
 
         public virtual bool Success => true;
 
-        public override string ToString() => string.Format("[ImageResolution: {0}", string.Join(", ", Packages.Select(x => $"{x.Name} {x.Version}")));
+        public override string ToString() =>
+            $"[ImageResolution: {string.Join(", ", Packages.Select(x => $"{x.Name} {x.Version}"))}";
     }
 }

--- a/Package/Image/ImageResolveException.cs
+++ b/Package/Image/ImageResolveException.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Package
+{
+    /// <summary>
+    /// Exception thrown when ImageSpecifier.Resolve fails.
+    /// </summary>
+    public class ImageResolveException : AggregateException
+    {
+        internal ImageSpecifier Image { get; }
+        internal ImmutableArray<PackageDef> InstalledPackages { get; }
+        internal ImageResolution Result { get; }
+
+        internal ImageResolveException(ImageResolution result, ImageSpecifier image,
+            ImmutableArray<PackageDef> installedPackages)
+        {
+            Result = result;
+            Image = image;
+            InstalledPackages = installedPackages;
+        }
+
+        /// <summary>
+        /// The description of the resolution error.
+        /// </summary>
+        public override string Message => ToString();
+
+        /// <summary>
+        /// Convert the resolution error to a string
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var unsatisfiedDependencies = new List<PackageDef>();
+            if (Result is FailedImageResolution fir && fir.Conflict != FailedImageResolution.ConflictType.Generic)
+            {
+                return fir.ToString();
+            }
+            
+            foreach (var pkg in InstalledPackages)
+            {
+                if (!pkg.Dependencies.All(dep => isSatisfied(dep, InstalledPackages)))
+                    unsatisfiedDependencies.Add(pkg);
+            }
+
+            if (unsatisfiedDependencies.Any())
+            {
+                var sb = new StringBuilder();
+                var namePadding = unsatisfiedDependencies.Max(n => n.Name.Length);
+                foreach (var sat in unsatisfiedDependencies)
+                {
+                    var missingDeps = sat.Dependencies.Where(dep => !isSatisfied(dep, InstalledPackages)).ToArray();
+                    missingDeps = missingDeps.Where(m =>
+                        this.Image.Packages.Where(p => p.Name == m.Name)
+                            .All(requested => !m.Version.IsSatisfiedBy(requested.Version))).ToArray();
+                    if (missingDeps.Any())
+                    {
+                        string missingMsg = string.Join(" and ",
+                            missingDeps.Select(pkg => $"{pkg.Name}:{pkg.Version}"));
+                        sb.AppendLine($"{sat.Name.PadRight(namePadding)} missing {missingMsg}");
+                    }
+                }
+
+                return $"Unable to resolve the packages: {Image}.\n" +
+                       $"This is probably due to:\n" +
+                       $"{sb}";
+            }
+
+            return Result.ToString();
+        }
+
+        static bool isSatisfied(PackageDependency dep, IEnumerable<PackageDef> InstalledPackages)
+        {
+            foreach (var i in InstalledPackages)
+            {
+                if (i.Name == dep.Name)
+                {
+                    if (dep.Version.IsSatisfiedBy(i.Version.AsExactSpecifier()))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+
+        /// <summary>
+        /// Dependency graph specified in Dot notation
+        /// </summary>
+        [Obsolete("This will always be null.")]
+        public string DotGraph { get; private set; }
+    }
+}

--- a/Package/Image/ImageSpecifier.cs
+++ b/Package/Image/ImageSpecifier.cs
@@ -220,26 +220,13 @@ namespace OpenTap.Package
     }
 
     /// <summary>
-    /// Exception thrown when ImageSpecifier.Resolve fails. The exception contains a dependency graph specified Dot notation.
+    /// Exception thrown when ImageSpecifier.Resolve fails.
     /// </summary>
     public class ImageResolveException : AggregateException
     {
-        internal readonly ImageSpecifier Image;
-        internal ImmutableArray<PackageDef> InstalledPackages = ImmutableArray<PackageDef>.Empty;
-
-        internal ImageResolveException(string dotGraph, string message, List<Exception> dependencyIssues) : base(message, dependencyIssues)
-        {
-            DotGraph = dotGraph;
-        }
-        internal ImageResolveException(ImageResolution result) : base(result.ToString())
-        {
-            Result = result;
-        }
-        
-        internal ImageResolveException(ImageResolution result, string message) : base(message)
-        {
-            Result = result;
-        }
+        internal ImageSpecifier Image { get; }
+        internal ImmutableArray<PackageDef> InstalledPackages { get; }
+        internal ImageResolution Result { get; }
         
         internal ImageResolveException(ImageResolution result, string message, ImageSpecifier image,
             ImmutableArray<PackageDef> installedPackages) : base(message)
@@ -249,11 +236,11 @@ namespace OpenTap.Package
             InstalledPackages = installedPackages;
         }
 
-        internal ImageResolution Result;
 
         /// <summary>
         /// Dependency graph specified in Dot notation
         /// </summary>
+        [Obsolete("This will always be null.")]
         public string DotGraph { get; private set; }
     }
 }

--- a/Package/Image/ImageSpecifier.cs
+++ b/Package/Image/ImageSpecifier.cs
@@ -125,25 +125,7 @@ namespace OpenTap.Package
             var image = resolver.ResolveImage(this, cache.Graph);
             if (image.Success == false)
             {
-                var unsatisfiedDependencies = InstalledPackages.Where(x => false == x.Dependencies.All(dep =>
-                    InstalledPackages.Any(x2 =>
-                        x2.Name == dep.Name && dep.Version.IsSatisfiedBy(x2.Version.AsExactSpecifier())))).ToArray();
-                if (unsatisfiedDependencies.Any())
-                {
-                    var unsatisfiedString = string.Join(" and ", unsatisfiedDependencies.Select(x =>
-                    {
-                        var missingDeps = x.Dependencies.Where(dep => !InstalledPackages.Any(x2 =>
-                            x2.Name == dep.Name && dep.Version.IsSatisfiedBy(x2.Version.AsExactSpecifier())));
-                        string missingMsg = string.Join(" and ", missingDeps.Select(x2 => $"{x2.Name}:{x2.Version}"));
-                        return $"{x.Name} missing {missingMsg}";
-                    }));
-                    throw new ImageResolveException(image,
-                        $"Unable to resolve the packages: {this}. This is probably due to: {unsatisfiedString}.",
-                        this,
-                        InstalledPackages
-                       );
-                }
-                throw new ImageResolveException(image, image.ToString(), this, InstalledPackages);
+                throw new ImageResolveException(image, this, InstalledPackages);
             }
             
             log.Debug(sw, "Resolved image: {0}", this);
@@ -217,30 +199,5 @@ namespace OpenTap.Package
         /// <summary> Turns an image into a readable string.</summary>
         /// <returns></returns>
         public override string ToString() => string.Join(", ", Packages.Select(x => $"{x.Name}:{x.Version}"));
-    }
-
-    /// <summary>
-    /// Exception thrown when ImageSpecifier.Resolve fails.
-    /// </summary>
-    public class ImageResolveException : AggregateException
-    {
-        internal ImageSpecifier Image { get; }
-        internal ImmutableArray<PackageDef> InstalledPackages { get; }
-        internal ImageResolution Result { get; }
-        
-        internal ImageResolveException(ImageResolution result, string message, ImageSpecifier image,
-            ImmutableArray<PackageDef> installedPackages) : base(message)
-        {
-            Result = result;
-            Image = image;
-            InstalledPackages = installedPackages;
-        }
-
-
-        /// <summary>
-        /// Dependency graph specified in Dot notation
-        /// </summary>
-        [Obsolete("This will always be null.")]
-        public string DotGraph { get; private set; }
     }
 }


### PR DESCRIPTION
This is part of an ongoing effort to make our resolver errors make sense.

The checks I have added are fairly ad-hoc, but they should mostly be correct in identifying issues.

Even if they are not completely correct, the errors we have today are mostly useless

Closes #1563 
Closes #1525 