### PR TITLE
1762 Embed Test Plan Reference: fix

### DIFF
--- a/BasicSteps/TestPlanReference.cs
+++ b/BasicSteps/TestPlanReference.cs
@@ -395,12 +395,37 @@ namespace OpenTap.Plugins.BasicSteps
         }
 
         public bool anyStepsLoaded => ChildTestSteps.Any() && File.Exists(GetPath());
+
+        
+        
+        [Display("Are you sure?")]
+        class ConvertWarning
+        {
+            public enum ConvertOrCancel
+            {
+                Convert,
+                Cancel
+            }
+            [Browsable(true)]
+            [Layout(LayoutMode.FullRow)]
+            public string Message => "Are you sure you want to convert the Test Plan Reference to a Sequence?\n\nAny future changes to the referenced test plan will not be reflected.";
+
+            [Layout(LayoutMode.FloatBottom | LayoutMode.FullRow)]
+            [Submit]
+            public ConvertOrCancel Response { set; get; } = ConvertOrCancel.Cancel;
+
+        }
+            
         
         [Browsable(true)]
         [Display("Convert to Sequence", "Convert  the test plan reference to a sequence step.", Order: 1.1)]
         [EnabledIf(nameof(anyStepsLoaded), HideIfDisabled = true)]
         public void ConvertToSequence()
         {
+            var warn = new ConvertWarning();
+            UserInput.Request(warn, true);
+            if (warn.Response == ConvertWarning.ConvertOrCancel.Cancel)
+                return;
             var subPlan = TestPlan.Load(GetPath());
             var seq = new SequenceStep
             {

--- a/BasicSteps/TestPlanReference.cs
+++ b/BasicSteps/TestPlanReference.cs
@@ -397,7 +397,7 @@ namespace OpenTap.Plugins.BasicSteps
         public bool anyStepsLoaded => ChildTestSteps.Any() && File.Exists(GetPath());
         
         [Browsable(true)]
-        [Display("Convert to Sequence", "Convert  the test plan reference to a sequence step.", Order: 10, Group:"Utilities", Collapsed: true)]
+        [Display("Convert to Sequence", "Convert  the test plan reference to a sequence step.", Order: 1.1)]
         [EnabledIf(nameof(anyStepsLoaded), HideIfDisabled = true)]
         public void ConvertToSequence()
         {

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -136,13 +136,12 @@ namespace OpenTap
         internal object Target { get; }
 
         /// <summary> Immutable data structure for managing parameter members. </summary>
-        readonly struct ParameterMembers : IEnumerable<(object, IMemberData)>
+        readonly struct ParameterMembers : ICollection<(object, IMemberData)>
         {
             public readonly object Source;
             public readonly IMemberData Member;
             public readonly ImmutableHashSet<(object Source, IMemberData Member)> Additional;
-            public readonly int Count;
-
+            
             public ParameterMembers(object source, IMemberData member, ImmutableHashSet<(object Source, IMemberData Member)> additionalMembers)
             {
                 Source = source;
@@ -190,6 +189,31 @@ namespace OpenTap
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
             
             public bool Contains(object findSource, IMemberData findMember) => Equals(findSource, Source) && Equals(findMember, Member) || Additional.Contains((findSource, findMember));
+            public void Add((object, IMemberData) item)
+            {
+                throw new NotSupportedException("This class is readonly, create a new instance instead.");
+            }
+            public void Clear()
+            {
+                throw new NotSupportedException("This class is readonly, create a new instance instead.");
+            }
+            public bool Contains((object, IMemberData) item) => Contains(item.Item1, item.Item2);
+            
+            public void CopyTo((object, IMemberData)[] array, int arrayIndex)
+            {
+                array[arrayIndex] = (Source, Member);
+                foreach (var elem in Additional)
+                {
+                    arrayIndex++;
+                    array[arrayIndex] = elem;
+                }
+            }
+            public bool Remove((object, IMemberData) item)
+            {
+                throw new NotSupportedException("This class is readonly, create a new instance instead.");
+            }
+            public int Count { get; }
+            public bool IsReadOnly => true;
         }
 
         ParameterMembers parameterMembers;
@@ -226,7 +250,8 @@ namespace OpenTap
         /// <summary>  The members and objects that make up the aggregation of this parameter. </summary>
         public IEnumerable<(object Source, IMemberData Member)> ParameterizedMembers => parameterMembers;
 
-        internal bool ContainsMember((object Source, IMemberData Member) memberKey) => parameterMembers.Contains(memberKey.Source, memberKey.Member);
+
+        internal bool ContainsMember(object Source, IMemberData Member) => parameterMembers.Contains(Source, Member);
 
         /// <summary> The target object type. </summary>
         public ITypeData DeclaringType { get; }

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -274,7 +274,7 @@ namespace OpenTap
         }
 
         /// <summary>  Call on a ParameterMemberData to remove itself from its parent type. </summary>
-        internal void Remove()
+        public void Remove()
         {
             while (ParameterizedMembers.Any())
             {

--- a/Engine/ParameterManager.cs
+++ b/Engine/ParameterManager.cs
@@ -493,7 +493,7 @@ namespace OpenTap
         
         static bool isParameterized(ITestStepParent item, IMemberData member) => item.GetParents().Any(parent =>
             TypeData.GetTypeData(parent).GetMembers().OfType<ParameterMemberData>()
-                .Any(x => x.ContainsMember((item, Member: member))));
+                .Any(x => x.ContainsMember(item, member)));
         static bool IsValidParameter(IMemberData property, ITestStepParent[] steps, bool checkTestPlan = true)
         {
             if (steps.Length == 0) return false;

--- a/Shared/ReflectionHelper.cs
+++ b/Shared/ReflectionHelper.cs
@@ -422,7 +422,6 @@ namespace OpenTap
 
         public static bool ContainsMember(this IParameterMemberData p, (object Source, IMemberData Member) item)
         {
-            if (p is ParameterMemberData p2) return p2.ContainsMember(item);
             return p.ParameterizedMembers.Contains(item);
         }
             


### PR DESCRIPTION
- Added code to convert a test plan reference to a sequence step.
- Added handling for mixins and parameters
- Not working: If a setting is parameterized to a parent.

![image](https://github.com/user-attachments/assets/b197405e-03ed-4fee-8055-3c490f1543f8)

![image](https://github.com/user-attachments/assets/072fbe61-bd75-47bd-a0b3-16e6730bb2eb)


![image](https://github.com/user-attachments/assets/f41caf64-25ce-4218-bef0-bf4e939105c0)


Close #1762