### PR TITLE
Update specifier comparison fallback values

### DIFF
--- a/Package/PackageCompatibilityHelper.cs
+++ b/Package/PackageCompatibilityHelper.cs
@@ -12,13 +12,21 @@ namespace OpenTap.Package
             SemanticVersion semanticVersion = new SemanticVersion(other.Major ?? 0, other.Minor ?? 0, other.Patch ?? 0, other.PreRelease, other.BuildMetadata);
             if (other.Patch == null || other.Minor == null)
             {
-                var spec2 = new VersionSpecifier(other.Major.HasValue ? spec.Major : 0,
-                    other.Minor.HasValue ? spec.Minor : 0
-                    
-                    , other.Patch.HasValue ? spec.Patch : (spec.Patch.HasValue ? (int?)0 : null), spec.PreRelease, spec.BuildMetadata,
-                    // Add AnyPrerelease to 'Compatible' match.
-                    // otherwise e.g ^9.18.0 is not satisfied by ^9.18.1-rc.
-                    spec.MatchBehavior == VersionMatchBehavior.Compatible ? (spec.MatchBehavior | VersionMatchBehavior.AnyPrerelease) : spec.MatchBehavior);
+                var specMajor = other.Major.HasValue ? spec.Major : null;
+                var specMinor = other.Minor.HasValue ? spec.Minor : null;
+                var specPatch = other.Patch.HasValue ? spec.Patch : null;
+                
+                // This is probably not needed, but a required invariant for version specifiers.
+                if (specMajor == null) specMinor = null;
+                if (specMinor == null) specPatch = null;
+                // Add AnyPrerelease to 'Compatible' match.
+                // otherwise e.g ^9.18.0 is not satisfied by ^9.18.1-rc.
+                var versionMatchBehavior = spec.MatchBehavior == VersionMatchBehavior.Compatible
+                    ? (spec.MatchBehavior | VersionMatchBehavior.AnyPrerelease)
+                    : spec.MatchBehavior;
+
+                var spec2 = new VersionSpecifier(specMajor, specMinor, specPatch, spec.PreRelease, spec.BuildMetadata,
+                    versionMatchBehavior);
                 return spec2.IsCompatible(semanticVersion);
             }
             var ok = spec.IsCompatible(semanticVersion);


### PR DESCRIPTION
This sets null as the specifier fallback value instead of 0 This fixes the case where the following conditions hold:

1. 'other' specifies a major version, and 'this' does not
2. neither version specifies a minor version

In this case, the version specifier would become (null).0.x, which is not a valid specifier.

With the new behavior, the specifier would become (null).(null).(null), which is effectively equivalent to Any or AnyRelease, depending on the prerelease and match behavior

Closes #1642 