### PR TITLE
EmbeddedMemberData checking in "Convert to Sequence" in Test Plan Reference

### DIFF
--- a/Engine/EmbedPropertiesAttribute.cs
+++ b/Engine/EmbedPropertiesAttribute.cs
@@ -34,7 +34,7 @@ namespace OpenTap
     // which contains the added properties.
     //
 
-    class EmbeddedMemberData : IMemberData, IDynamicMemberData
+    public class EmbeddedMemberData : IMemberData, IDynamicMemberData
     {
         public IMemberData OwnerMember => ownerMember;
         public IMemberData InnerMember => innerMember;


### PR DESCRIPTION
This adds checking for EmbeddedMemberData in TestPlanReference, so that mixins that use the EmbedPropertiesAttribute can be transferred using the "Convert to Sequence" option.

However, this change requires EmbeddedMemberData to be made public so that the BasicSteps project can access it. Unsure if this has any unintended side effects.

Related #1842 