### PR TITLE
fix gitversion calculation in pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,13 +237,6 @@ jobs:
       - name: Fix tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} # Fixes an issue with actions/checkout@v4. See https://github.com/actions/checkout/issues/290
-      - name: Nuget Cache
-        uses: actions/cache@v4
-        id: cache
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }} #hash of project files
-          restore-keys: ${{ runner.os }}-nuget-
       - name: Stamp Version
         run: |
           $AssemblyVersion = "`"${{needs.GetVersion.outputs.ShortVersion}}.0`""
@@ -257,14 +250,8 @@ jobs:
           $AssemblyInfoFile | Set-Content AssemblyInfo.cs
           cat AssemblyInfo.cs
           Pop-Location
-      - name: Restore
-        #if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          dotnet restore /p:Platform=${{ matrix.Architecture }}
       - name: Build
-        run: dotnet build --no-restore -c Release /p:Platform=${{ matrix.Architecture }}
-      - name: Build tap.csproj
-        run: dotnet build --no-restore tap/tap.csproj -c Release /p:Platform=${{ matrix.Architecture }}
+        run: dotnet build -c Release /p:Platform=${{ matrix.Architecture }}
       - name: cat tap.runtimeconfig.json 
         run: get-content ./bin/Release/tap.runtimeconfig.json
       - name: Upload binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Fix main branch
+        if: github.ref != 'refs/heads/main'
+        run: git pull origin main:main # Fixes an issue where the gitversion calculation can produce different results if the local main branch is out of date
       - name: Fix tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} # Fixes an issue with actions/checkout@v4. See https://github.com/actions/checkout/issues/290
@@ -613,6 +616,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Fix main branch
+        if: github.ref != 'refs/heads/main'
+        run: git pull origin main:main # Fixes an issue where the gitversion calculation can produce different results if the local main branch is out of date
       - name: Fix tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} # Fixes an issue with actions/checkout@v4. See https://github.com/actions/checkout/issues/290


### PR DESCRIPTION
Our gitversion calculation for alpha packages is currently dependent on the local revision of the beta (main) branch. This causes issues for our windows runners because they are re-using the same git directory for different builds, and the checkout action does not update other branches than the one being worked on.

This ensures the main branch is up to date where it is relevant.