### PR TITLE
AssemblyFinder will skip a subdirectory if it appears to be a OpenTap installation.

### DIFF
--- a/Engine/AssemblyFinder.cs
+++ b/Engine/AssemblyFinder.cs
@@ -97,7 +97,7 @@ namespace OpenTap
                             {
                                 if (StrEq(subDir.Name, "obj"))
                                     continue; // skip obj subfolder
-                                if (subDir.GetFiles("Tap.exe").Any())
+                                if (subDir.GetFiles("OpenTap.dll").Any())
                                     continue; // skip subdirectory if it appears to be an opentap installation
                                 var ignorePluginsInSubDir = dir.IgnorePlugins || StrEq(subDir.Name, "Dependencies");
                                 if (IncludeDependencies)

--- a/Engine/AssemblyFinder.cs
+++ b/Engine/AssemblyFinder.cs
@@ -96,12 +96,7 @@ namespace OpenTap
                             foreach (var subDir in dir.Info.EnumerateDirectories())
                             {
                                 if (StrEq(subDir.Name, "obj"))
-                                    continue; // skip obj subfolder
-                                if (subDir.GetFiles("OpenTap.dll").Any())
-                                {
-                                    log.Warning("Found OpenTap installation in subdirectory: '{0}'", subDir.Name);
-                                    continue; // skip subdirectory if it appears to be an opentap installation                                    
-                                }
+                                    continue; // skip obj subfolder                        
                                 var ignorePluginsInSubDir = dir.IgnorePlugins || StrEq(subDir.Name, "Dependencies");
                                 if (IncludeDependencies)
                                     ignorePluginsInSubDir = false;

--- a/Engine/AssemblyFinder.cs
+++ b/Engine/AssemblyFinder.cs
@@ -98,7 +98,10 @@ namespace OpenTap
                                 if (StrEq(subDir.Name, "obj"))
                                     continue; // skip obj subfolder
                                 if (subDir.GetFiles("OpenTap.dll").Any())
-                                    continue; // skip subdirectory if it appears to be an opentap installation
+                                {
+                                    log.Warning("Found OpenTap installation in subdirectory: '{0}'", subDir.Name);
+                                    continue; // skip subdirectory if it appears to be an opentap installation                                    
+                                }
                                 var ignorePluginsInSubDir = dir.IgnorePlugins || StrEq(subDir.Name, "Dependencies");
                                 if (IncludeDependencies)
                                     ignorePluginsInSubDir = false;

--- a/Engine/AssemblyFinder.cs
+++ b/Engine/AssemblyFinder.cs
@@ -97,6 +97,8 @@ namespace OpenTap
                             {
                                 if (StrEq(subDir.Name, "obj"))
                                     continue; // skip obj subfolder
+                                if (subDir.GetFiles("Tap.exe").Any())
+                                    continue; // skip subdirectory if it appears to be an opentap installation
                                 var ignorePluginsInSubDir = dir.IgnorePlugins || StrEq(subDir.Name, "Dependencies");
                                 if (IncludeDependencies)
                                     ignorePluginsInSubDir = false;

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -88,9 +88,10 @@ namespace OpenTap.Package
                 ImageIdentifier image;
                 var sw = Stopwatch.StartNew();
 
-                if (NestedTapInstallation() == true)
+                if (TryFindParentInstallation(Target, out var parent))
                 {
-                    throw new Exception("Unable to perform installation as the current directory is inside another OpenTap installation. Nested installations can cause unexpected behavior and are not supported.");
+                    log.Error($"OpenTAP installation detected in directory '{parent}'. Nested installations are not supported.");
+                    return 1;
                 }
                 if (Merge)
                 {

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -87,6 +87,11 @@ namespace OpenTap.Package
             {
                 ImageIdentifier image;
                 var sw = Stopwatch.StartNew();
+
+                if (NestedTapInstallation() == true)
+                {
+                    throw new Exception("Unable to perform installation as the current directory is inside another OpenTap installation. Nested installations can cause unexpected behavior and are not supported.");
+                }
                 if (Merge)
                 {
                     var deploymentInstallation = new Installation(Target);

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -109,9 +109,12 @@ namespace OpenTap.Package
         {
             if (Target == null)
                 Target = FileSystemHelper.GetCurrentInstallationDirectory();
-            if (NestedTapInstallation() == true)
+
+
+            if (TryFindParentInstallation(Target, out var parent))
             {
-                throw new Exception("Unable to perform installation as the current directory is inside another OpenTap installation. Nested installations can cause unexpected behavior and are not supported.");
+                log.Error($"OpenTAP installation detected in directory '{parent}'. Nested installations are not supported.");
+                return 1;
             }
 
             var targetInstallation = new Installation(Target);

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -109,7 +109,13 @@ namespace OpenTap.Package
         {
             if (Target == null)
                 Target = FileSystemHelper.GetCurrentInstallationDirectory();
+            if (NestedTapInstallation() == true)
+            {
+                throw new Exception("Unable to perform installation as the current directory is inside another OpenTap installation. Nested installations can cause unexpected behavior and are not supported.");
+            }
+
             var targetInstallation = new Installation(Target);
+
 
             if (NoCache) PackageManagerSettings.Current.UseLocalPackageCache = false;
             Repository = ExtractRepositoryTokens(Repository, true);

--- a/Package/PackageActions/IsolatedPackageAction.cs
+++ b/Package/PackageActions/IsolatedPackageAction.cs
@@ -78,27 +78,20 @@ namespace OpenTap.Package
             return base.Execute(cancellationToken);
         }
 
-        internal bool NestedTapInstallation()
+        internal static bool TryFindParentInstallation(string targetDirectory, out string parent)
         {
-            string parentDirectory = Directory.GetParent(Target).FullName;
-            string filePath = Path.Combine(parentDirectory, "OpenTap.dll");
-            bool fileExists = File.Exists(filePath);
-
-            if (!fileExists)
+            var dir = new DirectoryInfo(targetDirectory).Parent;
+            while (dir != null)
             {
-                DirectoryInfo parentDir = Directory.GetParent(parentDirectory);
-                while (parentDir != null)
+                if (dir.EnumerateFiles("OpenTap.dll").Any())
                 {
-                    filePath = Path.Combine(parentDir.FullName, "OpenTap.dll");
-                    if (File.Exists(filePath))
-                    {
-                        fileExists = true;
-                        break;
-                    }
-                    parentDir = parentDir.Parent;
+                    parent = dir.FullName;
+                    return true;
                 }
+                dir = dir.Parent;
             }
-            return fileExists;
+            parent = null;
+            return false;
         }
 
 

--- a/Package/PackageActions/IsolatedPackageAction.cs
+++ b/Package/PackageActions/IsolatedPackageAction.cs
@@ -78,6 +78,30 @@ namespace OpenTap.Package
             return base.Execute(cancellationToken);
         }
 
+        internal bool NestedTapInstallation()
+        {
+            string parentDirectory = Directory.GetParent(Target).FullName;
+            string filePath = Path.Combine(parentDirectory, "OpenTap.dll");
+            bool fileExists = File.Exists(filePath);
+
+            if (!fileExists)
+            {
+                DirectoryInfo parentDir = Directory.GetParent(parentDirectory);
+                while (parentDir != null)
+                {
+                    filePath = Path.Combine(parentDir.FullName, "OpenTap.dll");
+                    if (File.Exists(filePath))
+                    {
+                        fileExists = true;
+                        break;
+                    }
+                    parentDir = parentDir.Parent;
+                }
+            }
+            return fileExists;
+        }
+
+
         private static string GetChangeFile(string target) => Path.Combine(target, "Packages", ".changeId");
         internal static long GetChangeId(string target)
         {


### PR DESCRIPTION
Closes #1571 