### PR TITLE
1756 CableLossMemoryLeak: Fix

### DIFF
--- a/Engine/ComponentSettings.cs
+++ b/Engine/ComponentSettings.cs
@@ -216,7 +216,7 @@ namespace OpenTap
         public ComponentSettingsList()
         {
             list = new ObservableCollection<ContainedType>();
-            list.CollectionChanged += list_CollectionChanged;
+            list.CollectionChanged += OnCollectionChanged;
             ilist = list;
         }
 
@@ -225,7 +225,8 @@ namespace OpenTap
             return touchedResources.GetElements().Where(x => Contains(x) == false).ToArray();
         }
 
-        void list_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        /// <summary> This gets invoked when the collection is changed. </summary>
+        internal protected virtual void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.Action == NotifyCollectionChangedAction.Add)
             {
@@ -372,6 +373,7 @@ namespace OpenTap
             }
         }
 
+
         /// <summary>
         /// Invoked when collection is changed.
         /// </summary>
@@ -493,6 +495,8 @@ namespace OpenTap
         /// Get the currently loaded ComponentSettings instance for this class.
         /// </summary>
         public static T Current =>  GetCurrent();
+        
+        internal static T CurrentFromCache =>  (T)GetCurrentFromCache(typeof(T));
     }
 
     /// <summary>

--- a/Engine/DutSettings.cs
+++ b/Engine/DutSettings.cs
@@ -2,15 +2,31 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
-
+using System.Collections.Specialized;
 namespace OpenTap
 {
     /// <summary>
-    /// Settings related to the DUTs currently available. 
+    /// Settings governing configured DUTs. These are usually configured by the user. 
     /// </summary>
     [Display("DUTs", "DUT Settings.")]
     [SettingsGroup("Bench", Profile: true)]
     public class DutSettings : ComponentSettingsList<DutSettings, IDut>
     {
+     
+        /// <summary>
+        /// When the instrument settings list is modified some ports being used by connections might disappear.
+        ///  In that case we need to remove the ports from the connections.
+        /// </summary>
+        internal protected override void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            base.OnCollectionChanged(sender, e);
+            
+            var removedItems = e.OldItems;
+
+            if (removedItems == null) return;
+
+            var con = ConnectionSettings.CurrentFromCache;
+            con?.UpdateConnectionPorts(removedItems);
+        }
     }
 }

--- a/Engine/InstrumentSettings.cs
+++ b/Engine/InstrumentSettings.cs
@@ -2,14 +2,30 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
+using System.Collections.Specialized;
 namespace OpenTap
 {
     /// <summary>
-    /// ComponentSettings that contains an expandable list of instruments.
+    /// Settings governing configured instruments. These are usually configured by the user..
     /// </summary>
     [Display("Instruments", "Instrument Settings")]
-    [SettingsGroupAttribute("Bench", Profile: true)]
+    [SettingsGroup("Bench", Profile: true)]
     public class InstrumentSettings : ComponentSettingsList<InstrumentSettings, IInstrument>
     {
+        /// <summary>
+        /// When the instrument settings list is modified some ports being used by connections might disappear.
+        ///  In that case we need to remove the ports from the connections.
+        /// </summary>
+        internal protected override void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            base.OnCollectionChanged(sender, e);
+
+            var removedItems = e.OldItems;
+
+            if (removedItems == null) return;
+
+            var con = ConnectionSettings.CurrentFromCache;
+            con?.UpdateConnectionPorts(removedItems);
+        }
     }
 }

--- a/Engine/Port/Connection.cs
+++ b/Engine/Port/Connection.cs
@@ -4,7 +4,6 @@
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 
 namespace OpenTap
@@ -23,40 +22,20 @@ namespace OpenTap
         [Display("Name", Order: 0 - 100000)]
         public string Name { get; set; }
 
-        Port port1;
         /// <summary>
         /// The port at the first end of the connection.
         /// </summary>
         [Display("Port 1", Order: 1 - 100000)] 
-        public Port Port1
-        {
-            get { return port1; }
-            set
-            {
-                var oldvalue = port1;
-                port1 = value;
-                loadEndpoint(value, oldvalue);
-            }
-        }
+        public Port Port1 { get; set; }
 
         /// <summary> returns true if the port is used by this connection. </summary>
         internal bool HasPort(Port port) => Equals(Port1, port) || Equals(Port2, port);
 
-        Port port2;
         /// <summary>
         /// The port at the second end of the connection.
         /// </summary>
         [Display("Port 2", Order: 3 - 100000)]
