### PR TITLE
1872 more edge cases

### DIFF
--- a/BasicSteps/TestPlanReference.cs
+++ b/BasicSteps/TestPlanReference.cs
@@ -277,10 +277,11 @@ namespace OpenTap.Plugins.BasicSteps
                     if (currentSerializer != null)
                         newSerializer.GetSerializer<ExternalParameterSerializer>().PreloadedValues.MergeInto(currentSerializer.GetSerializer<ExternalParameterSerializer>().PreloadedValues);
                     var ext = newSerializer.GetSerializer<ExternalParameterSerializer>();
-                    ExternalParameters.ToList().ForEach(e =>
+                    foreach (var e in ExternalParameters)
                     {
-                        ext.PreloadedValues[e.Name] = StringConvertProvider.GetString(e.GetValue(plan));
-                    });
+                        if (StringConvertProvider.TryGetString(e.GetValue(plan), out var str))
+                            ext.PreloadedValues[e.Name] = str;
+                    }
 
                     CurrentMappings = allMapping;
 

--- a/Engine.UnitTests/ElementFactoryTest.cs
+++ b/Engine.UnitTests/ElementFactoryTest.cs
@@ -126,7 +126,7 @@ namespace OpenTap.UnitTests
         }
 
         [Test]
-        public void TestDeserializeParameterizedElements([Values(0, 1, 10)] int numRows)
+        public void TestDeserializeParameterizedElements([Values(0, 1, 2, 3, 10)] int numRows)
         {
             using var s = Session.Create(SessionOptions.OverlayComponentSettings);
             var trace = new TestTraceListener();
@@ -235,7 +235,7 @@ namespace OpenTap.UnitTests
             { /* verify that there are no warnings or errors logged */
                 trace.Flush();
                 trace.WarningMessage.RemoveAll(warn =>
-                    warn.StartsWith("Duplicate TEst packages detected.", StringComparison.OrdinalIgnoreCase));
+                    warn.StartsWith("Duplicate Test packages detected.", StringComparison.OrdinalIgnoreCase));
                 Assert.That(trace.WarningMessage, Is.Empty);
                 Assert.That(trace.ErrorMessage, Is.Empty);
             }

--- a/Engine/FactoryAttribute.cs
+++ b/Engine/FactoryAttribute.cs
@@ -27,7 +27,13 @@ namespace OpenTap
         internal static object Create(object ownerObj, IFactoryAttribute factoryAttribute)
         {
             var type = ownerObj.GetType();
-            return type.GetMethod(factoryAttribute.FactoryMethodName, BindingFlags.Instance |BindingFlags.Public | BindingFlags.NonPublic).Invoke(ownerObj, Array.Empty<object>());
+            var fac = type.GetMethod(factoryAttribute.FactoryMethodName,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            // This is a bug, but showing this message in the log is much nicer than a null reference exception.
+            if (fac == null)
+                throw new Exception(
+                    $"Factory method '{factoryAttribute.FactoryMethodName}' not found on object of type '{type.FullName}'");
+            return fac.Invoke(ownerObj, []);
         }
     }
 

--- a/Engine/IStringConvertProvider.cs
+++ b/Engine/IStringConvertProvider.cs
@@ -705,9 +705,10 @@ namespace OpenTap
             {
                 if (value is IEnumerable seq)
                 {
-                    bool isNumeric = true;
+                    bool isNumeric = false;
                     foreach (var elem in seq)
                     {
+                        isNumeric = true;
                         if (elem is Enum || Utils.IsNumeric(elem) == false)
                         {
                             isNumeric = false;

--- a/Engine/IStringConvertProvider.cs
+++ b/Engine/IStringConvertProvider.cs
@@ -683,7 +683,7 @@ namespace OpenTap
                         array.SetValue(item, idx++);
                     return array;
                 }
-                else if (type.GetConstructor(new Type[0]) != null)
+                else if (type.GetConstructor([]) != null)
                 {
                     object lst = Activator.CreateInstance(type);
                     var add = type.GetMethodsTap().First(m => m.Name == "Add");
@@ -703,6 +703,15 @@ namespace OpenTap
             /// <summary> Turns a value into a string, </summary>
             public string GetString(object value, CultureInfo culture)
             {
+                /* return null if we do not know how to construct this type.
+                 Another provider may be able to handle this, so this is fine.
+                 */
+                {
+                    var type = value?.GetType();
+                    if (type == null) return null;
+                    if (type.DescendsTo(typeof(string))) return null;
+                    if (type.IsArray == false && type.GetConstructor([]) == null) return null;
+                }
                 if (value is IEnumerable seq)
                 {
                     bool isNumeric = false;

--- a/Engine/ObjectCloner.cs
+++ b/Engine/ObjectCloner.cs
@@ -52,11 +52,8 @@ namespace OpenTap
                         strConvertSuccess = StringConvertProvider.TryGetString(value, out convertString);
                     if (strConvertSuccess == true)
                     {
-                        // Fall back to other clone methods if this fails.
-                        // This is required because misbehaving StringConvertProviders can return string values
-                        // for objects which they are not actually able to clone.
-                        if (StringConvertProvider.TryFromString(convertString, targetType, context, out clone))
-                            return true;
+                        clone = StringConvertProvider.FromString(convertString, targetType, context);
+                        return true;
                     }
 
                     if (value is ICloneable cloneable)

--- a/Engine/ObjectCloner.cs
+++ b/Engine/ObjectCloner.cs
@@ -35,7 +35,7 @@ namespace OpenTap
             return TryClone(context, targetType ?? typeOfValue, false, out object _);
         }
         
-        public bool TryClone(object context, ITypeData targetType, bool skipIfPossible, out object clone )
+        public bool TryClone(object context, ITypeData targetType, bool skipIfPossible, out object clone)
         {
             if (ReferenceEquals(targetType, typeOfValue) && valueType || value == null)
             {
@@ -52,8 +52,11 @@ namespace OpenTap
                         strConvertSuccess = StringConvertProvider.TryGetString(value, out convertString);
                     if (strConvertSuccess == true)
                     {
-                        clone = StringConvertProvider.FromString(convertString, targetType, context);
-                        return true;
+                        // Fall back to other clone methods if this fails.
+                        // This is required because misbehaving StringConvertProviders can return string values
+                        // for objects which they are not actually able to clone.
+                        if (StringConvertProvider.TryFromString(convertString, targetType, context, out clone))
+                            return true;
                     }
 
                     if (value is ICloneable cloneable)

--- a/Engine/ObjectCloner.cs
+++ b/Engine/ObjectCloner.cs
@@ -94,7 +94,7 @@ namespace OpenTap
         {
             if (TryClone(context, targetType, skipIfPossible, out var clone) == false)
             {
-                throw new InvalidCastException($"Failed cloning {value} as {targetType.Name}.");
+                throw new InvalidCastException($"Failed cloning '{value}' as '{targetType.Name}'.");
             }
             return clone;
         }


### PR DESCRIPTION
This fixes an edge case causing error messages in the log when loading a test plan on a test plan reference step with an empty Sweep Values list parameterized

This is another addon to #1872 