### PR TITLE
1687 build time gitversion

### DIFF
--- a/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
+++ b/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
@@ -120,7 +120,7 @@ conditionally control it through an environment variable:
   <OpenTapSetAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' == ''">true</OpenTapSetAssemblyVersion>
   <!-- Otherwise use the version from the environment variable -->
   <OpenTapSetAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' != ''">
-    <GitVersion>$(SomeVersionFromEnvironment)</GitVersion>
+    <Version>$(SomeVersionFromEnvironment)</Version>
   </OpenTapSetAssemblyVersion>
 </PropertyGroup>
 ```

--- a/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
+++ b/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
@@ -99,7 +99,7 @@ To do so, set the following options in a property group in your .csproj file:
   <!-- Must be set. otherwise the compiler will not version the output -->
   <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   <!-- Enable automatic versioning -->
-  <OpenTapSetAssemblyVersion>true</OpenTapSetAssemblyVersion>
+  <OpenTapSetAssemblyVersion>gitversion</OpenTapSetAssemblyVersion>
 </PropertyGroup>
 ```
 
@@ -117,7 +117,7 @@ conditionally control it through an environment variable:
   <!-- Must be set. otherwise the compiler will not version the output -->
   <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   <!-- Calculate the version if it is not controlled by an environment variable -->
-  <OpenTapSetAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' == ''">true</OpenTapSetAssemblyVersion>
+  <OpenTapSetAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' == ''">gitversion</OpenTapSetAssemblyVersion>
   <!-- Otherwise use the version from the environment variable -->
   <OpenTapSetAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' != ''">
     <Version>$(SomeVersionFromEnvironment)</Version>

--- a/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
+++ b/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
@@ -89,6 +89,44 @@ You can also specify a package that you just want installed (in e.g. bin/Debug/)
 </ItemGroup>
 ```
 
+### Versioning Assemblies with OpenTapGitAssistedAssemblyVersion
+
+If you are already using [Git Assisted Versioning](../Plugin%20Packaging%20and%20Versioning/Readme.html#git-assisted-versioning), you can automatically version your DLLs during build.
+To do so, set the following options in a property group in your .csproj file:
+
+```xml
+<PropertyGroup>
+  <!-- Must be set. otherwise the compiler will not version the output -->
+  <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+  <!-- Enable automatic versioning -->
+  <OpenTapGitAssistedAssemblyVersion>true</OpenTapGitAssistedAssemblyVersion>
+</PropertyGroup>
+```
+
+This feature requires that:
+
+1. Your project directory is tracked by git.
+2. You have configured git-assisted-versioning.
+3. Your git directory is a full clone (as opposed to a shallow clone, which many CI systems default to).
+
+If you are operating on a shallow clone, and still wish to version your assemblies according to some known version number, you can 
+conditionally control it through an environment variable:
+
+```xml
+<PropertyGroup>
+  <!-- Must be set. otherwise the compiler will not version the output -->
+  <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+  <!-- Calculate the version if it is not controlled by an environment variable -->
+  <OpenTapGitAssistedAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' == ''">true</OpenTapGitAssistedAssemblyVersion>
+  <!-- Otherwise use the version from the environment variable -->
+  <OpenTapGitAssistedAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' != ''">
+    <GitVersion>$(SomeVersionFromEnvironment)</GitVersion>
+  </OpenTapGitAssistedAssemblyVersion>
+</PropertyGroup>
+```
+
+When a version is explicitly specified like this, OpenTAP will use this version instead of trying to calculate it.
+
 ## SDK Package
 
 The Software Development Kit (SDK) package demonstrates the core capabilities of OpenTAP and makes it faster and simpler to develop your solutions. It also contains the Developer Guide which contains documentation relevant for developers.

--- a/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
+++ b/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
@@ -89,7 +89,7 @@ You can also specify a package that you just want installed (in e.g. bin/Debug/)
 </ItemGroup>
 ```
 
