### PR TITLE
1913-AbandonedMutexFix

### DIFF
--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -283,8 +283,15 @@ namespace OpenTap
             {
                 if (!recentFilesValid) 
                     return Array.Empty<string>();
-                
-                recentLock.WaitOne();
+
+                try
+                {
+                    recentLock.WaitOne();
+                }
+                catch (AbandonedMutexException)
+                {
+                    // recover from abandoned mutex
+                }
                 try
                 {
                     return ensureFileExistsAndReadLines();
@@ -303,7 +310,14 @@ namespace OpenTap
                 
                 // Important to lock the file and to re-read if the file was changed since last checked.
                 // otherwise there is a risk that a log file will be forgotten and never cleaned up.
-                recentLock.WaitOne();
+                try
+                {
+                    recentLock.WaitOne();
+                }
+                catch (AbandonedMutexException)
+                {
+                    // recover from abandoned mutex
+                }
                 try
                 {
                     var currentFiles = ensureFileExistsAndReadLines().Append(newname).DistinctLast();


### PR DESCRIPTION
- Fixed the issue by catching the AbandonedMutexException. When this exception is caught we still get the mutex and the opportunity to release it, but if its not released the same issue will occur for the next application trying to use it.

- Due the complexity of the bug, this cannot really be reproduced using a unit test. It should be reproducible by attaching a debugger and stopping the application without releasing the mutex.

Close #1913 