### PR TITLE
Update version resolving

### DIFF
--- a/Package/Image/ImageResolver.cs
+++ b/Package/Image/ImageResolver.cs
@@ -284,7 +284,8 @@ namespace OpenTap.Package
                     versions.Sort();
                     // any version -> take the newest first.
                     versions.Reverse();
-                }else if(pkg.Version.MatchBehavior.HasFlag(VersionMatchBehavior.Exact))
+                }
+                else if(pkg.Version.MatchBehavior.HasFlag(VersionMatchBehavior.Exact))
                 {
                     //exact may be more than one version, even though the match behavior is 'exact'.
                     // for example OpenTAP '9.17' is exact, but many versions matches that.

--- a/Package/Image/PackageDependencyGraph.cs
+++ b/Package/Image/PackageDependencyGraph.cs
@@ -196,7 +196,7 @@ namespace OpenTap.Package
                 string newPreRelease;
                 if (packageSpecifier.Version.MatchBehavior.HasFlag(VersionMatchBehavior.AnyPrerelease))
                 {
-                    newPreRelease = "alpha";
+                    newPreRelease = "^alpha";
                 }
                 else
                 {


### PR DESCRIPTION
* Ensure '^0' resolves all prereleases, and not just alphas #1880
* Ensure release > rc > beta > alpha is preferred when no prerelease preference is specified #1879 

Closes #1879 
Closes #1880 