### PR TITLE
Fix bug causing image resolutions from local caches to fail

### DIFF
--- a/Engine.UnitTests/SemanticVersionTests.cs
+++ b/Engine.UnitTests/SemanticVersionTests.cs
@@ -145,7 +145,15 @@ namespace OpenTap.Engine.UnitTests
         [TestCase("^9.0.0-alpha.2", "9.0.0-alpha.1", false)]
         [TestCase("^9.0.0-alpha.1", "9.0.0-alpha", false)]
         [TestCase("^9.0.1200-alpha.1.7", "9.0.1200-alpha.1.2", false)]
-        [TestCase("^9.1.0-alpha.1", "9.0.0-alpha.1", false)]
+        [TestCase("^9.1.0-alpha.1", "9.0.0-alpha.1", false)] 
+        [TestCase("^1", "0.1.0", false)] 
+        [TestCase("^1", "1.1.0", true)] 
+        [TestCase("^1", "1.0.0-beta.1", true)] 
+        [TestCase("^1", "1.1.0-beta.1", true)] 
+        [TestCase("^1.0", "1.1.0-beta.1", true)] 
+        [TestCase("^1.1", "1.1.0-beta.1", false)] 
+        [TestCase("^1.1", "1.2.0-beta.1", true)] 
+        [TestCase("^1.1", "2.1.0", false)] 
         public void SpecifierCompatibilityTest(string specifier, string version, bool expected)
         {
             Assert.AreEqual(expected, VersionSpecifier.Parse(specifier).IsCompatible(SemanticVersion.Parse(version)));

--- a/Package.UnitTests/Image/DependencyGraphTest.cs
+++ b/Package.UnitTests/Image/DependencyGraphTest.cs
@@ -103,7 +103,7 @@ namespace OpenTap.Image.Tests
             yield return ("OpenTAP; TUI, beta", "OpenTAP, 9.18.4;TUI, 0.1.0-beta.145+6c192a43");
             yield return ("OpenTAP; REST-API; CSV", "CSV, 9.11.0+98498e58;Keysight Licensing, 1.1.1+7a2a1fe3;OpenTAP, 9.18.4+7dec4717;REST-API, 2.9.1+e5319b91");
             yield return ("TEST-A", "TEST-A, 1.0.0; TEST-B,1.0.0;TEST-C,1.0.0");
-            // requesting a bet, but the newest is actually a release. The release versions should then be resolved.
+            // requesting a beta, but the newest is actually a release. The release versions should then be resolved.
             yield return ("Developer's System, beta", "CSV, 9.11.0+98498e58;Developer's System, 9.17.2-beta.12+a3f06537;" +
                                                       "Editor, 9.17.2-beta.12+a3f06537;Keysight Licensing, 1.1.0-rc.3+fc48665d;" +
                                                       "OpenTAP, 9.17.4-rc.1+3ffb292e;OSIntegration, 1.4.2+15f32a31;Results Viewer, 9.17.2-beta.12+a3f06537;" +

--- a/Package.UnitTests/Image/Resolve.cs
+++ b/Package.UnitTests/Image/Resolve.cs
@@ -108,6 +108,7 @@ namespace OpenTap.Image.Tests
         [TestCase("B", "3-beta", "", CpuArchitecture.AnyCPU, "3.2.1-beta.1")] // means we want latest 3 beta
         [TestCase("B", "2-beta", "Linux", CpuArchitecture.x86, "2.1.0-beta.1")] // means we want latest 2 beta
         [TestCase("B", "^3-beta", "", CpuArchitecture.AnyCPU, "3.2.1-beta.1")] // means we want latest 3, minimum beta
+        [TestCase("B", "^3", "", CpuArchitecture.AnyCPU, "3.1.1")] // ^3 means we want the latest 3, release preferred
         [TestCase("B", "^2-beta", "Linux", CpuArchitecture.x86, "2.1.0-beta.1")] // means we want latest 2 beta
         [TestCase("B", "any", "", CpuArchitecture.AnyCPU, "3.2.2-alpha.1")]  // any means we want latest, even if it is a prerelease
         [TestCase("C", "^1.0-beta", "Linux", CpuArchitecture.x86, "1.0.0-beta.1")]

--- a/Package/PackageDefinitionSerializerPlugin.cs
+++ b/Package/PackageDefinitionSerializerPlugin.cs
@@ -228,15 +228,7 @@ namespace OpenTap.Package
                 return VersionSpecifier.Any;
             if (VersionSpecifier.TryParse(Version, out var semver))
             {
-                if (semver.MatchBehavior.HasFlag(VersionMatchBehavior.Exact))
-                    return semver;
-
-                return new VersionSpecifier(semver.Major,
-                    semver.Minor,
-                    semver.Patch,
-                    semver.PreRelease,
-                    semver.BuildMetadata, 
-                    VersionMatchBehavior.Compatible | VersionMatchBehavior.AnyPrerelease);
+                return semver;
             }
             // For compatability (pre 9.0 packages may not have correctly formatted version numbers)
             var plugins = PluginManager.GetPlugins<IVersionTryConverter>().Concat(PluginManager.GetPlugins<IVersionConverter>());

--- a/Package/PackageSpecifier.cs
+++ b/Package/PackageSpecifier.cs
@@ -356,6 +356,14 @@ namespace OpenTap.Package
                 if (Minor.HasValue && Minor.Value == actualVersion.Minor)
                     if (Patch.HasValue && Patch.Value < actualVersion.Patch)
                         return true;
+
+                // In short: We want ^1 to accept 1.x.x-beta
+                // In long: If minor and patch are not specified, then this version specifier is underdetermined.
+                // If the prerelease is also not specified that means the version specifier should be satisfiable by
+                // any prerelease within the appropriate major.
+                if (PreRelease == null && !Minor.HasValue && !Patch.HasValue && Major.HasValue &&
+                    Major.Value == actualVersion.Major)
+                    return true;
             }
 
             if (0 < new SemanticVersion(0, 0, 0, PreRelease, null).CompareTo(new SemanticVersion(0, 0, 0, actualVersion.PreRelease, null)))


### PR DESCRIPTION
* Update VersionSpecifier compatibility check to now accept prereleases for underspecified majors
This is more in line with underspecified minors. Currently, ^1.0 matches 1.2.3-beta.1, but ^1 does not. With this fix, it will.
* Update PackageDefinitionSerializer to no longer add `MatchBehavior.AnyPrerelease` to `Compatible` specifiers.
I tracked down the original commit, and found that this behavior was added in order for OpenTAP to stop complaining about 
version compatibility issues when e.g. 9.27.0-beta.1 is installed in an installation with e.g. Demonstration, which depends on OpenTAP ^9. With this updated versin matching, this should no longer be an issue.

I also added a bunch of unit test to verify new behavior.

Closes #1865 