### PR TITLE
1699 Connection GetOtherPort with Equals

### DIFF
--- a/Engine/Port/Connection.cs
+++ b/Engine/Port/Connection.cs
@@ -91,10 +91,11 @@ namespace OpenTap
         /// </summary>
         public Port GetOtherPort(Port p)
         {
-            if (p == port1)
+            if (Equals(p, port1))
                 return port2;
-            if (p == port2)
-                return Port1;
+            if (Equals(p, port2))
+                return port1;
+            
             throw new ArgumentException("Argument must be either Port1 or Port2");
         }
 


### PR DESCRIPTION
Fixed the issue by using Equals.

Added a unit test to show the issue.

Close #1699