### PR TITLE
Restructured Image Resolution error messages

### DIFF
--- a/Package.UnitTests/Image/Deploy.cs
+++ b/Package.UnitTests/Image/Deploy.cs
@@ -283,7 +283,7 @@ namespace OpenTap.Image.Tests
             catch (ImageResolveException ex)
             {
                 var result = ex.Result.ToString();
-                StringAssert.Contains("Unable to resolve image", result);
+                StringAssert.Contains("The following required packages do not exist", result);
             }
         }
 

--- a/Package/Image/ImageResolveException.cs
+++ b/Package/Image/ImageResolveException.cs
@@ -64,9 +64,7 @@ namespace OpenTap.Package
                     }
                 }
 
-                return $"Unable to resolve the packages: {Image}.\n" +
-                       $"This is probably due to:\n" +
-                       $"{sb}";
+                return $"{sb} ({Image} from {string.Join(", ", Image.Repositories)})";
             }
 
             return Result.ToString();

--- a/Package/Image/ImageResolver.cs
+++ b/Package/Image/ImageResolver.cs
@@ -414,8 +414,7 @@ namespace OpenTap.Package
 
         public override string Description()
         {
-            return "The following required packages do not exist: " + string.Join(", ", this.Packages.Select(p => p.Name)) + "\n" +
-                "Please verify your configured repositories, or check if a prerelease exists.";
+            return "The following required packages do not exist: " + string.Join(", ", this.Packages.Select(p => p.Name));
         }
     }
 
@@ -470,7 +469,9 @@ namespace OpenTap.Package
 
         public override string ToString()
         {
-            return $"Unable to resolve image '{image}':\n" + resolveProblems.Description();
+            string packages = $"Packages: {image}";
+            string repositories = image.Repositories.Any() ? $" from {string.Join(", ", image.Repositories)}" : "";
+            return $"{resolveProblems.Description()} ({packages}{repositories})";
         }
     }
 }


### PR DESCRIPTION
- Problem first, packages and repositories after. 
- Generic "Image Resolution failed" stuff removed, because it is not needed