### PR TITLE
Stop suggesting upgrading to prereleases

### DIFF
--- a/Package/Repositories/FilePackageRepository.cs
+++ b/Package/Repositories/FilePackageRepository.cs
@@ -382,6 +382,7 @@ namespace OpenTap.Package
                 // Try finding a OpenTAP package
                 var latest = allPackages
                     .Where(p => package?.Name == p?.Name)
+                    .Where(p => string.IsNullOrWhiteSpace(p?.Version?.PreRelease)) // Only suggest upgrading to released versions
                     .Where(p => p.Dependencies.All(dep => IsCompatible(dep, openTapIdentifier))).FirstOrDefault(p => p.Version != null && p.Version.CompareTo(package.Version) > 0);
 
                 if (latest != null)


### PR DESCRIPTION
The update check exists to notify users that a new stable release is available. It does not make sense to suggest upgrading from one beta to another.

Closes #1520