### PR TITLE
Update newtonsoft

### DIFF
--- a/Engine.UnitTests/AssemblyDataTest.cs
+++ b/Engine.UnitTests/AssemblyDataTest.cs
@@ -50,10 +50,10 @@ namespace OpenTap.UnitTests
             Assert.AreEqual(Version.Parse("3.0.1.0"), globAsm.Version);
             
             var newtonsoftAsm = s.Assemblies.FirstOrDefault(a => a.Name.Contains("Newtonsoft.Json"));
-            Assert.AreEqual(SemanticVersion.Parse("12.0.3"), SemanticVersion.Parse(newtonsoftAsm.SemanticVersion.ToString(3)));
+            Assert.AreEqual(SemanticVersion.Parse("13.0.3"), SemanticVersion.Parse(newtonsoftAsm.SemanticVersion.ToString(3)));
             // The newtonsoft package is actually version 12.0.0.3, but the assembly version is 12.0.0.0 for some reason.
             // This was changed in 9.18.2 due to a regression, but it has been so for a long long time.  
-            Assert.AreEqual(Version.Parse("12.0.0.0"), newtonsoftAsm.Version);
+            Assert.AreEqual(Version.Parse("13.0.0.0"), newtonsoftAsm.Version);
         }
 
         [Test]

--- a/Package/Tap.Package.csproj
+++ b/Package/Tap.Package.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.27.0.0-preview-0175" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Mono.Cecil" Version="0.10.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NuGet.Client" Version="4.2.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />


### PR DESCRIPTION
The only breaking change in this Newtonsoft major bump is a max limit on recursion depth during serialization. It should be safe to upgrade.

Closes #1599 