### PR TITLE
build sdk examples in pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,44 @@ jobs:
           retention-days: 5
           path: public
 
+  Build-SDK-Windows:
+    runs-on: [self-hosted, windows]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Build SDK (debug)
+        working-directory: sdk/Examples
+        run: dotnet build -c "Debug CE"
+      - name: Build SDK (debug)
+        working-directory: sdk/Examples
+        run: dotnet build -c Debug
+      - name: Build SDK (release)
+        working-directory: sdk/Examples
+        run: dotnet build -c Release
+
+  Build-SDK-Linux:
+    runs-on:
+      group: OpenTAP-SpokeVPC
+      labels:  [Linux, X64]
+    container: ghcr.io/opentap/oci-images/build-dotnet:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build SDK (debug)
+        working-directory: sdk/Examples
+        run: dotnet build -c LinuxDebug
+      - name: Build SDK (release)
+        working-directory: sdk/Examples
+        run: dotnet build -c LinuxRelease
+
   Build-Linux:
     runs-on:
       group: OpenTAP-SpokeVPC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,44 +193,6 @@ jobs:
           retention-days: 5
           path: public
 
-  Build-SDK-Windows:
-    runs-on: [self-hosted, windows]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Build SDK (debug)
-        working-directory: sdk/Examples
-        run: dotnet build -c "Debug CE"
-      - name: Build SDK (debug)
-        working-directory: sdk/Examples
-        run: dotnet build -c Debug
-      - name: Build SDK (release)
-        working-directory: sdk/Examples
-        run: dotnet build -c Release
-
-  Build-SDK-Linux:
-    runs-on:
-      group: OpenTAP-SpokeVPC
-      labels:  [Linux, X64]
-    container: ghcr.io/opentap/oci-images/build-dotnet:latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
-      - name: Build SDK (debug)
-        working-directory: sdk/Examples
-        run: dotnet build -c LinuxDebug
-      - name: Build SDK (release)
-        working-directory: sdk/Examples
-        run: dotnet build -c LinuxRelease
-
   Build-Linux:
     runs-on:
       group: OpenTAP-SpokeVPC
@@ -1020,6 +982,7 @@ jobs:
           tag: ${{env.TAG_NAME}}${{ matrix.tag-suffix }}
           path: docker/Linux
 
+
   ###############
   ### Publish ###
   ###############
@@ -1121,3 +1084,58 @@ jobs:
           packages: 'Repository Client:1.0'
       - name: Publish Packages
         run: tap repo upload --repository https://packages.opentap.io --token ${{ secrets.PUBLIC_REPO_TOKEN }} ./publish/*.TapPackage
+
+  Build-SDK-Linux:
+    runs-on: ubuntu-latest
+    needs:
+      - Package-NuGet
+      - Package-SDK
+    steps:
+      - name: Download SDK package
+        uses: actions/download-artifact@v4
+        with:
+          name: package-sdk
+          path: ./sdk-package/
+      - name: Unzip SDK package
+        run: unzip ./sdk-package/SDK.*.TapPackage
+      - name: Download nuget package
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-package
+          path: ./Packages/SDK/Examples/nuget-package
+      - name: Create Local Nuget Package Source
+        run: echo '<configuration><packageSources><add key="local-nuget" value="./nuget-package" /></packageSources></configuration>' > ./Packages/SDK/Examples/Nuget.config
+      - run: dotnet build -c LinuxDebug
+        working-directory: ./Packages/SDK/Examples
+      - run: dotnet build -c LinuxRelease
+        working-directory: ./Packages/SDK/Examples
+
+  Build-SDK-Windows:
+    runs-on: windows-2022
+    needs:
+      - Package-NuGet
+      - Package-SDK
+    steps:
+      - name: Download SDK package
+        uses: actions/download-artifact@v4
+        with:
+          name: package-sdk
+          path: ./sdk-package/
+      - name: Rename SDK package
+        run: mv ./sdk-package/SDK.*.TapPackage SDK.zip
+      - name: Unzip SDK package
+        run: unzip SDK.zip
+      - name: Download nuget package
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-package
+          path: ./Packages/SDK/Examples/nuget-package
+      - name: Create Local Nuget Package Source
+        run: echo '<configuration><packageSources><add key="local-nuget" value="./nuget-package" /></packageSources></configuration>' > ./Packages/SDK/Examples/Nuget.config
+      - run: dotnet build -c Debug
+        working-directory: ./Packages/SDK/Examples
+      - run: dotnet build -c "Debug CE"
+        working-directory: ./Packages/SDK/Examples
+      - run: dotnet build -c Release
+        working-directory: ./Packages/SDK/Examples
+

--- a/sdk/Examples/Directory.Build.props
+++ b/sdk/Examples/Directory.Build.props
@@ -9,7 +9,7 @@
 	<PropertyGroup>
 		<!-- This variable is only defined so we can compile locally without replacing GitVersion. 
 		     It will be removed in the build script. -->
-		<GitVersion>9.22.2</GitVersion>
+		<GitVersion>9.26.1</GitVersion>
 	</PropertyGroup>	
 	<PropertyGroup>
 		<!-- Ensure that all projects in this solution use the same version of OpenTAP -->		

--- a/sdk/Examples/Directory.Build.props
+++ b/sdk/Examples/Directory.Build.props
@@ -37,10 +37,4 @@
 		<DevelopersSystem Condition="'$(Configuration)' == 'Debug CE'">Editor X</DevelopersSystem>
 		<DevelopersSystem Condition="'$(Configuration)' != 'Debug CE'">Developer's System</DevelopersSystem>
 	</PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="OpenTAP" Version="$(OpenTapVersion)" />
-  </ItemGroup>
-
-
 </Project>

--- a/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
+++ b/sdk/Examples/PluginDevelopment.Gui/PluginDevelopment.Gui.csproj
@@ -15,9 +15,13 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="OpenTAP" Version="$(OpenTapVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(IsWindows)'=='True'">
-	<AdditionalOpenTapPackage Include="$(DevelopersSystem)" />
-	<OpenTapPackageReference Include="WPF Controls" />
+	  <AdditionalOpenTapPackage Include="$(DevelopersSystem)" />
+	  <OpenTapPackageReference Include="WPF Controls" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/Examples/PluginDevelopment/PluginDevelopment.csproj
+++ b/sdk/Examples/PluginDevelopment/PluginDevelopment.csproj
@@ -30,4 +30,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="OpenTAP" Version="$(OpenTapVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/sdk/Examples/TestPlanExecution/BuildTestPlan.Api/BuildTestPlan.Api.csproj
+++ b/sdk/Examples/TestPlanExecution/BuildTestPlan.Api/BuildTestPlan.Api.csproj
@@ -12,9 +12,7 @@
   
   <ItemGroup>
     <PackageReference Include="OpenTAP" Version="$(OpenTapVersion)" />
-    <Reference Include="OpenTap.Plugins.BasicSteps">
-      <HintPath>$(NugetPackageRoot)\opentap\$(OpenTapVersion)\build\payload\Packages\OpenTAP\OpenTap.Plugins.BasicSteps.dll</HintPath>
-    </Reference>
+    <OpenTapPackageReference Include="OpenTAP" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This will build the examples from the SDK package using the OpenTAP nuget package created in the pipeline.

This ensures our SDK will always be able to build, and also serves as a test of the nuget package.

Closes #1830 