-### Versioning Assemblies with OpenTapGitAssistedAssemblyVersion
+### Versioning Assemblies with OpenTapSetAssemblyVersion
 
 If you are already using [Git Assisted Versioning](../Plugin%20Packaging%20and%20Versioning/Readme.html#git-assisted-versioning), you can automatically version your DLLs during build.
 To do so, set the following options in a property group in your .csproj file:
@@ -99,7 +99,7 @@ To do so, set the following options in a property group in your .csproj file:
   <!-- Must be set. otherwise the compiler will not version the output -->
   <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   <!-- Enable automatic versioning -->
-  <OpenTapGitAssistedAssemblyVersion>true</OpenTapGitAssistedAssemblyVersion>
+  <OpenTapSetAssemblyVersion>true</OpenTapSetAssemblyVersion>
 </PropertyGroup>
 ```
 
@@ -117,11 +117,11 @@ conditionally control it through an environment variable:
   <!-- Must be set. otherwise the compiler will not version the output -->
   <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   <!-- Calculate the version if it is not controlled by an environment variable -->
-  <OpenTapGitAssistedAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' == ''">true</OpenTapGitAssistedAssemblyVersion>
+  <OpenTapSetAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' == ''">true</OpenTapSetAssemblyVersion>
   <!-- Otherwise use the version from the environment variable -->
-  <OpenTapGitAssistedAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' != ''">
+  <OpenTapSetAssemblyVersion Condition="'$(SomeVersionFromEnvironment)' != ''">
     <GitVersion>$(SomeVersionFromEnvironment)</GitVersion>
-  </OpenTapGitAssistedAssemblyVersion>
+  </OpenTapSetAssemblyVersion>
 </PropertyGroup>
 ```
 

--- a/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
+++ b/doc/Developer Guide/Getting Started in Visual Studio/Readme.md
@@ -127,6 +127,12 @@ conditionally control it through an environment variable:
 
 When a version is explicitly specified like this, OpenTAP will use this version instead of trying to calculate it.
 
+> NOTE: `GenerateAssemblyInfo` is incompatible with the
+> `[assembly:AssemblyVersionAttribute()]` attribute. If you are currently using
+> this attribute to set your assembly version, you should delete it before
+> using this feature. Otherwise you will see compiler errors such as `Duplicate
+> 'System.Reflection.AssemblyVersionAttribute' attribute.`
+
 ## SDK Package
 
 The Software Development Kit (SDK) package demonstrates the core capabilities of OpenTAP and makes it faster and simpler to develop your solutions. It also contains the Developer Guide which contains documentation relevant for developers.

--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -163,26 +163,26 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CheckVersioningVariables" BeforeTargets="Build">
+  <Target Name="OpenTapCheckVersioningVariables" BeforeTargets="Build">
     <Error 
-    Condition="'$(OpenTapGitAssistedAssemblyVersion)' != '' AND '$(OpenTapGitAssistedAssemblyVersion)' != 'false' AND '$(GenerateAssemblyInfo)' != 'true'"
-           Text="OpenTapGitAssistedAssemblyVersion was specified, but GenerateAssemblyInfo is false. Please set GenerateAssemblyInfo to true."/>
+    Condition="'$(OpenTapSetAssemblyVersion)' != '' AND '$(OpenTapSetAssemblyVersion)' != 'false' AND '$(GenerateAssemblyInfo)' != 'true'"
+           Text="OpenTapSetAssemblyVersion was specified, but GenerateAssemblyInfo is false. Please set GenerateAssemblyInfo to true."/>
   </Target>
 
-  <UsingTask TaskName="Keysight.OpenTap.Sdk.MSBuild.SetGitVersion" AssemblyFile="$(MSBuildThisFileDirectory)\Keysight.OpenTap.Sdk.MSBuild.dll"/>
+  <UsingTask TaskName="Keysight.OpenTap.Sdk.MSBuild.CalculateVersion" AssemblyFile="$(MSBuildThisFileDirectory)\Keysight.OpenTap.Sdk.MSBuild.dll"/>
   <Target 
-    Condition="'$(OpenTapGitAssistedAssemblyVersion)' != '' AND '$(OpenTapGitAssistedAssemblyVersion)' != 'false'"
-    Name="OpenTapGitAssistedAssemblyVersion"
-    AfterTargets="CheckVersioningVariables"
+    Condition="'$(OpenTapSetAssemblyVersion)' != '' AND '$(OpenTapSetAssemblyVersion)' != 'false'"
+    Name="OpenTapCalculateAssemblyVersion"
+    AfterTargets="OpenTapCheckVersioningVariables"
     BeforeTargets="GetAssemblyAttributes">
-    <SetGitVersion 
+    <CalculateVersion 
       TapDir="$(OutDir)"
-      InputGitVersion="$(OpenTapGitAssistedAssemblyVersion)"
+      InputGitVersion="$(OpenTapSetAssemblyVersion)"
       SourceFile="$(MSBuildProjectFullPath)"
       >
       <Output TaskParameter="OutputShortVersion" ItemName="_OpenTapPluginVersion"/>
       <Output TaskParameter="OutputGitVersion" ItemName="_OpenTapPluginInformationalVersion"/>
-    </SetGitVersion>
+    </CalculateVersion>
     <PropertyGroup>
       <Version>@(_OpenTapPluginVersion)</Version>
       <AssemblyVersion>@(_OpenTapPluginVersion)</AssemblyVersion>

--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -177,11 +177,11 @@
     BeforeTargets="GetAssemblyAttributes">
     <CalculateVersion 
       TapDir="$(OutDir)"
-      InputGitVersion="$(OpenTapSetAssemblyVersion)"
+      InputVersion="$(OpenTapSetAssemblyVersion)"
       SourceFile="$(MSBuildProjectFullPath)"
       >
       <Output TaskParameter="OutputShortVersion" ItemName="_OpenTapPluginVersion"/>
-      <Output TaskParameter="OutputGitVersion" ItemName="_OpenTapPluginInformationalVersion"/>
+      <Output TaskParameter="OutputLongVersion" ItemName="_OpenTapPluginInformationalVersion"/>
     </CalculateVersion>
     <PropertyGroup>
       <Version>@(_OpenTapPluginVersion)</Version>

--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -162,4 +162,33 @@
       <Reference Include="@(_OpenTapPackagesReferences-> '$(OutDir)%(Identity)')"/>
     </ItemGroup>
   </Target>
+
+  <Target Name="CheckVersioningVariables" BeforeTargets="Build">
+    <Error 
+    Condition="'$(OpenTapGitAssistedAssemblyVersion)' != '' AND '$(OpenTapGitAssistedAssemblyVersion)' != 'false' AND '$(GenerateAssemblyInfo)' != 'true'"
+           Text="OpenTapGitAssistedAssemblyVersion was specified, but GenerateAssemblyInfo is false. Please set GenerateAssemblyInfo to true."/>
+  </Target>
+
+  <UsingTask TaskName="Keysight.OpenTap.Sdk.MSBuild.SetGitVersion" AssemblyFile="$(MSBuildThisFileDirectory)\Keysight.OpenTap.Sdk.MSBuild.dll"/>
+  <Target 
+    Condition="'$(OpenTapGitAssistedAssemblyVersion)' != '' AND '$(OpenTapGitAssistedAssemblyVersion)' != 'false'"
+    Name="OpenTapGitAssistedAssemblyVersion"
+    AfterTargets="CheckVersioningVariables"
+    BeforeTargets="GetAssemblyAttributes">
+    <SetGitVersion 
+      TapDir="$(OutDir)"
+      InputGitVersion="$(OpenTapGitAssistedAssemblyVersion)"
+      SourceFile="$(MSBuildProjectFullPath)"
+      >
+      <Output TaskParameter="OutputShortVersion" ItemName="_OpenTapPluginVersion"/>
+      <Output TaskParameter="OutputGitVersion" ItemName="_OpenTapPluginInformationalVersion"/>
+    </SetGitVersion>
+    <PropertyGroup>
+      <Version>@(_OpenTapPluginVersion)</Version>
+      <AssemblyVersion>@(_OpenTapPluginVersion)</AssemblyVersion>
+      <FileVersion>@(_OpenTapPluginVersion).0</FileVersion>
+      <InformationalVersion>@(_OpenTapPluginInformationalVersion)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/sdk/OpenTap.Sdk.MSBuild/CalculateVersion.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/CalculateVersion.cs
@@ -14,9 +14,9 @@ namespace Keysight.OpenTap.Sdk.MSBuild
     /// MSBuild Task to version the build output using gitversion.
     /// </summary>
     [Serializable]
-    public class SetGitVersion : Task, ICancelableTask
+    public class CalculateVersion : Task, ICancelableTask
     {
-        private const string TargetName = "OpenTapGitAssistedAssemblyVersion";
+        private const string TargetName = "OpenTapSetAssemblyVersion";
         /// <summary>
         /// The build directory containing 'tap.exe' and 'OpenTAP.dll'
         /// </summary>

--- a/sdk/OpenTap.Sdk.MSBuild/CalculateVersion.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/CalculateVersion.cs
@@ -96,7 +96,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             stdout = outStream.ToString();
             stderr = errStream.ToString();
 
-            return true;
+            return proc.ExitCode == 0;
         }
 
         private bool isWindows()
@@ -215,7 +215,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             // 3. An xml tag enclosing a value, such as <GitVersion>1.2.3</GitVersion>
 
             // Case 1: calculate the version
-            if (new[] { "true", "1" }.Contains(InputVersion.Trim(), StringComparer.OrdinalIgnoreCase))
+            if (new[] { "true", "1" , "gitversion", "auto", "git" }.Contains(InputVersion.Trim(), StringComparer.OrdinalIgnoreCase))
             {
                 if (tryCalculateGitversion(out shortVersion, out longVersion))
                 {

--- a/sdk/OpenTap.Sdk.MSBuild/SetGitVersion.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/SetGitVersion.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Task = Microsoft.Build.Utilities.Task;
+
+namespace Keysight.OpenTap.Sdk.MSBuild
+{
+    /// <summary>
+    /// MSBuild Task to version the build output using gitversion.
+    /// </summary>
+    [Serializable]
+    public class SetGitVersion : Task, ICancelableTask
+    {
+        private const string TargetName = "OpenTapGitAssistedAssemblyVersion";
+        /// <summary>
+        /// The build directory containing 'tap.exe' and 'OpenTAP.dll'
+        /// </summary>
+        public string TapDir { get; set; }
+
+        /// <summary>
+        /// csproj file. This is needed because OpenTAP supports multiple gitversion files.
+        /// Gitversion should be resolved from the directory containing the project file.
+        /// </summary>
+        public string SourceFile { get; set; }
+
+        /// <summary>
+        /// Optional input gitversion. This is useful in CI pipelines where shallow clones
+        /// are used for performance reasons.
+        /// </summary>
+        public string InputGitVersion { get; set; }
+        
+        /// <summary>
+        /// The output gitversion.
+        /// </summary>
+        [Microsoft.Build.Framework.Output]
+        public string OutputShortVersion { get; set; }
+
+        /// <summary>
+        /// The output gitversion plus informational version.
+        /// </summary>
+        [Microsoft.Build.Framework.Output]
+        public string OutputGitVersion { get; set; }
+
+        private bool tryParseXElement(string text, out XElement elem)
+        {
+            try
+            {
+                elem = XElement.Parse(text, LoadOptions.None);
+                return true;
+            }
+            catch
+            {
+                elem = null;
+                return false;
+            }
+        }
+
+        private bool runProcess(string filename, string arguments, string workingDirectory, out string stdout,
+            out string stderr)
+        {
+            var si = new ProcessStartInfo(filename, arguments)
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                WorkingDirectory = workingDirectory,
+            };
+            var errStream = new StringBuilder();
+            var outStream = new StringBuilder();
+            var proc = new Process();
+            proc.StartInfo = si;
+            proc.OutputDataReceived += (_, data) =>
+            {
+                if (!string.IsNullOrWhiteSpace(data?.Data)) outStream.Append(data.Data);
+            };
+            proc.ErrorDataReceived += (_, data) =>
+            {
+                if (!string.IsNullOrWhiteSpace(data?.Data)) errStream.Append(data.Data);
+            };
+            proc.Start();
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+            proc.WaitForExit(10000); 
+
+            if (!proc.HasExited)
+            {
+                stdout = stderr = null;
+                Log.LogError($"{TargetName}: tap sdk gitversion appears to hanging.");
+                return false;
+            }
+            stdout = outStream.ToString();
+            stderr = errStream.ToString();
+
+            return true;
+        }
+
+        private bool isWindows()
+        {
+            switch (Environment.OSVersion.Platform)
+            {
+                case PlatformID.Win32NT:
+                case PlatformID.Win32S:
+                case PlatformID.Win32Windows:
+                case PlatformID.WinCE:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        // Check if a file with the given name exists in any ancestor directory
+        private bool fileIsAncestor(string name, DirectoryInfo root)
+        {
+            var comparer = isWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            while (root != null)
+            {
+                if (root.EnumerateFileSystemInfos().Any(i => i.Name.Equals(name, comparer)))
+                    return true;
+                root = root.Parent;
+            }
+
+            return false;
+        }
+
+        // This does not need to be perfect.
+        private static Regex gitversionRegex = new Regex(@"^\d+\.\d+\.\d+", RegexOptions.Compiled); 
+        private bool tryParseGitVersion(string inputGitVersion, out string shortVersion, out string gitversion)
+        {
+            inputGitVersion = inputGitVersion.Trim();
+            var m = gitversionRegex.Match(inputGitVersion);
+            if (m.Success)
+            {
+                shortVersion = m.Value;
+                gitversion = inputGitVersion;
+                return true;
+            }
+
+            shortVersion = gitversion = null;
+            return false;
+        }
+
+        private bool tryCalculateGitversion(out string shortVersion, out string gitversion)
+        {
+            shortVersion = null;
+            gitversion = null;
+
+            var workingDirectory = Path.GetDirectoryName(SourceFile);
+            var dirInfo = new DirectoryInfo(workingDirectory);
+
+            // Ensure this is a git repository
+            if (!fileIsAncestor(".git", dirInfo))
+            {
+                Log.LogError(
+                    $"{TargetName}: The project file '{SourceFile}' is not in a git directory. {TargetName} is only supported in git projects.");
+                return false;
+            }
+
+            // And that it uses gitversioning
+            if (!fileIsAncestor(".gitversion", dirInfo))
+            {
+                Log.LogError(
+                    $"{TargetName}: This project does not have a .gitversion file. {TargetName} is only supported in gitversion projects.\n" +
+                    $"See https://doc.opentap.io/Developer%20Guide/Plugin%20Packaging%20and%20Versioning/Readme.html#git-assisted-versioning");
+                return false;
+            }
+
+            // Start a subprocess to get the gitversion. There are a couple of reasons we don't calculate it in-process:
+            // 1. libgit uses a native dll which is annoying to load. OpenTAP already includes logic for this which
+            // makes several assumptions that do not apply during dotnet build.
+            // 2. GitVersionCalculator is internal, and I would prefer to not make it public.
+            // For these reasons, it is much simpler to just start a process and parse the output.
+            string tapName = isWindows() ? "tap.exe" : "tap";
+            var tap = Path.Combine(TapDir, tapName);
+            if (!runProcess(tap, "sdk gitversion", workingDirectory, out var stdout, out var stderr))
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(stderr))
+            {
+                // This could indicate a problem, but logging it as an error would fail the build.
+                // Log it as a warning instead so the user is at least aware
+                Log.LogWarning(stderr);
+            }
+
+            // There could potentially be multiple lines in the output due diagnostics or warnings from OpenTAP.
+            // Find the line that looks like a gitversion
+            var lines = stdout.Split('\n').Select(line => line.Trim()).ToArray();
+
+            foreach (var l in lines)
+            {
+                if (tryParseGitVersion(l, out shortVersion, out gitversion))
+                    return true;
+            }
+
+            Log.LogError($"{TargetName}: Unable to parse gitversion from output:\n{stdout}");
+
+            return false;
+        } 
+
+        public override bool Execute()
+        {
+            string shortVersion;
+            string longVersion;
+            string input;
+
+            // parse input gitversion. It can have a couple of different formats:
+            // 1. A flag, such as '1' or 'true'
+            // 2. A semantic version
+            // 3. An xml tag enclosing a value, such as <GitVersion>1.2.3</GitVersion>
+
+            // Case 1: calculate the version
+            if (new[] { "true", "1" }.Contains(InputGitVersion.Trim(), StringComparer.OrdinalIgnoreCase))
+            {
+                if (tryCalculateGitversion(out shortVersion, out longVersion))
+                {
+                    OutputShortVersion = shortVersion;
+                    OutputGitVersion = longVersion;
+                    return true;
+                }
+
+                return false;
+            }
+
+            // Case 2/3: parse the provided version from the input
+            if (!tryParseXElement($"<{TargetName}>{InputGitVersion.Trim()}</{TargetName}>", out var elem))
+            {
+                // This should not be possible since the input is exactly the inner text of the .csproj property element.
+                // If the input is not valid xml, then the compilation should have already failed.
+                Log.LogError($"{TargetName}: Failed to parse input.");
+                return false;
+            }
+            
+            if (elem.Element("GitVersion") is XElement gv)
+            {
+                input = gv.Value.Trim();
+            }
+            else if (tryParseGitVersion(elem.Value.Trim(), out _, out _))
+            {
+                input = elem.Value.Trim();
+            }
+            else
+            { 
+                Log.LogError($"{TargetName}: Expected element named 'GitVersion'.");
+                return false;
+            }
+
+            if (!tryParseGitVersion(input, out shortVersion, out longVersion))
+            {
+                Log.LogError($"{TargetName}: Provided gitversion is not a valid semantic version: '{input}'"); 
+                return false;
+            }
+            
+            OutputShortVersion = shortVersion;
+            OutputGitVersion = longVersion;
+            return true; 
+        }
+
+        public void Cancel()
+        {
+            // No cancel logic needed
+        }
+    }
+}


### PR DESCRIPTION
This adds support for versioning assemblies with GitVersion during build. This is an alternative to versioning assemblies in the packaging stage with `<File Path="my.dll"><SetAssemblyInfo Attributes="Version"/></File>`

This also correctly sets the version information in the appropriate PE sections (example from local test with the CSV plugin) on both Windows and Linux so it shows up in the Properties tab of a file. This is an improvement on our current `SetAssemblyInfo` implementation which only works on Windows because it relies on P/Invoke APIs.

![image](https://github.com/user-attachments/assets/60199dda-8efb-4351-bf29-634dbc76075b)


Closes #1687 