### PR TITLE
Avoid loading stub assemblies

### DIFF
--- a/Engine/PluginManager.cs
+++ b/Engine/PluginManager.cs
@@ -602,7 +602,10 @@ namespace OpenTap
                     try
                     {
                         if (!reflectionOnly)
-                            return Assembly.LoadFrom(loadFilename);
+                        {
+                            var asm = PluginManager.GetSearcher().AddAssembly(loadFilename, null);
+                            return asm?.Load();
+                        }
                         else
                             return Assembly.ReflectionOnlyLoadFrom(loadFilename);
                     }


### PR DESCRIPTION
This is a partial solution to #1750. There are still other unresolved aspects:

* runtime assemblies are not copied into projects targeting netstandard2.0. After OpenTAP moves to .NET 9 on Windows, we need to recommend targeting .NET 9 in plugins (at least if they use nuget packages with native dependencies).

* We should ensure that `tap package create` does not bundle stub assemblies. It would be great if OpenTAP could automatically select the correct variant for the target os/arch, or throw an error if this is not possible