### PR TITLE
1872 fix deserializing factory elements 2

### DIFF
--- a/Engine/SerializerPlugins/CollectionSerializer.cs
+++ b/Engine/SerializerPlugins/CollectionSerializer.cs
@@ -121,9 +121,7 @@ namespace OpenTap.Plugins
                         if (mem == null) throw new Exception("Unable to get member list");
                         if (Serializer.SerializerStack
                                 .OfType<ObjectSerializer>()
-                                .FirstOrDefault()?.CurrentMember is IMemberData member 
-                                // If this is a parameter, it should have been deserialized on the source step
-                                && member is not ParameterMemberData 
+                                .FirstOrDefault()?.CurrentMember is MemberData member 
                                 && member.GetAttribute<FactoryAttribute>() is FactoryAttribute factory
                                 && member.TypeDescriptor.DescendsTo(t))
                         {
@@ -197,7 +195,7 @@ namespace OpenTap.Plugins
                 else if (!_t.CanCreateInstance && !t.IsArray
                                                && Serializer.SerializerStack
                                                    .OfType<ObjectSerializer>()
-                                                   .FirstOrDefault()?.CurrentMember is IMemberData member 
+                                                   .FirstOrDefault()?.CurrentMember is MemberData member 
                                                && member.GetAttribute<FactoryAttribute>() is FactoryAttribute factory
                                                && member.TypeDescriptor.DescendsTo(t))
                 {


### PR DESCRIPTION
This fixes an issue causing the factory logic to apply to all kinds of typedata implementations: ParameterMemberData, ExpandedMemberData, and any plugin-defined member data. MemberData from such typedata should have already been deserialized in the object that actually owns the member, and thus no special handling is required. 

This also allows removing the special-case for test plan parameters which was added in #1853

Closes #1872 