### PR TITLE
Add new syntax for asserting that a variable must be defined

### DIFF
--- a/Package.UnitTests/PackageXmlPreprocessorTests.cs
+++ b/Package.UnitTests/PackageXmlPreprocessorTests.cs
@@ -28,8 +28,8 @@ namespace OpenTap.Package.UnitTests
     <SourceUrl>{sourceUrl}</SourceUrl>
     <SignVar Condition=""{sign} == True"">true</SignVar>
   </Variables>
-  <SourceUrl Condition=""$(PlatformVar) == Windows"">$(SourceUrl)</SourceUrl>
-  <Owner Condition=""$(PlatformVar) == Linux"">$(Owner)</Owner>
+  <SourceUrl Condition=""$(PlatformVar) == Windows"">$!(SourceUrl)</SourceUrl>
+  <Owner Condition=""$!(PlatformVar) == Linux"">$(Owner)</Owner>
   <Files Condition=""a == b"">
     <File Path=""WrongFile""/>
   </Files>

--- a/Package/XmlEvaulation/ElementExpander.cs
+++ b/Package/XmlEvaulation/ElementExpander.cs
@@ -21,7 +21,8 @@ namespace OpenTap.Package
             foreach (var textNode in textNodes)
             {
                 var curr = textNode.Value;
-                var newValue = textNode.Value.Replace($"$({token})", value);
+                var newValue = textNode.Value.Replace($"$({token})", value)
+                    .Replace($"$!({token})", value);
 
                 if (curr != newValue)
                 {
@@ -33,7 +34,8 @@ namespace OpenTap.Package
             foreach (var attribute in element.Attributes().ToArray())
             {
                 var curr = attribute.Value;
-                var newValue = attribute.Value.Replace($"$({token})", value);
+                var newValue = attribute.Value.Replace($"$({token})", value)
+                    .Replace($"$!({token})", value);
 
                 if (curr != newValue)
                 {

--- a/Package/XmlEvaulation/IVariableProvider.cs
+++ b/Package/XmlEvaulation/IVariableProvider.cs
@@ -182,7 +182,9 @@ namespace OpenTap.Package
     [DependsOn(typeof(EnvironmentVariableExpander))]
     internal class DefaultVariableExpander : IElementExpander
     {
-        private static Regex VariableRegex = new Regex("\\$\\(.*?\\)");
+        private static Regex VariableRegex = new Regex("\\$!?\\(.*?\\)");
+        public HashSet<string> UndefinedVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         /// <summary>
         /// Replace all variables with an empty string. E.g. '$(whatever) -> '')'
         /// </summary>
@@ -195,17 +197,22 @@ namespace OpenTap.Package
             {
                 foreach (Match match in VariableRegex.Matches(textNode.Value))
                 {
+                    if (match.Value.StartsWith("$!("))
+                        UndefinedVariables.Add(match.Value.Substring(3, match.Value.Length - 4));
                     textNode.Value = textNode.Value.Replace(match.Value, "");
                 }
             }
 
-            foreach (var attribute in element.Attributes().ToArray())
+            var attributeNodes = element.Attributes().ToArray();
+            foreach (var attribute in attributeNodes)
             {
                 foreach (Match match in VariableRegex.Matches(attribute.Value))
                 {
+                    if (match.Value.StartsWith("$!("))
+                        UndefinedVariables.Add(match.Value.Substring(3, match.Value.Length - 4));
                     attribute.Value = attribute.Value.Replace(match.Value, "");
                 }
-            }
+            } 
         }
     }
 

--- a/Package/XmlEvaulation/PackageXmlPreprocessor.cs
+++ b/Package/XmlEvaulation/PackageXmlPreprocessor.cs
@@ -51,12 +51,12 @@ namespace OpenTap.Package
             InitExpander(projectPath);
         }
 
+        private readonly DefaultVariableExpander _defaultExpander = new DefaultVariableExpander();
         private void InitExpander(string projectPath = null)
         {
             // The project directory is required to compute the gitversion. If it is not set, GitVersion will not be computed.
             Expander.AddProvider(new GitVersionExpander(projectPath));
-
-            Expander.AddProvider(new DefaultVariableExpander());
+            Expander.AddProvider(_defaultExpander);
             Expander.AddProvider(new EnvironmentVariableExpander());
             Expander.AddProvider(new ConditionExpander());
 
@@ -91,6 +91,10 @@ namespace OpenTap.Package
             // but with conditions it makes sense to specify these elements multiple times with different conditions.
             // Their children should be merged in a single parent element so the XML is still valid according to the schema.
             MergeDuplicateElements(Root);
+            
+            if (_defaultExpander.UndefinedVariables.Any())
+                throw new Exception(
+                    $"The following required variables are not defined: {string.Join(", ", _defaultExpander.UndefinedVariables)}");
 
             return Root;
         }


### PR DESCRIPTION
This enables requiring that a variable is set. E.g.

```xml
<PackageDependency Name="OpenTAP" Version="^$!(OpenTapVersion)" />
```

`package create` will throw an appropriate exception if `OpenTapVersion` is not defined.