### PR TITLE
1740 Assign Output Bug Fix

### DIFF
--- a/Engine.UnitTests/InputTest.cs
+++ b/Engine.UnitTests/InputTest.cs
@@ -206,6 +206,14 @@ namespace OpenTap.Engine.UnitTests
             var run = plan.Execute();
             Assert.AreEqual(Verdict.Pass, run.Verdict);
         }
+
+        [Test]
+        public void AssignOutputDialogWithPlan()
+        {
+            var plan = new TestPlan();
+            var selectedOutputItem = AssignOutputDialog.SelectedOutputItem.Create(plan, TypeData.GetTypeData(plan).GetMembers().First());
+            Assert.DoesNotThrow(() => selectedOutputItem.ToString());
+        }
     }
 
     [AllowAnyChild]

--- a/Engine/AssignOutputDialog.cs
+++ b/Engine/AssignOutputDialog.cs
@@ -50,7 +50,7 @@ namespace OpenTap
                 return new SelectedOutputItem(testStepParent, mem);
             }
 
-            public override string ToString() => $"{Member.GetDisplayAttribute().GetFullName()} from {(Step as ITestStep).GetFormattedName() ?? "plan"}";
+            public override string ToString() => $"{Member.GetDisplayAttribute().GetFullName()} from {(Step as ITestStep)?.GetFormattedName() ?? "test plan"}";
 
             public override bool Equals(object obj)
             {


### PR DESCRIPTION
Close #1740 

Fixed the issue by adding a null check in the ToString method.

Added a unit test to verify the fix.