### PR TITLE
Serialize empty test step lists

### DIFF
--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -120,7 +120,6 @@ namespace OpenTap
         [Browsable(false)]
         [AnnotationIgnore]
         [SettingsIgnore]
-        [DefaultValue(new object[]{})]
         public TestStepList ChildTestSteps
         {
             get => childTestSteps; 


### PR DESCRIPTION
This fixes a missing <ChildTestSteps/> element in serialized test steps. This solves a serializer issues that affects steps that add child steps in their constructor, which are re-added if a test plan is reloaded after removing those child steps.

Closes #1721