### PR TITLE
Add missing source license

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
         <Debug Condition="$(Debug) != true">false</Debug>
     </Variables>
     <SourceUrl>https://github.com/opentap/opentap</SourceUrl>
+    <SourceLicense>MPL-2.0</SourceLicense>
     <Owner>OpenTAP</Owner>
     <!-- Common files  -->
     <Files Condition="$(Debug) == false">


### PR DESCRIPTION
Support for this was added 3 years ago: 
https://gitlab.com/OpenTAP/opentap/-/merge_requests/730

And we recommend including this in our documentation here: https://doc.opentap.io/Developer%20Guide/Package%20Publishing/Readme.html#update-the-package-definition-package-xml-file

Let's include this.