### PR TITLE
Add missing release notes

### DIFF
--- a/doc/.vitepress/config.mts
+++ b/doc/.vitepress/config.mts
@@ -72,6 +72,8 @@ export default defineConfig({
         text: 'Release Notes',
         collapsed: true,
         items: [
+          { link: '/Release Notes/ReleaseNote_OpenTAP9.27.md', text: "Release Notes - OpenTAP 9.27"},
+          { link: '/Release Notes/ReleaseNote_OpenTAP9.26.md', text: "Release Notes - OpenTAP 9.26"},
           { link: '/Release Notes/ReleaseNote_OpenTAP9.25.md', text: "Release Notes - OpenTAP 9.25"},
           { link: '/Release Notes/ReleaseNote_OpenTAP9.24.md', text: "Release Notes - OpenTAP 9.24"},
           { link: '/Release Notes/ReleaseNote_OpenTAP9.23.md', text: "Release Notes - OpenTAP 9.23"},

--- a/doc/Release Notes/ReleaseNote_OpenTAP9.26.md
+++ b/doc/Release Notes/ReleaseNote_OpenTAP9.26.md
@@ -1,0 +1,27 @@
+Release Notes - opentap 9.26.0 
+ ============= 
+
+New Features 
+ ------- 
+
+- Made ViaPoint.IsActive virtual [#1745](https://github.com/opentap/opentap/issues/1745)
+- Connection.GetOtherPort now uses Equals instead of reference equality check [#1699](https://github.com/opentap/opentap/issues/1699)
+- ScpiQuery and ScpiCommand from SCPIInstrument are now thread safe [#1698](https://github.com/opentap/opentap/issues/1698)
+- Add PluginManager Initialize method [#1683](https://github.com/opentap/opentap/issues/1683)
+- Add support for disabling VISA discovery [#1678](https://github.com/opentap/opentap/issues/1678)
+
+
+Bug Fixes 
+ ------- 
+
+- SetAssemblyInfo no longer adds System.Private.CoreLib as a dependency when building on Linux [#1684](https://github.com/opentap/opentap/issues/1684)
+- Linux: `.TapPackage.lock` file is now properly deleted after downloading a package [#1662](https://github.com/opentap/opentap/issues/1662)
+- `tap sdk new integration vscode -o <path>` now treats path as a directory rather than the output file name [#1533](https://github.com/opentap/opentap/issues/1533)
+- RfConnection.GetInterpolatedCableLoss no longer throws an exception when there is no calibration data [#1701](https://github.com/opentap/opentap/issues/1701)
+
+
+Other 
+ ------- 
+
+- Show appropriate error when installing SDK while 32 bit dotnet is in PATH [#1672](https://github.com/opentap/opentap/issues/1672)
+- NuGet: speed up incremental builds [#1670](https://github.com/opentap/opentap/issues/1670)

--- a/doc/Release Notes/ReleaseNote_OpenTAP9.27.md
+++ b/doc/Release Notes/ReleaseNote_OpenTAP9.27.md
@@ -1,0 +1,45 @@
+Release Notes - opentap 9.27.0 
+ ============= 
+
+New Features 
+ ------- 
+
+- Support `Convert to sequence` when multi-selecting [#1824](https://github.com/opentap/opentap/issues/1824)
+- TestStepList API now raises an event when setting an index. [#1768](https://github.com/opentap/opentap/issues/1768)
+- CableLoss interpolation now uses binary search instead of linear scan [#1758](https://github.com/opentap/opentap/issues/1758)
+- Support adding Mixins to Test Plan Reference steps [#1737](https://github.com/opentap/opentap/issues/1737)
+- Make ResourceManager available outside of TestPlan [#1679](https://github.com/opentap/opentap/issues/1679)
+- Add IElementFactory interface for constructing list elements in lists with special behavior [#1798](https://github.com/opentap/opentap/issues/1798)
+- Sweeps now include an iteration parameter [#1789](https://github.com/opentap/opentap/issues/1789)
+- Allow TestPlan.Open to be called multipled times [#1766](https://github.com/opentap/opentap/issues/1766)
+- Added a button for converting test plan reference to a sequence step [#1762](https://github.com/opentap/opentap/issues/1762)
+- Added support for mixins on `TestPlanReference` steps [#1761](https://github.com/opentap/opentap/pull/1761)
+- Support settings assembly versions at build-time [#1687](https://github.com/opentap/opentap/issues/1687)
+
+
+Bug Fixes 
+ ------- 
+
+- Image no longer tries extracting local files as zip archives if they happen to match a package name from the image [#1835](https://github.com/opentap/opentap/issues/1835)
+- TapAssemblyResolver.Invalidate now correctly invalidates assemblies [#1775](https://github.com/opentap/opentap/issues/1775)
+- TestPlanReference can now be copy-pasted after adding an Expression mixin [#1771](https://github.com/opentap/opentap/issues/1771)
+- Fixed intermittent memory leaks with Connections and Cable Losses [#1756](https://github.com/opentap/opentap/issues/1756)
+- SDK: Error is not displayed when selecting multiple Measure Peak Amplitude steps [#1663](https://github.com/opentap/opentap/issues/1663)
+- Embed Properties Attribute Example: Cannot modify test step settings when more than one step is selected [#1527](https://github.com/opentap/opentap/issues/1527)
+- Properties changed in TestStepPreRunEvent are now properly reflected in result parameters [#1805](https://github.com/opentap/opentap/issues/1805)
+- Fix OS detection logic [#1783](https://github.com/opentap/opentap/issues/1783)
+- gitversion calculation fails when local revision of beta branch is outdated [#1780](https://github.com/opentap/opentap/issues/1780)
+- Error annotations now properly shown when Multi-Selected properties have the same error [#1700](https://github.com/opentap/opentap/issues/1700)
+
+
+Documentation 
+ ------- 
+
+- Documented FilePath on Lists in the developer guide [#1793](https://github.com/opentap/opentap/issues/1793)
+
+
+Other 
+ ------- 
+
+- TestStepList: Update ID Lookup on set item [#1773](https://github.com/opentap/opentap/issues/1773)
+- Improve error message when .NET 6 runtime dlls cannot be loaded [#1765](https://github.com/opentap/opentap/issues/1765)


### PR DESCRIPTION
This adds release notes for OpenTAP 9.26 and 9.27