### PR TITLE
Test Plan Reference Removing Parameter Fix

### DIFF
--- a/BasicSteps/ExpandedMemberData.cs
+++ b/BasicSteps/ExpandedMemberData.cs
@@ -6,7 +6,7 @@ using System.Text.RegularExpressions;
 
 namespace OpenTap.Plugins.BasicSteps
 {
-    class ExpandedMemberData : IMemberData, IParameterMemberData
+    class ExpandedMemberData : IMemberData, IParameterMemberData, IDynamicMemberData
     {
         public override bool Equals(object obj)
         {
@@ -94,6 +94,9 @@ namespace OpenTap.Plugins.BasicSteps
             ExternalParameter.ParameterizedMembers
                 .Select(x => new KeyValuePair<ITestStep, IEnumerable<IMemberData>>((ITestStep)x.Source, new []{x.Member}))
                 .SelectMany(x => x.Value.Select(y => ((object)x.Key, y)));
+        
+        /// <summary> Set to true if the member has been removed from the test plan reference.</summary>
+        public bool IsDisposed => ExternalParameter == null || ParameterizedMembers.Any() == false;
     }
 
     class ExpandedTypeData : ITypeData

--- a/Engine.UnitTests/TestPlanReferenceTest.cs
+++ b/Engine.UnitTests/TestPlanReferenceTest.cs
@@ -1,0 +1,49 @@
+﻿using System.IO;
+using NUnit.Framework;
+using OpenTap.Plugins.BasicSteps;
+namespace OpenTap.UnitTests;
+
+[TestFixture]
+public class TestPlanReferenceTest
+{
+    [Test]
+    public void TestRemovingParameter()
+    {
+        var planWithoutParam = nameof(TestRemovingParameter) + ".no-parameter.TapPlan";
+        var planWithParam = nameof(TestRemovingParameter) + ".parameter.TapPlan";
+        try
+        {
+            {
+                var plan = new TestPlan();
+                var step = new DelayStep();
+                plan.ChildTestSteps.Add(step);
+                plan.Save(planWithoutParam);
+                TypeData.GetTypeData(step).GetMember(nameof(step.DelaySecs)).Parameterize(plan, step, "A");
+                plan.Save(planWithParam);
+            }
+
+            {
+                var plan = new TestPlan();
+                var tpr = new TestPlanReference();
+                tpr.Filepath.Text = planWithParam;
+                plan.ChildTestSteps.Add(tpr);
+                tpr.LoadTestPlan();
+                var aMember = TypeData.GetTypeData(tpr).GetMember("A");
+                aMember.Parameterize(plan, tpr, "B");
+                tpr.Filepath.Text = planWithoutParam;
+                var mem0 = TypeData.GetTypeData(plan).GetMember("B");
+                tpr.LoadTestPlan();
+                var mem = TypeData.GetTypeData(plan).GetMember("B");
+                
+                Assert.IsNotNull(mem0);
+                Assert.IsNull(mem);
+            }
+            
+        }
+        finally
+        {
+            File.Delete(planWithoutParam);
+            File.Delete(planWithParam);
+        }
+    }
+}


### PR DESCRIPTION
Added unit test to show the issue.

Fixed the issue, by using IDynamicMemberData

Close #1816