### PR TITLE
Add missing expected exit code on Linux

### DIFF
--- a/sdk/sdk.package.xml
+++ b/sdk/sdk.package.xml
@@ -62,7 +62,8 @@
       106        : .NET 7 or later if the template is already installed
       -2147352567: Earlier than .NET 7 if the template is already installed
       -2147450735: The error code when .NET runtime is installed, but .NET SDK is not
+      145:         Same as above, but on Linux
     -->
-		<ActionStep ExpectedExitCodes="0,106,-2147352567,-2147450735" Quiet="true" ExeFile="dotnet" Arguments='new --install Packages/SDK/OpenTap.Templates.$(GitLongVersion).nupkg' ActionName="install" Optional="true"/>
+		<ActionStep ExpectedExitCodes="0,106,-2147352567,-2147450735,145" Quiet="true" ExeFile="dotnet" Arguments='new --install Packages/SDK/OpenTap.Templates.$(GitLongVersion).nupkg' ActionName="install" Optional="true"/>
 	</PackageActionExtensions>
 </Package>


### PR DESCRIPTION
This adds an equivalent expected exit code to linux to an exit code we were already handling on Windows

Closes #1652 