### PR TITLE
flush InitTraceListener before removal

### DIFF
--- a/Cli/TapInitializer.cs
+++ b/Cli/TapInitializer.cs
@@ -23,7 +23,7 @@ namespace OpenTap
                     AllEvents.AddRange(events);
             }
             public void Flush(){
-
+                Log.Flush();
             }
             public static readonly InitTraceListener Instance = new InitTraceListener();  
         }


### PR DESCRIPTION
This fixes an issue causing startup messages to disappear.

Because the flush method on the init trace listener dit not actually flush, messages from e.g. PluginSearcher during startup did not always arrive before the listener was removed.

Closes #1631 