### PR TITLE
1805 prerun mixin parameters not updated

### DIFF
--- a/Engine.UnitTests/MixinTests.cs
+++ b/Engine.UnitTests/MixinTests.cs
@@ -307,6 +307,68 @@ namespace OpenTap.UnitTests
             var isDisabled2 = enabled.Any(x => x.IsEnabled == false);
             Assert.IsFalse(isDisabled2);
 
+        } 
+        public class PrerunMixinModifyingParametersBuilder : IMixinBuilder
+        {
+            public void Initialize(ITypeData targetType)
+            {
+            }
+            
+            IEnumerable<Attribute> GetAttributes()
+            {
+                yield return new EmbedPropertiesAttribute();
+            }
+
+            public MixinMemberData ToDynamicMember(ITypeData targetType)
+            {
+                return new MixinMemberData(this, () => new PrerunMixinModifyingParameters())
+                {
+                    TypeDescriptor = TypeData.FromType(typeof(PrerunMixinModifyingParameters)),
+                    Writable = true,
+                    Readable = true,
+                    DeclaringType = targetType,
+                    Attributes = GetAttributes(),
+                    Name = nameof(PrerunMixinModifyingParameters) 
+                };
+            }
+        }
+        
+        public class PrerunMixinModifyingParameters : IMixin, ITestStepPreRunMixin
+        {
+            public PrerunMixinModifyingParameters()
+            {
+                
+            }
+            public void OnPreRun(TestStepPreRunEventArgs eventArgs)
+            {
+                var step = eventArgs.TestStep as LogStep;
+                step.LogMessage = "Hello Prerun";
+                step.StepRun.Parameters["Additional Parameter"] = "More Info";
+            }
+        }
+
+        [Test]
+        public void PrerunMixinModifyParametersTest()
+        { 
+            var plan = new TestPlan();
+            var step = new LogStep() { LogMessage = "No Prerun" };
+            plan.ChildTestSteps.Add(step);
+
+            { /* no mixin */
+                var rl = new RecordAllResultListener();
+                plan.Execute(new[] { rl });
+                var run = rl.RunStart.First(r => (r.Value as TestStepRun)?.TestStepId == step.Id).Value; 
+                Assert.AreEqual("No Prerun", run.Parameters["Log Message"]);
+            }
+
+            { /* prerun mixin */
+                MixinFactory.LoadMixin(step, new PrerunMixinModifyingParametersBuilder());
+                var rl = new RecordAllResultListener();
+                plan.Execute(new[] { rl });
+                var run = rl.RunStart.First(r => (r.Value as TestStepRun)?.TestStepId == step.Id).Value; 
+                Assert.AreEqual("Hello Prerun", run.Parameters["Log Message"]);
+                Assert.AreEqual("More Info", run.Parameters["Additional Parameter"]);
+            }
         }
 
         [Test]

--- a/Engine.UnitTests/Resources/RecordAllResultListener.cs
+++ b/Engine.UnitTests/Resources/RecordAllResultListener.cs
@@ -8,6 +8,7 @@ namespace OpenTap.UnitTests
 {
     public class RecordAllResultListener : ResultListener
     {
+        public Dictionary<Guid, TestStepRun> RunStart { get; set; } = new Dictionary<Guid, TestStepRun>();
         public Dictionary<Guid, TestRun> Runs { get; set; } = new Dictionary<Guid, TestRun>();
         public Dictionary<Guid, string> planLogs = new Dictionary<Guid, string>();
         public List<ResultTable> Results = new List<ResultTable>();
@@ -20,6 +21,7 @@ namespace OpenTap.UnitTests
         public override void OnTestStepRunStart(TestStepRun stepRun)
         {
             OnTestStepRunStartAction();
+            RunStart[stepRun.Id] = stepRun;
             Runs[stepRun.Id] = stepRun;
             Interlocked.Increment(ref running);
             base.OnTestStepRunStart(stepRun);

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -942,6 +942,12 @@ namespace OpenTap
             // evaluate pre run mixins
             bool skipStep = TestStepPreRunEvent.Invoke(Step).SkipStep;
 
+            // Update parameters after running prerun mixins. This is needed to reflect updated properties.
+            // Note that this does not handle the edge case where e.g. a PreRun mixin caused 
+            // the removal of a member sourced from some TypeData, but it is impossible to distinguish a TypeData parameter
+            // from a manually added 'steprun.Parameters["foo"] = "bar" - style parameter.
+            stepRun.Parameters.AddRange(ResultParameters.GetParams(Step));
+
             planRun.ThrottleResultPropagation();
 
             var previouslyExecutingTestStep = currentlyExecutingTestStep;


### PR DESCRIPTION
This fixes an issue causing updates to test step parameters in pre-run mixins to not be reflected in `StepRun.Parameters` in the `OnTestStepRunStart` event in result listeners

Closes #1805
