### PR TITLE
Alpha build using new smartinstaller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   OPENTAP_NO_UPDATE_CHECK: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_CONSOLE_ANSI_COLOR: true
-  SMARTINSTALLER_IMAGE: ghcr.io/opentap/smartinstaller:2.2.0-beta.3
+  SMARTINSTALLER_IMAGE: ghcr.io/opentap/smartinstaller:update-bundled-dotnet
 
 jobs:
   GetVersion:


### PR DESCRIPTION
This is just a test for the updated smartinstaller which installs dotnet 8 instead of dotnet 6