### PR TITLE
Remove public property added by mistake

### DIFF
--- a/Package/PackageActions/List.cs
+++ b/Package/PackageActions/List.cs
@@ -13,9 +13,6 @@ namespace OpenTap.Package
     [Display("list", Group: "package", Description: "List locally installed packages and browse the online package repository.")]
     public class PackageListAction : LockingPackageAction
     {
-        [CommandLineArgument("token", Description = CommandLineArgumentTokenDescription)]
-        public string[] Tokens { get; set; }
-        
         [CommandLineArgument("repository", Description = CommandLineArgumentRepositoryDescription, ShortName = "r")]
         public string[] Repository { get; set; }
 

--- a/Package/PackageActions/LockingPackageAction.cs
+++ b/Package/PackageActions/LockingPackageAction.cs
@@ -19,9 +19,6 @@ namespace OpenTap.Package
     /// </summary>
     public abstract class LockingPackageAction : PackageAction
     {
-        internal const string CommandLineArgumentTokenDescription =
-            "Specify one or more user tokens to use for repository authentication.\n" +
-            "Has no effect without manually specifying repositories with '--repository'.";
         internal const string CommandLineArgumentRepositoryDescription =
             "Override the package repository.\n" +
             "The default is https://packages.opentap.io.\n" +


### PR DESCRIPTION
This made it in with https://github.com/opentap/opentap/pull/1406 This is an API break that I am willing to make.