### PR TITLE
upgrade macos test image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
             bin/Release/*
 
   Build-MacOS:
-    runs-on: macos-11
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -391,7 +391,7 @@ jobs:
       - run: bin/Release/tap run tests/regression.TapPlan --verbose --color
 
   TestMacPlan:
-    runs-on: macos-11
+    runs-on: macos-14
     needs: 
       - Build-MacOS
       - Package-Templates


### PR DESCRIPTION
macos-11 will be removed June 28, so let's upgrade it to the most recent version now