### PR TITLE
1589 make tap image browsable

### DIFF
--- a/Engine.UnitTests/TestTestSteps/PipingProcessStep.cs
+++ b/Engine.UnitTests/TestTestSteps/PipingProcessStep.cs
@@ -19,8 +19,7 @@ namespace OpenTap.Engine.UnitTests.TestTestSteps
             [Submit] public string Answer { get; set; }
         }
 
-        [CommandLineArgument("answers", ShortName = "a",
-            Description = "The answers that the caller is intending to give.")]
+        [CommandLineArgument("answers", ShortName = "a", Description = "The answers that the caller is intending to give.")]
         public string[] ExpectedAnswers { get; set; }
 
         private static TraceSource log = Log.CreateSource(nameof(UserInputTestAction));

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -8,33 +8,33 @@ using System.Threading;
 
 namespace OpenTap.Package
 {
-    [Display("install", Group: "image")]
+    [Display("install", Description: "Install the specified image, overwriting the existing installation.", Group: "image")]
     internal class ImageInstallAction : IsolatedPackageAction
     {
         /// <summary>
         /// Path to Image file containing XML or JSON formatted Image specification, or just the string itself, e.g "REST-API,TUI:beta".
         /// </summary>
-        [UnnamedCommandLineArgument("image")]
+        [UnnamedCommandLineArgument("image", Required = true)]
         public string ImagePath { get; set; }
 
         /// <summary>
         /// Option to merge with target installation. Default is false, which means overwrite installation
         /// </summary>
-        [CommandLineArgument("merge")]
+        [CommandLineArgument("merge", Description = "Merge the requested image with the existing installation instead of overwriting it.")]
         public bool Merge { get; set; }
-        
+
         /// <summary> Never prompt for user input. </summary>
         [CommandLineArgument("non-interactive", Description = "Never prompt for user input.")]
         public bool NonInteractive { get; set; } = false;
-        
+
         /// <summary> Which operative system to resolve packages for. </summary>
-        [CommandLineArgument("os", Description = "Specify which operative system to resolve packages for.")]
+        [CommandLineArgument("os", Description = "The operating system to resolve packages for.")]
         public string Os { get; set; }
 
         /// <summary> Which CPU architecture to resolve packages for. </summary>
-        [CommandLineArgument("architecture", Description = "Specify which architecture to resolve packages for.")]
+        [CommandLineArgument("architecture", Description = "The architecture to resolve packages for.")]
         public CpuArchitecture Architecture { get; set; } = CpuArchitecture.Unspecified;
-        
+
         /// <summary> Resolve and print a summary of the changes that would be applied, but don't apply them. </summary>
         [CommandLineArgument("dry-run", Description = "Only print the result, don't install the packages.")]
         public bool DryRun { get; set; }
@@ -54,14 +54,14 @@ namespace OpenTap.Package
 
             if (string.IsNullOrEmpty(ImagePath))
                 throw new ArgumentException("'image' not specified.", nameof(ImagePath));
-            
+
             var imageString = ImagePath;
             if (File.Exists(imageString))
                 imageString = File.ReadAllText(imageString);
             var imageSpecifier = ImageSpecifier.FromString(imageString);
 
             // image specifies any repositories?
-            if(imageSpecifier.Repositories?.Any() != true)
+            if (imageSpecifier.Repositories?.Any() != true)
             {
                 if (Repositories?.Any() == true)
                     imageSpecifier.Repositories = Repositories.ToList();
@@ -79,7 +79,7 @@ namespace OpenTap.Package
 
             if (!string.IsNullOrWhiteSpace(Os))
                 imageSpecifier.OS = Os;
-            if (Architecture!= CpuArchitecture.Unspecified)
+            if (Architecture != CpuArchitecture.Unspecified)
                 imageSpecifier.Architecture = Architecture;
 
 
@@ -104,7 +104,7 @@ namespace OpenTap.Package
                     // or if the package cache has been cleared by the user, and an image install is attempted
                     // without the original source repository of some package.
                     imageSpecifier.AdditionalPackages.AddRange(new Installation(Target).GetPackages());
-                    
+
                     image = imageSpecifier.Resolve(TapThread.Current.AbortToken);
                 }
 
@@ -127,7 +127,7 @@ namespace OpenTap.Package
                         throw new OperationCanceledException("Image installation was canceled.");
                     }
                 }
-                
+
                 log.Debug("Image hash: {0}", image.Id);
                 if (DryRun)
                 {
@@ -151,7 +151,7 @@ namespace OpenTap.Package
             }
 
         }
-        
+
         enum WipeInstallationResponse
         {
             No,

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -8,7 +8,6 @@ using System.Threading;
 
 namespace OpenTap.Package
 {
-    [Browsable(false)]
     [Display("install", Group: "image")]
     internal class ImageInstallAction : IsolatedPackageAction
     {
@@ -36,7 +35,7 @@ namespace OpenTap.Package
         [CommandLineArgument("architecture", Description = "Specify which architecture to resolve packages for.")]
         public CpuArchitecture Architecture { get; set; } = CpuArchitecture.Unspecified;
         
-        /// <summary> dry-run - resolve, but don't install the packages. </summary>
+        /// <summary> Resolve and print a summary of the changes that would be applied, but don't apply them. </summary>
         [CommandLineArgument("dry-run", Description = "Only print the result, don't install the packages.")]
         public bool DryRun { get; set; }
 


### PR DESCRIPTION
This will make `tap image install` appear in the output of e.g. `tap --help`, and most
importantly, reveals the possible arguments in `tap image install
--help` which is currently a bit too secret.

Closes #1589