### PR TITLE
Upgrade System.Text.Encodings.Web to use the most secure version.

### DIFF
--- a/Engine/Tap.Engine.csproj
+++ b/Engine/Tap.Engine.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
System.Text.Json depends on System.Text.Encodings.Web internally