### PR TITLE
1765 improve system runtime exceptions

### DIFF
--- a/Engine/Cli/CliActionExecutor.cs
+++ b/Engine/Cli/CliActionExecutor.cs
@@ -331,6 +331,12 @@ namespace OpenTap.Cli
                 log.Info("{0}", e.Message);
                 return (int)ExitCodes.UnknownCliAction;
             }
+            catch (InvalidOperationException ex)
+            {
+                log.Error("Unable to load CLI Action '{0}'", SelectedAction.GetDisplayAttribute().GetFullName());
+                log.Info("{0}", ex.Message);
+                return (int)ExitCodes.GeneralException;
+            }
             
             if (packageAction == null)
             {

--- a/tests/package-create-error.TapPlan
+++ b/tests/package-create-error.TapPlan
@@ -110,7 +110,7 @@
           <BreakConditions>Inherit</BreakConditions>
         </TestStep>
       </ChildTestSteps>
-      <BreakConditions>Inherit</BreakConditions>
+      <BreakConditions>BreakOnError</BreakConditions>
     </TestStep>
     <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.ReplaceInFileStep" Version="0.0.0" Id="7dba2808-7a59-46fb-b0b3-3f168c7ab560">
       <File>../../NewProj/NewProj.csproj</File>
@@ -237,7 +237,7 @@
               <BreakConditions>Inherit</BreakConditions>
             </TestStep>
           </ChildTestSteps>
-          <BreakConditions>Inherit</BreakConditions>
+          <BreakConditions>BreakOnError</BreakConditions>
         </TestStep>
       </ChildTestSteps>
       <BreakConditions>Inherit</BreakConditions>

--- a/tests/regression.TapPlan
+++ b/tests/regression.TapPlan
@@ -114,6 +114,7 @@
           <Name Metadata="Step Name">Test Plan {Referenced Plan}</Name>
         </TestStep>
       </ChildTestSteps>
+      <BreakConditions>BreakOnError, BreakOnFail</BreakConditions>
     </TestStep>
   </Steps>
 </TestPlan>

--- a/tests/run-parse-test.TapPlan
+++ b/tests/run-parse-test.TapPlan
@@ -72,7 +72,7 @@
         <TestStep type="OpenTap.Engine.UnitTests.TestTestSteps.ExpectStep" Version="0.0.0" Id="66ddb666-f317-4e0d-b5b4-773d4f18bc30">
           <ExpectedVerdict Parameter="Expected Verdict" Scope="91e27594-d0d9-4f48-b4d6-91caefd97942">Fail</ExpectedVerdict>
           <Enabled>true</Enabled>
-          <Name>Expect</Name>
+          <Name>Expect {ExpectedVerdict}</Name>
           <ChildTestSteps>
             <TestStep type="OpenTap.Plugins.BasicSteps.ProcessStep" Version="9.4.0-Development" Id="8bf0e1df-3e0e-4b85-b460-45cf89920e22">
               <Application>tap</Application>
@@ -100,7 +100,7 @@
               <BreakConditions>Inherit</BreakConditions>
             </TestStep>
           </ChildTestSteps>
-          <BreakConditions>Inherit</BreakConditions>
+          <BreakConditions>BreakOnError</BreakConditions>
         </TestStep>
       </ChildTestSteps>
       <BreakConditions>Inherit</BreakConditions>

--- a/tests/test-cli-load-plan-with-error.TapPlan
+++ b/tests/test-cli-load-plan-with-error.TapPlan
@@ -13,6 +13,7 @@
           <Name Metadata="Step Name">Run: {Application} {Command Line Arguments}</Name>
         </TestStep>
       </ChildTestSteps>
+      <BreakConditions>BreakOnError</BreakConditions>
     </TestStep>
   </Steps>
 </TestPlan>

--- a/tests/test-sdk-templates.TapPlan
+++ b/tests/test-sdk-templates.TapPlan
@@ -95,7 +95,7 @@
           <BreakConditions>Inherit</BreakConditions>
         </TestStep>
       </ChildTestSteps>
-      <BreakConditions>Inherit</BreakConditions>
+      <BreakConditions>BreakOnError</BreakConditions>
       <Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>sdk new project symbols?&amp;/()=</Parameters_x0020__x005C__x0020_Command_x0020_Line_x0020_Arguments>
     </TestStep>
     <TestStep type="OpenTap.Plugins.BasicSteps.SweepParameterStep" Version="9.4.0-Development" Id="8a6aa2a3-b87d-416a-b264-91886d44b78e">


### PR DESCRIPTION
This adds special handling when `System.Runtime` cannot be loaded, since this always means we tried to load an assembly which depends on dotnet 6+ in a .NET Framework process

Closes #1765 