### PR TITLE
Set assembly version to gitversion during build

### DIFF
--- a/Package/CreatePackage/GitVersionCalculator.cs
+++ b/Package/CreatePackage/GitVersionCalculator.cs
@@ -18,7 +18,7 @@ namespace OpenTap.Package
     /// <summary>
     /// Calculates the version number of a commit in a git repository
     /// </summary>
-    internal class GitVersionCalulator : IDisposable
+    public class GitVersionCalulator : IDisposable
     {
         private static readonly TraceSource log = Log.CreateSource("GitVersion");
         private const string configFileName = ".gitversion";
@@ -143,7 +143,8 @@ namespace OpenTap.Package
                 return;
             }
             
-            var requiredFile = Path.Combine(PathUtils.OpenTapDir, libgit2name);
+            var libgitDir = Path.GetDirectoryName(typeof(LibGit2Sharp.Repository).Assembly.Location);
+            var requiredFile = Path.Combine(libgitDir, libgit2name);
             if (File.Exists(requiredFile))
                 return;
 

--- a/nuget/build/OpenTap.props
+++ b/nuget/build/OpenTap.props
@@ -4,6 +4,7 @@
     <OpenTapPackageDefinitionPath>package.xml</OpenTapPackageDefinitionPath>
     <CreateOpenTapPackage>false</CreateOpenTapPackage>
     <InstallCreatedOpenTapPackage>true</InstallCreatedOpenTapPackage>
+    <UseGitVersionAssemblyInfo>false</UseGitVersionAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CreateOpenTapPackage>true</CreateOpenTapPackage>

--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -129,4 +129,24 @@
       <ReferencePathWithRefAssemblies Include="@(_OpenTapPackagesReferences-> '$(OutDir)%(Identity)')"/>
     </ItemGroup>
   </Target>
+
+  <UsingTask TaskName="Keysight.OpenTap.Sdk.MSBuild.SetVersionPropertiesFromGit" AssemblyFile="$(MSBuildThisFileDirectory)\Keysight.OpenTap.Sdk.MSBuild.dll"/>
+  <Target Name="GenerateGitVersionInfo"
+    Condition="'$(UseGitVersionAssemblyInfo)' != 'false'"
+    DependsOnTargets="InstallOpenTapPackages" BeforeTargets="ResolveReferences;CoreCompile;ResolveAssemblyReferences"
+    >
+    <SetVersionPropertiesFromGit TapDir="$(OutDir)" >
+      <Output TaskParameter="Version" ItemName="_TaskVersion" />
+      <Output TaskParameter="AssemblyVersion" ItemName="_TaskAssemblyVersion" />
+      <Output TaskParameter="InformationalVersion" ItemName="_TaskInformationalVersion" />
+      <Output TaskParameter="FileVersion" ItemName="_TaskFileVersion" />
+    </SetVersionPropertiesFromGit>
+    <PropertyGroup Condition="'@(_TaskVersion)' != ''">
+      <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+      <Version>@(_TaskVersion)</Version>
+      <AssemblyVersion>@(_TaskAssemblyVersion)</AssemblyVersion>
+      <InformationalVersion>@(_TaskInformationalVersion)</InformationalVersion>
+      <FileVersion>@(_TaskFileVersion)</FileVersion> 
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/sdk/OpenTap.Sdk.MSBuild/PackageTask.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/PackageTask.cs
@@ -7,7 +7,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace Keysight.OpenTap.Sdk.MSBuild

--- a/sdk/OpenTap.Sdk.MSBuild/SetVersionPropertiesFromGit.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/SetVersionPropertiesFromGit.cs
@@ -1,0 +1,51 @@
+//            Copyright Keysight Technologies 2012-2024
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Keysight.OpenTap.Sdk.MSBuild
+{
+
+    /// <summary>
+    /// MSBuild Task to help version assemblies. 
+    /// </summary>
+    [Serializable]
+    public class SetVersionPropertiesFromGit : Task
+    {
+        /// <summary>
+        /// The build directory containing 'tap.exe' and 'OpenTAP.dll'
+        /// </summary>
+        public string TapDir { get; set; }
+
+        [Output] 
+        public string Version { get; set; }
+        [Output] 
+        public string AssemblyVersion { get; set; }
+        [Output] 
+        public string InformationalVersion { get; set; }
+        [Output] 
+        public string FileVersion { get; set; }
+
+        private void SetVersionProperties()
+        {
+            global::OpenTap.PluginManager.Search();
+
+            var calc = new global::OpenTap.Package.GitVersionCalulator(TapDir);
+            var semver = calc.GetVersion();
+            Version = semver.ToString(3);
+            AssemblyVersion = Version;
+            FileVersion = $"{Version}.0";
+            InformationalVersion = semver.ToString();
+        }
+
+        public override bool Execute()
+        {
+            using (OpenTapContext.Create(TapDir))
+                SetVersionProperties();
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This adds a new target to the nuget package to set gitversion during build instead of during package creation.

This is nice for a couple of reasons:

* we can remove the dependency on mono.cecil
* shorter package.xml files since version injection no longer needs to be specified for all dlls
* The hash of a packaged DLL will match the hash of the input dll, unless signed / obfuscated of course
* dlls will be versioned correctly in debug builds
* we no longer need to update pdb files when we update the version info, since this is now done correctly by the compiler

I had to make GitVersionCalculator public. Let's consider if we want to actually do this. It would not be a big deal if it was in the 'SDK' package, but unfortunately it is in OpenTap.Package.