### PR TITLE
1793 FilePathDocumentation: fix

### DIFF
--- a/doc/Developer Guide/Attributes/Readme.md
+++ b/doc/Developer Guide/Attributes/Readme.md
@@ -182,6 +182,14 @@ The syntax works as follows:
 
 Each filter comes in pairs of two, a name and a list of extensions. The name of a filter can be anything, excluding the '|' character. It normally contains the name of all the included file extensions, for example "Image Files (\*.png, \*.jpg)". The file extensions is normally not seen by the user, but should contain all the supported file extensions as a semi-colon separated list. Lastly, it is common practice to include the 'AllFiles | \*.\*' part, which makes it possible for the user to override the known filters and manually select any kind of file.
 
+In addition to string properties, the FilePath attribute can also be applied to List<string> types. For example:
+```cs
+[FilePath]
+public List<string> FilePaths {get;set;} = new List<string>();
+```
+
+When used this way, multiple files can be selected simultaneously, simplifying the process of choosing several files from the same directory. However, the user experience may vary across different platforms.
+
 ### Submit Attribute
 This attribute is used only for objects used together with UserInput.Request. It is used to mark the property that finalizes the input. For example this could be used with an enum to add an OK/Cancel button, that closes the dialog when clicked. See the example in UserInputExample.cs for an example of how to use it.
 

--- a/doc/Developer Guide/Attributes/Readme.md
+++ b/doc/Developer Guide/Attributes/Readme.md
@@ -182,7 +182,7 @@ The syntax works as follows:
 
 Each filter comes in pairs of two, a name and a list of extensions. The name of a filter can be anything, excluding the '|' character. It normally contains the name of all the included file extensions, for example "Image Files (\*.png, \*.jpg)". The file extensions is normally not seen by the user, but should contain all the supported file extensions as a semi-colon separated list. Lastly, it is common practice to include the 'AllFiles | \*.\*' part, which makes it possible for the user to override the known filters and manually select any kind of file.
 
-In addition to string properties, the FilePath attribute can also be applied to List<string> types. For example:
+In addition to string properties, the FilePath attribute can also be applied to `List<string>` types. For example:
 ```cs
 [FilePath]
 public List<string> FilePaths {get;set;} = new List<string>();

--- a/sdk/Examples/PluginDevelopment/TestSteps/Attributes/PathAttributeExample.cs
+++ b/sdk/Examples/PluginDevelopment/TestSteps/Attributes/PathAttributeExample.cs
@@ -21,6 +21,11 @@ namespace OpenTap.Plugins.PluginDevelopment
         // This will create a button that opens a dialog for browsing for files. 
         [FilePath]
         public string MyFilePath { get; set; }
+        
+        // This will create a button that opens a dialog for browsing for files. In this dialog multiple files can be selected at the same time. 
+        // in addition, a table format is used to show all the selected paths.
+        [FilePath]
+        public List<string> MyFilePaths { get; set; } = new List<string>();
 
         // This will create a button that opens a dialog for browsing for files. This dialog will also filter for CSV files, with 'any files' filter being optional.
         [FilePath(FilePathAttribute.BehaviorChoice.Open, "csv")]


### PR DESCRIPTION
Added documentation about using FilePathAttribute on List of strings.

Added SDK examples.

Close #1793
