### PR TITLE
1701 RF Connection Get Intepolated Cable loss default: Fix

### DIFF
--- a/Engine.UnitTests/ConnectionTest.cs
+++ b/Engine.UnitTests/ConnectionTest.cs
@@ -64,6 +64,13 @@ namespace OpenTap.Engine.UnitTests
         }
 
         [Test]
+        public void EmptyRfConnectionCableLoss()
+        {
+            var loss = new RfConnection().GetInterpolatedCableLoss(0.0);
+            Assert.AreEqual(0.0, loss);
+        }
+
+        [Test]
         public void CableLossInterpolationTest()
         {
             // check linear (first order) interpolation:
@@ -97,6 +104,10 @@ namespace OpenTap.Engine.UnitTests
             Assert.AreEqual(2, loss);
             loss = con.GetInterpolatedCableLoss(200);
             Assert.AreEqual(4, loss);
+            loss = con.GetInterpolatedCableLoss(250);
+            Assert.AreEqual(4.5, loss);
+            loss = con.GetInterpolatedCableLoss(275);
+            Assert.AreEqual(4.75, loss);
             loss = con.GetInterpolatedCableLoss(300);
             Assert.AreEqual(5, loss);
         }

--- a/Engine/Port/RfConnection.cs
+++ b/Engine/Port/RfConnection.cs
@@ -89,6 +89,13 @@ namespace OpenTap
         /// <returns></returns>
         public double GetInterpolatedCableLoss(double frequency)
         {
+            // If there are no cable loss points configured assume no loss.
+            if (CableLoss.Count == 0) return 0.0;
+            
+            // If there is only one point there is nothing to interpolate
+            if (CableLoss.Count == 1) return CableLoss[0].Loss;
+            
+            // Calculate loss using linear interpolation or nearest neighbour when outside the bounds. 
             CableLoss = CableLoss.OrderBy(loss => loss.Frequency).ToList();
             CableLossPoint below = CableLoss.LastOrDefault(loss => loss.Frequency < frequency || (Math.Abs(loss.Frequency - frequency) < double.Epsilon)); //Check for below, or if value exists.
             CableLossPoint above = CableLoss.FirstOrDefault(loss => loss.Frequency > frequency);
@@ -102,7 +109,9 @@ namespace OpenTap
                 return below.Loss;
             else if (above != null)
                 return above.Loss;
-            throw new System.Exception("No cable loss values specified.");
+            
+            // this should never happen.
+            throw new InvalidOperationException("");
         }
     }
 }


### PR DESCRIPTION
- Added that the RF connection should return 0.0 dB loss if there are no loss points configured.

- Added unit tests to verify the behavior.
- Modified unit tests to test more interpolation cases.

Close #1701 