### PR TITLE
run linux regression tests on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
             NewProj*/**
 
   TestLinuxPlan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/opentap/oci-images/build-dotnet:latest
     needs: 
     - Build-Linux


### PR DESCRIPTION
Ubuntu 20.04 jobs will soon start failing. Let's just use latest.