### PR TITLE
Create timestamps based on stopwatches instead of UtcNow

### DIFF
--- a/Engine/Logging/diag_impl.cs
+++ b/Engine/Logging/diag_impl.cs
@@ -19,10 +19,16 @@ namespace OpenTap.Diagnostic
         /// <summary> Prints a friendly name. </summary>
         /// <returns></returns>
         public override string ToString() => "Local and Accurate";
+        
+        // DateTime.UtcNow is not very accurate (Roughly 10-15ms accuracy)
+        // Stopwatches are much higher resolution. We can use Datetime to get a rough
+        // estimate of the current time, and stopwatches to the number of ticks that elapsed since it was created.
+        private readonly long UtcStart = DateTime.UtcNow.Ticks;
+        private readonly Stopwatch StopwatchStart = Stopwatch.StartNew();
         long ILogTimestampProvider.Timestamp()
         {
-            return DateTime.UtcNow.Ticks;
-        }
+            return UtcStart + StopwatchStart.ElapsedTicks;
+        } 
 
         Stopwatch sw = Stopwatch.StartNew();
         long UtcOffset = TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow).Ticks;


### PR DESCRIPTION
Measure time with stopwatches instead of UtcNow.Ticks

See remarks: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.utcnow?view=net-8.0#remarks

The system timer can be anything between 0.5ms to 15 ms. Session logs specify timestamps with 6 significant digits which is a bit misleading if we can only provide 2-3.

Closes #1808 