### PR TITLE
1737 Allow adding mixins to test plan reference

### DIFF
--- a/Engine.UnitTests/MixinTests.cs
+++ b/Engine.UnitTests/MixinTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using NUnit.Framework;
 using OpenTap.Plugins.BasicSteps;
+using Tap.Shared;
 namespace OpenTap.UnitTests
 {
     [TestFixture]
@@ -308,6 +309,38 @@ namespace OpenTap.UnitTests
 
         }
 
+        [Test]
+        public void CanAddMixinToTestPlanReference()
+        {
+            var plan1 = new TestPlan();
+            plan1.ChildTestSteps.Add(new DelayStep());
+            var plan1File = PathUtils.GetTempFileName("TapPlan");
+            plan1.Save(plan1File);
+
+            var plan2 = new TestPlan();
+            var tpr = new TestPlanReference();
+            tpr.Filepath.Text = plan1File;
+
+            plan2.ChildTestSteps.Add(tpr);
+            tpr.LoadTestPlan();
+            {
+                var a = AnnotationCollection.Annotate(tpr);
+                var addMixin = a.GetIcon(IconNames.AddMixin);
+                var enabled = addMixin.Get<IAccessAnnotation>();
+                // it _is_ allowed to add mixins to test plan reference.
+                Assert.IsTrue(enabled.IsVisible);
+            }
+            {
+                var a = AnnotationCollection.Annotate(tpr.ChildTestSteps[0]);
+                var addMixin = a.GetIcon(IconNames.AddMixin);
+                var enabled = addMixin.Get<IAccessAnnotation>();
+                // it is not allowed to add mixins to the child steps of test plan reference.
+                Assert.IsFalse(enabled.IsVisible);
+            }
+
+        }
+        
+        
 
         [Test]
         public void CannotModifyMixinTest()

--- a/Engine/MixinMenuModel.cs
+++ b/Engine/MixinMenuModel.cs
@@ -19,7 +19,7 @@ namespace OpenTap
         public MixinMenuModel(ITypeData type) => this.type = type;
         bool? showMixins;
         public bool ShowMixins => (showMixins ??= (MixinFactory.GetMixinBuilders(type).Any()))&& !TestPlanLocked;
-        public bool StepLocked => source.OfType<ITestStep>().Any(x => x.ChildTestSteps.IsReadOnly);
+        public bool StepLocked => source.OfType<ITestStep>().Any(x => x.IsReadOnly);
         
         [Display("Add Mixin...", "Add a new mixin.", Order: 2.0, Group: "Mixins")]
         [Browsable(true)]


### PR DESCRIPTION
- Modified the rules on AddMixin to support adding mixins to test plan reference.
- Added unit test to verify the behavior.

Close #1737 