### PR TITLE
Add arm64 support to nuget package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,6 +769,8 @@ jobs:
 
           Expand-Archive OpenTAP.x64.zip win-x64 -Verbose
           Expand-Archive OpenTAP.x86.zip win-x86 -Verbose
+          # TODO: create a real arm64 build and copy here. Rely on emulation mode for now
+          Expand-Archive OpenTAP.x64.zip win-arm64 -Verbose
           Expand-Archive OpenTAP.Linux.x64.zip linux-x64 -Verbose
           Expand-Archive OpenTAP.Linux.arm64.zip linux-arm64 -Verbose
           Expand-Archive OpenTAP.MacOS.x64.zip macos-x64 -Verbose

--- a/nuget/NugetPackager.ps1
+++ b/nuget/NugetPackager.ps1
@@ -110,3 +110,20 @@ $git2dll = Get-ChildItem -File -Recurse *git2-*.dll.x64 | Resolve-Path -Relative
 CopyPreserveRelativePath $git2dll $runtimeDir
 
 Pop-Location
+
+# Copy win-arm64 specific files
+# TODO: This relies on arm64 emulation mode. In a future release we should ship native arm64 binaries
+Push-Location win-arm64
+$runtimeDir = "../nuget/build/runtimes/win-arm64"
+$packageXml = Get-ChildItem -File -Recurse package.xml | Resolve-Path -Relative | Select-Object -First 1
+CopyPreserveRelativePath $packageXml $runtimeDir
+
+CopyPreserveRelativePath ./tap.exe  $runtimeDir
+# .net462 revert:
+#CopyPreserveRelativePath ./tap.dll $runtimeDir
+#CopyPreserveRelativePath ./tap.runtimeconfig.json $runtimeDir
+
+$git2dll = Get-ChildItem -File -Recurse *git2-*.dll.x64  | Resolve-Path -Relative | Select-Object -First 1
+CopyPreserveRelativePath $git2dll $runtimeDir
+
+Pop-Location


### PR DESCRIPTION
This is a workaround until the real fix is mature: #1673 

Closes #1677 