### PR TITLE
Fix system-wide installs failing with exit code 0

### DIFF
--- a/Package/Installer.cs
+++ b/Package/Installer.cs
@@ -73,8 +73,7 @@ namespace OpenTap.Package
                         Stopwatch timer = Stopwatch.StartNew();
                         PackageDef pkg = PluginInstaller.InstallPluginPackage(TapDir, fileName, UnpackOnly);
 
-                        log.Info(timer, "Installed " + pkg.Name + " version " + pkg.Version);
-
+                        log.Info(timer, $"Installed {pkg.Name} version {pkg.Version}");
 
                         if (pkg.Files.Any(s => s.Plugins.Any(p => p.BaseType == nameof(ICustomPackageData))) && PackagePaths.Last() != fileName)
                         {

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -398,6 +398,7 @@ namespace OpenTap.Package
                         var ex = new Exception(
                             $"Failed installing system-wide packages. Try running the command as administrator.");
                         RaiseError(ex);
+                        throw ex;
                     }
 
                     var pct = ((double)systemwidePackages.Length / (systemwidePackages.Length + packagesToInstall.Count)) * 100;
@@ -484,6 +485,10 @@ namespace OpenTap.Package
                 RaiseError(e);
                 return (int)ExitCodes.NetworkError;
             }
+
+            // This happens in cases where only system-wide packages were requested.
+            if (installer.PackagePaths.Count == 0)
+                return 0;
 
             Log.Info("Installing to {0}", Path.GetFullPath(Target));
 


### PR DESCRIPTION
This causes failing system-wide installs to actually fail the installation. Also fixes an edge case related to logging

Closes #1658
Closes #1655