### PR TITLE
fix gitversion calculation when local revision of beta branch is outdated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,13 +237,6 @@ jobs:
       - name: Fix tags
         if: startsWith(github.ref, 'refs/tags/v')
         run: git fetch -f origin ${{ github.ref }}:${{ github.ref }} # Fixes an issue with actions/checkout@v4. See https://github.com/actions/checkout/issues/290
-      - name: Nuget Cache
-        uses: actions/cache@v4
-        id: cache
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }} #hash of project files
-          restore-keys: ${{ runner.os }}-nuget-
       - name: Stamp Version
         run: |
           $AssemblyVersion = "`"${{needs.GetVersion.outputs.ShortVersion}}.0`""
@@ -257,14 +250,8 @@ jobs:
           $AssemblyInfoFile | Set-Content AssemblyInfo.cs
           cat AssemblyInfo.cs
           Pop-Location
-      - name: Restore
-        #if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          dotnet restore /p:Platform=${{ matrix.Architecture }}
       - name: Build
-        run: dotnet build --no-restore -c Release /p:Platform=${{ matrix.Architecture }}
-      - name: Build tap.csproj
-        run: dotnet build --no-restore tap/tap.csproj -c Release /p:Platform=${{ matrix.Architecture }}
+        run: dotnet build -c Release /p:Platform=${{ matrix.Architecture }}
       - name: cat tap.runtimeconfig.json 
         run: get-content ./bin/Release/tap.runtimeconfig.json
       - name: Upload binaries

--- a/Package/CreatePackage/GitVersionCalculator.cs
+++ b/Package/CreatePackage/GitVersionCalculator.cs
@@ -419,13 +419,11 @@ namespace OpenTap.Package
                 var unreachableCommits = (IQueryableCommitLog)repo.Commits.QueryBy(new CommitFilter() { IncludeReachableFrom = b1.Tip, ExcludeReachableFrom = b1.TrackedBranch.Tip});
                 if (unreachableCommits.Any())
                 {
-                    log.Debug($"The local branch '{b1.GetShortName()}' contains commits not contained in the remote tracking branch. The local branch will be used for gitversion calculation.");
+                    throw new Exception(
+                        $"The local branch '{b1.GetShortName()}' contains commits missing from the tracked upstream branch.\n" +
+                        $"This can cause unexpected mismatching version numbers. Please align '{b1.GetShortName()}' with its upstream.");
                 }
-                else 
-                {
-                    log.Debug($"The local branch '{b1.GetShortName()}' is fully merged in the remote tracking branch. The remote branch will be used for gitversion calculation.");
-                    b1 = b1.TrackedBranch;
-                }
+                b1 = b1.TrackedBranch;
             }
 
             Commit b1Commit = b1.Tip;

--- a/Package/CreatePackage/GitVersionCalculator.cs
+++ b/Package/CreatePackage/GitVersionCalculator.cs
@@ -415,14 +415,15 @@ namespace OpenTap.Package
             // This should make the gitversion calculation work as expected after `git fetch --all`.
             if (b1.TrackedBranch != null)
             {
+                // Check if all local commits are reachable from the tracking branch
                 var unreachableCommits = (IQueryableCommitLog)repo.Commits.QueryBy(new CommitFilter() { IncludeReachableFrom = b1.Tip, ExcludeReachableFrom = b1.TrackedBranch.Tip});
                 if (unreachableCommits.Any())
                 {
-                    log.Debug($"{b1.GetShortName()} contains commits not contained in the tracked branch, and will be used for gitversion calculation.");
+                    log.Debug($"The local branch '{b1.GetShortName()}' contains commits not contained in the remote tracking branch. The local branch will be used for gitversion calculation.");
                 }
                 else 
                 {
-                    log.Debug($"The remote tracking branch of {b1.GetShortName()} contains all local commits and will be used for gitversion calculation.");
+                    log.Debug($"The local branch '{b1.GetShortName()}' is fully merged in the remote tracking branch. The remote branch will be used for gitversion calculation.");
                     b1 = b1.TrackedBranch;
                 }
             }

--- a/Package/CreatePackage/GitVersionCalculator.cs
+++ b/Package/CreatePackage/GitVersionCalculator.cs
@@ -415,9 +415,9 @@ namespace OpenTap.Package
             // This should make the gitversion calculation work as expected after `git fetch --all`.
             if (b1.TrackedBranch != null)
             {
-                // Check if all local commits are reachable from the tracking branch
-                var unreachableCommits = (IQueryableCommitLog)repo.Commits.QueryBy(new CommitFilter() { IncludeReachableFrom = b1.Tip, ExcludeReachableFrom = b1.TrackedBranch.Tip});
-                if (unreachableCommits.Any())
+                // Check if any local commits are unreachable from the tracking branch
+                var commitsMissingFromUpstream = (IQueryableCommitLog)repo.Commits.QueryBy(new CommitFilter() { IncludeReachableFrom = b1.Tip, ExcludeReachableFrom = b1.TrackedBranch.Tip});
+                if (commitsMissingFromUpstream.Any())
                 {
                     throw new Exception(
                         $"The local branch '{b1.GetShortName()}' contains commits missing from the tracked upstream branch.\n" +


### PR DESCRIPTION
Our current gitversion calculation is based on the tip of the local beta branch. This can lead to confusing behavior because it can cause the version of an alpha branch to change if an older version of the main branch is checked out, even if the relevant history is available in the local git index (e.g. by running git fetch main)

To fix this, we should check if the beta branch is fully merged in the remote tracking branch, and if this is the case, base the calculation on that instead.

This should lead to the least surprising behavior, since local commits to the main branch will still be reflected, and pulling an updated alpha branch (which may be based on a newer main branch) will still get the correct gitversion even without manually updating the local main branch.

Closes #1780 