### PR TITLE
Incremental work on 1870

### DIFF
--- a/Package.UnitTests/Image/DependencyGraphTest.cs
+++ b/Package.UnitTests/Image/DependencyGraphTest.cs
@@ -111,6 +111,8 @@ namespace OpenTap.Image.Tests
                                                       "Timing Analyzer, 9.17.2-beta.12+a3f06537;Visual Studio SDK, 1.2.5+08b71a6e;WPF Controls, 9.17.2-beta.12+a3f06537");
             yield return ("OpenTAP, 9.17.4;OpenTAP, ^9.17.4;OpenTAP, 9.17.4", "OpenTAP, 9.17.4");
             yield return ("OpenTAP, 9.17.4;OpenTAP, ^9.17.4+ea67c63a;OpenTAP, 9.17.4", "OpenTAP, 9.17.4");
+            //[ImageResolution: Editor 9.17.0-rc.2+3810d814, Keysight Licensing 1.0.0+8a228623, OpenTAP 9.17.1+9a03c7c8, OSIntegration 1.4.2+15f32a31, WPF Controls 9.17.0-rc.2+3810d814
+            yield return ("Editor, ^9.17.0-alpha;", "Editor, 9.17.0-rc.2;OpenTAP, 9.17.1");
 
         }}
 

--- a/Package/Image/ImageResolveException.cs
+++ b/Package/Image/ImageResolveException.cs
@@ -35,7 +35,7 @@ namespace OpenTap.Package
         public override string ToString()
         {
             var unsatisfiedDependencies = new List<PackageDef>();
-            if (Result is FailedImageResolution fir && fir.resolveProblems is not GenericResolutionProblem)
+            if (Result is FailedImageResolution fir && fir.Problem is not GenericResolutionProblem)
             {
                 return fir.ToString();
             }

--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -44,6 +44,14 @@ namespace OpenTap.Package
         /// <summary> Which repositories to use. </summary>
         [CommandLineArgument("repository", ShortName = "r", Description = "Repositories to use for resolving the image.")]
         public string[] Repositories { get; set; } = null;
+        
+        
+        public override bool Unlocked
+        {
+            get => DryRun;
+            set {}
+        }
+
 
         protected override int LockedExecute(CancellationToken cancellationToken)
         {

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -178,9 +178,9 @@ namespace OpenTap.Package
                     // A beta version strikes a good middle ground. It is pretty likely to resolve, and probably won't be too unstable.
                     if (NonInteractive) throw;
                     if (Packages.Length != 1) throw;
-                    if (fir.resolveProblems.Count != 1) throw;
+                    if (fir.Problem.Count != 1) throw;
 
-                    var problem = fir.resolveProblems[0];
+                    var problem = fir.Problem[0];
                     if (problem.Version != VersionSpecifier.AnyRelease) throw;
                     // Only show the beta option if the resolution problem was with the package we are trying to install
                     if (problem.Name != Packages[0]) throw;
@@ -471,8 +471,8 @@ namespace OpenTap.Package
                 }
 
                 // If the problem is not generic, then there are additional details about the resolution problem.
-                if (ex.Result is FailedImageResolution f && f.resolveProblems is not GenericResolutionProblem)
-                    log.Info(f.resolveProblems.Description());
+                if (ex.Result is FailedImageResolution f && f.Problem is not GenericResolutionProblem)
+                    log.Info(f.Problem.Description());
 
                 Log.Debug("{0}", ex.Message);
                 return (int)ExitCodes.PackageResolutionError;

--- a/Package/PackageActions/LockingPackageAction.cs
+++ b/Package/PackageActions/LockingPackageAction.cs
@@ -43,7 +43,7 @@ namespace OpenTap.Package
         /// <summary>
         /// Unlockes the package action to allow multiple running at the same time.
         /// </summary>
-        public bool Unlocked { get; set; }
+        public virtual bool Unlocked { get; set; }
 
         /// <summary>
         /// The location to apply the command to. The default is the location of OpenTap.PackageManager.exe
@@ -98,11 +98,12 @@ namespace OpenTap.Package
                 }
                 FileSystemHelper.EnsureDirectoryOf(Target);
             }
-
-            var lockfile = Path.Combine(Target, ".lock");
-            FileSystemHelper.EnsureDirectoryOf(lockfile);
-            using var fileLock = FileLock.Create(lockfile);
             bool useLocking = Unlocked == false;
+            var lockfile = Path.Combine(Target, ".lock");
+            if(useLocking)
+                FileSystemHelper.EnsureDirectoryOf(lockfile);
+            using var fileLock = useLocking ? FileLock.Create(lockfile) : null;
+            
             if (useLocking && !fileLock.WaitOne(0))
             {
                 log.Info("Waiting for other package manager operation to complete.");

--- a/tap/Properties/launchSettings.json
+++ b/tap/Properties/launchSettings.json
@@ -14,7 +14,7 @@
     },
     "tap (commands)": {
       "commandName": "Project"
-    },
+    }, 
     "tap (run)": {
       "commandName": "Project",
       "commandLineArgs": "run ../../tests/RepeatOutputCompare.TapPlan"
@@ -22,6 +22,10 @@
     "tap (profile)": {
       "commandName": "Project",
       "commandLineArgs": "profile --test OpenTap.UnitTests.ScopeParametersTest.TestIsParameterized"
+    },
+    "tap license resolve": {
+      "commandName": "Project",
+      "commandLineArgs": "image install \"OpenTAP:9-alpha, Basic Mixins:0-beta, Editor:9.27-rc\" --dry-run -t ../test --os Windows --architecture x64 --no-isolation" 
     }
   }
 }


### PR DESCRIPTION
- added pruning optimization to the version selection, filtering based on other dependencies.

- Added performance improvements for the error generator. It will only build the error once asked.