-        public Port Port2
-        {
-            get { return port2; }
-            set
-            {
-                var oldvalue = port2;
-                port2 = value;
-                loadEndpoint(value, oldvalue);
-            }
-        }
+        public Port Port2 { get; set; }
         
         /// <summary>
         /// Gets the list of <see cref="ViaPoint"/>s that this connection goes through. 
@@ -81,8 +60,6 @@ namespace OpenTap
         public Connection()
         {
             Name = "Conn";
-            port1 = null;
-            port2 = null;
             Via = new List<ViaPoint>();
         }
 
@@ -91,53 +68,16 @@ namespace OpenTap
         /// </summary>
         public Port GetOtherPort(Port p)
         {
-            if (Equals(p, port1))
-                return port2;
-            if (Equals(p, port2))
-                return port1;
+            if (Equals(p, Port1))
+                return Port2;
+            if (Equals(p, Port2))
+                return Port1;
             
             throw new ArgumentException("Argument must be either Port1 or Port2");
         }
 
-        /// <summary>
-        /// Handle that an endpoint can disappear.
-        /// </summary>
-        /// <param name="newport"></param>
-        /// <param name="oldPort"></param>
-        void loadEndpoint(Port newport, Port oldPort)
-        {
-            if (oldPort?.Device != null)
-            {
-                var type = oldPort.Device.GetType();
-                var list = ComponentSettingsList.GetContainer(type) as INotifyCollectionChanged;
-                if (list != null)
-                    list.CollectionChanged -= componentSettingsChanged;
 
-            }
-
-            if (newport?.Device != null)
-            {
-                var type = newport.Device.GetType();
-                var list = ComponentSettingsList.GetContainer(type) as INotifyCollectionChanged;
-                if (list != null)
-                {
-                    list.CollectionChanged += componentSettingsChanged;
-                }
-            }
-        }
-
-        private void componentSettingsChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            // Check if an endpoint has disappeared.
-            if (e.OldItems != null)
-            {
-                if (Port1 != null && e.OldItems.Contains(Port1.Device))
-                    Port1 = null;
-                if (Port2 != null && e.OldItems.Contains(Port2.Device))
-                    Port2 = null;
-            }
-        }
-
+        
         /// <summary>
         /// Returns a string representation of this connection which names the ports in each end.
         /// </summary>

--- a/Engine/Port/ConnectionSettings.cs
+++ b/Engine/Port/ConnectionSettings.cs
@@ -3,15 +3,29 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+using System.Collections;
 namespace OpenTap
 {
     /// <summary>
     /// Settings specifying how DUTs and Instruments are connected.
     /// </summary>
     [Display("Connections", "Connection Settings")]
-    [ComponentSettingsLayoutAttribute(ComponentSettingsLayoutAttribute.DisplayMode.DataGrid)]
-    [SettingsGroupAttribute("Bench", Profile: true)]
+    [ComponentSettingsLayout(ComponentSettingsLayoutAttribute.DisplayMode.DataGrid)]
+    [SettingsGroup("Bench", Profile: true)]
     public class ConnectionSettings : ComponentSettingsList<ConnectionSettings, Connection>
     {
+        /// <summary>
+        /// Removes a port whose device has been deleted from a settings list.
+        /// </summary>
+        internal void UpdateConnectionPorts(IList oldItems)
+        {
+            foreach (var connection in this)
+            {
+                if (connection.Port1?.Device is IResource res && oldItems.Contains(res))
+                    connection.Port1 = null;
+                if (connection.Port2?.Device is IResource res2 && oldItems.Contains(res2))
+                    connection.Port2 = null;
+            }
+        }
     }
 }

--- a/Engine/Port/RfConnection.cs
+++ b/Engine/Port/RfConnection.cs
@@ -20,12 +20,15 @@ namespace OpenTap
         /// </summary>
         public class CableLossPoint : ValidatingObject
         {
-            /// <summary>
-            /// Initializes a new instance of the <see cref="CableLossPoint"/> class.
-            /// </summary>
-            public CableLossPoint()
+            /// <summary> Returns an error if the frequency is less 0. </summary>
+            protected override string GetError(string propertyName = null)
             {
-                Rules.Add(() => Frequency >= 0, "Frequency must not be negative.", "Frequency");
+                if (propertyName == nameof(Frequency) || propertyName == null)
+                {
+                    if (Frequency < 0)
+                        return "Frequency must not be negative";
+                }
+                return null;
             }
 
             /// <summary>


### PR DESCRIPTION
Close #1756 

- Fixed the issue by not registering an event handler for every connection created.
- Optimized the memory usage and initialization for cable loss points, by overriding GetError directly.