### PR TITLE
Allow resources to be both DUTs and Instruments

### DIFF
--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -2167,6 +2167,53 @@ namespace OpenTap.UnitTests
             }
         }
 
+        public class DutAndInstrumentResource : Resource, IDut, IInstrument
+        { 
+        }
+        
+        public class DutAndInstrumentUser : TestStep
+        {
+            public IDut DUT { get; set; }
+            public IInstrument Instrument { get; set; }
+            public DutAndInstrumentResource Both { get; set; }
+            public override void Run()
+            {
+            }
+        }
+        [Test]
+        public void AvailableResourcesTest()
+        {
+            using var session = Session.Create(SessionOptions.OverlayComponentSettings);
+            DutSettings.Current.Clear();
+            InstrumentSettings.Current.Clear();
+            
+            var ins = new DutAndInstrumentResource() { Name = "The Instrument" };
+            var dut = new DutAndInstrumentResource() { Name = "The DUT" };
+            
+            InstrumentSettings.Current.Add(ins);
+            DutSettings.Current.Add(dut);
+
+            var step = new DutAndInstrumentUser();
+            var a = AnnotationCollection.Annotate(step);
+
+            DutAndInstrumentResource[] getAvailable(string name) =>
+                a.GetMember(name).Get<IAvailableValuesAnnotation>().AvailableValues.Cast<DutAndInstrumentResource>().ToArray();
+
+            var availableInstruments = getAvailable(nameof(step.Instrument));
+            var availableDuts = getAvailable(nameof(step.DUT));
+            var availableBoth = getAvailable(nameof(step.Both)); 
+            
+            Assert.AreEqual(1, availableInstruments.Length);
+            CollectionAssert.Contains(availableInstruments, ins);
+            
+            Assert.AreEqual(1, availableDuts.Length);
+            CollectionAssert.Contains(availableDuts, dut);
+            
+            Assert.AreEqual(2, availableBoth.Length);
+            CollectionAssert.Contains(availableBoth, ins);
+            CollectionAssert.Contains(availableBoth, dut);
+        }
+
         [Test]
         public void AvailableValuesUpdateTest()
         {

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -2153,9 +2153,10 @@ namespace OpenTap
             {
                 get
                 {
-                    var x = ComponentSettingsList.GetContainer(baseType);
+                    var x = ComponentSettingsList.GetContainers(baseType).Select(x => x.Cast<object>())
+                        .SelectMany(x => x);
                     var cv = a.Get<IObjectValueAnnotation>()?.Value as IResource;
-                    var result = x.Cast<object>().Where(y => y.GetType().DescendsTo(baseType)).ToList();
+                    var result = x.Where(y => y.GetType().DescendsTo(baseType)).ToList();
                     // if the selected value is not in the list show it anyway.
                     if (cv != null && result.Contains(cv) == false)
                         result.Add(cv);

--- a/Engine/ComponentSettings.cs
+++ b/Engine/ComponentSettings.cs
@@ -103,6 +103,11 @@ namespace OpenTap
         /// <returns></returns>
         static PropertyInfo getGetCurrentMethodForContainer(Type T)
         {
+            return getGetCurrentMethodsForContainer(T).FirstOrDefault();
+        }
+        
+        static IEnumerable<PropertyInfo> getGetCurrentMethodsForContainer(Type T)
+        {
             if (T == null)
                 throw new ArgumentNullException("T");
             foreach (Type key in typeHandlers.Keys)
@@ -113,10 +118,9 @@ namespace OpenTap
                     Type compSetType = typeHandlers[key];
                     PropertyInfo prop = compSetType.GetProperty("Current", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
                     if (prop != null)
-                        return prop;
+                        yield return prop;
                 }
             }
-            return null;
         }
         
         /// <summary>
@@ -129,6 +133,14 @@ namespace OpenTap
             var m = getGetCurrentMethodForContainer(T);
             if (m == null) return null;
             return (IList)m.GetValue(null, null);
+        }
+
+        internal static IEnumerable<IList> GetContainers(Type T)
+        {
+            foreach (var m in getGetCurrentMethodsForContainer(T))
+            {
+                yield return (IList)m.GetValue(null, null);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes an issue preventing selecting a configured Instrument if the concrete implementation is also a DUT

Closes #1666 