### PR TITLE
Use Reference instead of ReferencePathWIthRefAssemblies

### DIFF
--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -159,7 +159,7 @@
     </AddAssemblyReferencesFromPackage>
     <Touch Files="$(MSBuildThisFileFullPath)"/>
     <ItemGroup>
-      <ReferencePathWithRefAssemblies Include="@(_OpenTapPackagesReferences-> '$(OutDir)%(Identity)')"/>
+      <Reference Include="@(_OpenTapPackagesReferences-> '$(OutDir)%(Identity)')"/>
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
For unclear reasons, WPF intermediate builds don't pick up references added with ReferencePathWithRefAssemblies, but references added with the Reference element are added just fine.

This fixes an issue that causes WPF builds using OpenTapPackageReference to fail the first time.

We currently have workarounds in various WPF projects that involve setting up a dummy project that installs packages, and then manually referencing assemblies from those packages. This should no longer be needed.