### PR TITLE
Change invariant string comparisons to ordinal

### DIFF
--- a/Engine.UnitTests/TestTestSteps/PipingProcessStep.cs
+++ b/Engine.UnitTests/TestTestSteps/PipingProcessStep.cs
@@ -53,7 +53,7 @@ namespace OpenTap.Engine.UnitTests.TestTestSteps
                     var act = DescribeBytes(r.Answer);
                     log.Info($"Expected: {exp}");
                     log.Info($"  Actual: {act}");
-                    if (r.Answer.Equals(ExpectedAnswers[i], StringComparison.Ordinal) == false)
+                    if (r.Answer.Equals(ExpectedAnswers[i], StringComparison.InvariantCulture) == false)
                     {
                         log.Error($"Input {i + 1} did not match the expected input:");
                         log.Error($"Expected '{ExpectedAnswers[i]}', got '{r.Answer}'");

--- a/Engine.UnitTests/TestTestSteps/PipingProcessStep.cs
+++ b/Engine.UnitTests/TestTestSteps/PipingProcessStep.cs
@@ -53,7 +53,7 @@ namespace OpenTap.Engine.UnitTests.TestTestSteps
                     var act = DescribeBytes(r.Answer);
                     log.Info($"Expected: {exp}");
                     log.Info($"  Actual: {act}");
-                    if (r.Answer.Equals(ExpectedAnswers[i], StringComparison.InvariantCulture) == false)
+                    if (r.Answer.Equals(ExpectedAnswers[i], StringComparison.Ordinal) == false)
                     {
                         log.Error($"Input {i + 1} did not match the expected input:");
                         log.Error($"Expected '{ExpectedAnswers[i]}', got '{r.Answer}'");

--- a/Engine.UnitTests/TestTestSteps/WriteFileStep.cs
+++ b/Engine.UnitTests/TestTestSteps/WriteFileStep.cs
@@ -120,7 +120,7 @@ namespace OpenTap.Engine.UnitTests.TestTestSteps
             }
 
             var nf = normalize(File);
-            var asm = s.Assemblies.FirstOrDefault(a => normalize(a.Location).Equals(nf, StringComparison.InvariantCultureIgnoreCase));
+            var asm = s.Assemblies.FirstOrDefault(a => normalize(a.Location).Equals(nf, StringComparison.OrdinalIgnoreCase));
 
             if (asm == null)
             {

--- a/Engine/AssemblyFinder.cs
+++ b/Engine/AssemblyFinder.cs
@@ -40,7 +40,7 @@ namespace OpenTap
             return matching.Invoke(fileName);
         }
 
-        static bool StrEq(string a, string b) => string.Equals(a, b, StringComparison.InvariantCultureIgnoreCase);
+        static bool StrEq(string a, string b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
 
         public string[] AllAssemblies()
         {

--- a/Engine/BigFloat.cs
+++ b/Engine/BigFloat.cs
@@ -331,11 +331,11 @@ namespace OpenTap
         /// <returns></returns>
         internal static object Parse(string value, IFormatProvider format = null)
         {
-            if (string.Equals(value, "infinity", StringComparison.InvariantCultureIgnoreCase))
+            if (string.Equals(value, "infinity", StringComparison.OrdinalIgnoreCase))
                 return Infinity;
-            if (string.Equals(value, "-infinity", StringComparison.InvariantCultureIgnoreCase))
+            if (string.Equals(value, "-infinity", StringComparison.OrdinalIgnoreCase))
                 return NegativeInfinity;
-            if (string.Equals(value, "nan", StringComparison.InvariantCultureIgnoreCase))
+            if (string.Equals(value, "nan", StringComparison.OrdinalIgnoreCase))
                 return NaN;
             if (value.Contains("/"))
             {

--- a/Engine/Cli/RunCliAction.cs
+++ b/Engine/Cli/RunCliAction.cs
@@ -288,7 +288,7 @@ namespace OpenTap.Cli
                         log.Info($"Loading external parameters from '{file}'.");
                         var importer = importers
                                 // find importer that accepts that extension, case-insensitively. 
-                            .FirstOrDefault(i => string.Compare(i.Extension, ext, StringComparison.InvariantCultureIgnoreCase) == 0);
+                            .FirstOrDefault(i => string.Equals(i.Extension, ext, StringComparison.OrdinalIgnoreCase));
                         if (importer != null)
                         {
                             importer.ImportExternalParameters(Plan, file);

--- a/Engine/IStringConvertProvider.cs
+++ b/Engine/IStringConvertProvider.cs
@@ -489,7 +489,7 @@ namespace OpenTap
                     for (int i = 0; i < names.Length; i++)
                     {
                         var display = type.GetMember(names[i]).Select(x => x.GetDisplayAttribute()).FirstOrDefault();
-                        if (StringComparer.InvariantCultureIgnoreCase.Equals(display.Name, str))
+                        if (StringComparer.OrdinalIgnoreCase.Equals(display.Name, str))
                         {
                             result = (Enum)Enum.GetValues(type).GetValue(i);
                             return true;
@@ -515,8 +515,8 @@ namespace OpenTap
                     {
                         var display = type.GetMember(names[i]).Select(x => x.GetDisplayAttribute()).FirstOrDefault();
                         var name = display.Name.ToLower().Trim();
-                        if (StringComparer.InvariantCultureIgnoreCase.Equals(name, str) || 
-                            StringComparer.InvariantCultureIgnoreCase.Equals(name.Replace('_', ' '), str))
+                        if (StringComparer.OrdinalIgnoreCase.Equals(name, str) || 
+                            StringComparer.OrdinalIgnoreCase.Equals(name.Replace('_', ' '), str))
                         {
                             result = (Enum) Enum.GetValues(type).GetValue(i);
                             return true;

--- a/Engine/MacroPath.cs
+++ b/Engine/MacroPath.cs
@@ -165,7 +165,7 @@ namespace OpenTap
         /// <returns>A string with macros expanded.</returns>
         internal static string ReplaceMacros(string userString, IEnumerable<(string,string)> keyvaluepairs, string macroDefault = "TBD")
         {
-            var cmp = StringComparer.InvariantCultureIgnoreCase;
+            var cmp = StringComparer.OrdinalIgnoreCase;
             Dictionary<string, string> cache = new Dictionary<string, string>(cmp);
             IEnumerator<(string, string)> valueiterator = keyvaluepairs.GetEnumerator();
             string getMacroDef(string key)

--- a/Engine/NumberParser.cs
+++ b/Engine/NumberParser.cs
@@ -144,7 +144,7 @@ namespace OpenTap
                 post_scale.AppendTo(sb, culture);
             else
             {
-                if (format.StartsWith("x", StringComparison.InvariantCultureIgnoreCase))
+                if (format.StartsWith("x", StringComparison.OrdinalIgnoreCase))
                     sb.Append(((long)post_scale.Rounded()).ToString(format, culture));
                 else
                 {
@@ -183,7 +183,7 @@ namespace OpenTap
                 final_string = post_scale.ToString("R", culture);
             else
             {
-                if (format.StartsWith("x", StringComparison.InvariantCultureIgnoreCase))
+                if (format.StartsWith("x", StringComparison.OrdinalIgnoreCase))
                     final_string = ((long)post_scale.Rounded()).ToString(format, culture);
                 else
                 {
@@ -224,18 +224,18 @@ namespace OpenTap
             str = str.Trim();
 
             bool IsHex =
-                (str.StartsWith("0x", StringComparison.InvariantCultureIgnoreCase) ||
-                str.StartsWith("-0x", StringComparison.InvariantCultureIgnoreCase));
+                (str.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ||
+                str.StartsWith("-0x", StringComparison.OrdinalIgnoreCase));
             int HexSkip = 2;
 
             if ((!IsHex) &&
-               (format.StartsWith("x", StringComparison.InvariantCultureIgnoreCase)))
+               (format.StartsWith("x", StringComparison.OrdinalIgnoreCase)))
             {
                 IsHex = true;
                 HexSkip = 0;
             }
 
-            if (unit.Length > 0 && str.EndsWith(unit, StringComparison.InvariantCultureIgnoreCase))
+            if (unit.Length > 0 && str.EndsWith(unit, StringComparison.OrdinalIgnoreCase))
                 str = str.Remove(str.Length - unit.Length);
             str = str.TrimEnd();
             if (str.Length == 0)
@@ -248,7 +248,7 @@ namespace OpenTap
             if (levels.Contains(prefix))
             {
                 // Handle case of "femto" unit
-                if (!(IsHex && (prefix == 'f') && !str.EndsWith(" f", StringComparison.InvariantCulture)))
+                if (!(IsHex && (prefix == 'f') && !str.EndsWith(" f", StringComparison.Ordinal)))
                 {
                     multiplier = engineeringPrefixLevel(prefix);
                     if (str[str.Length - 1] == prefix)
@@ -256,15 +256,15 @@ namespace OpenTap
                 }
             }
 
-            if (IsHex && str.StartsWith("-", StringComparison.InvariantCultureIgnoreCase))
+            if (IsHex && str.StartsWith("-", StringComparison.OrdinalIgnoreCase))
                 return new BigFloat(-Int64.Parse(str.Substring(HexSkip + 1).ToUpper(), NumberStyles.HexNumber, culture)) * multiplier;
             else if (IsHex)
                 return new BigFloat(BigInteger.Parse("0" + str.Substring(HexSkip).ToUpper(), NumberStyles.HexNumber, culture)) * multiplier;
 
-            if (str.StartsWith("0b", StringComparison.InvariantCultureIgnoreCase) || str.StartsWith("-0b", StringComparison.InvariantCultureIgnoreCase))
+            if (str.StartsWith("0b", StringComparison.OrdinalIgnoreCase) || str.StartsWith("-0b", StringComparison.OrdinalIgnoreCase))
             {
                 string bits = "";
-                if (str.StartsWith("-0b", StringComparison.InvariantCultureIgnoreCase))
+                if (str.StartsWith("-0b", StringComparison.OrdinalIgnoreCase))
                 {
                     multiplier = -multiplier;
                     bits = str.Substring(2);

--- a/Package.UnitTests/PackageDefTests.cs
+++ b/Package.UnitTests/PackageDefTests.cs
@@ -755,8 +755,8 @@ namespace OpenTap.Package.UnitTests
             var plugins = Directory.EnumerateFiles(".");
 
             Assert.IsTrue(plugins.Any(package =>
-                Path.GetFileName(package).StartsWith("Test", System.StringComparison.InvariantCultureIgnoreCase) &&
-                Path.GetExtension(package).EndsWith("TapPackage", System.StringComparison.InvariantCultureIgnoreCase)
+                Path.GetFileName(package).StartsWith("Test", System.StringComparison.OrdinalIgnoreCase) &&
+                Path.GetExtension(package).EndsWith("TapPackage", System.StringComparison.OrdinalIgnoreCase)
             ), "Generated OpenTAP package file not found");
         }
 

--- a/Package/CreatePackage/FileHashPackageAction.cs
+++ b/Package/CreatePackage/FileHashPackageAction.cs
@@ -230,7 +230,7 @@ namespace OpenTap.Package
                     // remove conflicts that came from the same package name. These may be overwritten.
                     .Where(x => x.Item1.Name != package.Name)
                     // remove conflicts in files that came from Dependencies. 
-                    .Where(x => x.Item2.FileName.StartsWith("Dependencies/", StringComparison.InvariantCultureIgnoreCase) == false)
+                    .Where(x => x.Item2.FileName.StartsWith("Dependencies/", StringComparison.OrdinalIgnoreCase) == false)
                     .Select(x => (x.Item1, x.Item2, package)));
             }
 

--- a/Package/CreatePackage/GitVersionCalculator.cs
+++ b/Package/CreatePackage/GitVersionCalculator.cs
@@ -363,7 +363,7 @@ namespace OpenTap.Package
                 // but this causes issues in scenarios where merge commits are fast-forwarded onto e.g. the main branch.
                 // See here: https://github.com/opentap/opentap/pull/1384
                 // And here: https://github.com/opentap/opentap/issues/1321#issuecomment-1895749385
-                bool isRc = preRelease.StartsWith("rc", StringComparison.InvariantCultureIgnoreCase);
+                bool isRc = preRelease.StartsWith("rc", StringComparison.OrdinalIgnoreCase);
                 Commit cfgCommit = getLatestConfigVersionChange(targetCommit);
                 Commit commonAncestor = findFirstCommonAncestor(defaultBranch, targetCommit);
                 int commitsFromDefaultBranch = countCommitsBetween(commonAncestor, targetCommit, firstParentOnly: isRc);

--- a/Package/CreatePackage/IncludePackageDependenciesData.cs
+++ b/Package/CreatePackage/IncludePackageDependenciesData.cs
@@ -92,7 +92,7 @@ namespace OpenTap.Package
                     VersionSpecifier thisVersionSpec;
                     SemanticVersion thisSemver;
                     var thisAny = string.IsNullOrWhiteSpace(thisVersion) ||
-                                  thisVersion.Equals("any", StringComparison.InvariantCultureIgnoreCase);
+                                  thisVersion.Equals("any", StringComparison.OrdinalIgnoreCase);
 
                     try
                     {
@@ -132,7 +132,7 @@ namespace OpenTap.Package
                     if (existing != null)
                     {
                         var otherAny =
-                            existing.RawVersion.Equals("any", StringComparison.InvariantCultureIgnoreCase);
+                            existing.RawVersion.Equals("any", StringComparison.OrdinalIgnoreCase);
 
                         var otherSemver = otherAny ? null : SemanticVersion.Parse(existing.RawVersion);
 

--- a/Package/Installation.cs
+++ b/Package/Installation.cs
@@ -160,8 +160,8 @@ namespace OpenTap.Package
             // Path case sensitivity is file system dependent. Typically Windows and MacOS will be case-insensitive,
             // and Linux will be case-sensitive, but not always. TODO: check if path file system is case sensitive
             var stringComparer = OperatingSystem.Current == OperatingSystem.Linux
-                ? StringComparison.InvariantCulture
-                : StringComparison.InvariantCultureIgnoreCase;
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase;
             // Ensure the file is in a subdirectory of the installation. Otherwise it is not contained in a package.
             if (!abs.StartsWith(installDir, stringComparer))
                 return null;

--- a/Package/Installer.cs
+++ b/Package/Installer.cs
@@ -279,8 +279,8 @@ namespace OpenTap.Package
             // Check if the files that are in use are used by any other package
             var packages = packagePaths.Select(p => p.EndsWith("TapPackage") ? PackageDef.FromPackage(p) : PackageDef.FromXml(p));
             var remainingInstalledPlugins = new Installation(tapDir).GetPackages().Where(i => packages.Any(p => p.Name == i.Name) == false);
-            var filesToRemain = remainingInstalledPlugins.SelectMany(p => p.Files).Select(f => f.RelativeDestinationPath).Distinct(StringComparer.InvariantCultureIgnoreCase);
-            filesInUse = filesInUse.Where(f => filesToRemain.Contains(f.Name, StringComparer.InvariantCultureIgnoreCase) == false).ToList();
+            var filesToRemain = remainingInstalledPlugins.SelectMany(p => p.Files).Select(f => f.RelativeDestinationPath).Distinct(StringComparer.OrdinalIgnoreCase);
+            filesInUse = filesInUse.Where(f => filesToRemain.Contains(f.Name, StringComparer.OrdinalIgnoreCase) == false).ToList();
 
             return filesInUse.ToArray();
         }

--- a/Package/PackageActionHelpers.cs
+++ b/Package/PackageActionHelpers.cs
@@ -111,7 +111,7 @@ namespace OpenTap.Package
                         }
                     }
                     else if (Path.GetExtension(packageName)
-                             .Equals(".Tappackage", StringComparison.InvariantCultureIgnoreCase) || File.Exists(packageName))
+                             .Equals(".Tappackage", StringComparison.OrdinalIgnoreCase) || File.Exists(packageName))
                     {
                         
                         var pkg = PackageDef.FromPackage(packageName);

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -923,11 +923,11 @@ namespace OpenTap.Package
                     var files = Directory.GetFiles(dir, "*", SearchOption.TopDirectoryOnly);
 
                     if (files.Any(f =>
-                        string.Equals(Path.GetFileName(f), ".OpenTapIgnore", StringComparison.InvariantCulture)))
+                        string.Equals(Path.GetFileName(f), ".OpenTapIgnore", StringComparison.OrdinalIgnoreCase)))
                         continue;
 
                     var packageXml = files.FirstOrDefault(f =>
-                        string.Equals(Path.GetFileName(f), "package.xml", StringComparison.InvariantCulture));
+                        string.Equals(Path.GetFileName(f), "package.xml", StringComparison.OrdinalIgnoreCase));
 
                     if (packageXml != null)
                         results.Add(packageXml);

--- a/Package/PluginInstaller.cs
+++ b/Package/PluginInstaller.cs
@@ -84,11 +84,11 @@ namespace OpenTap.Package
                 if (isSystemWide)
                 {
                     yield return Path.Combine(systemWideDir, file);
-                    if(!file.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
+                    if(!file.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                         yield return Path.Combine(systemWideDir,file + ".exe");
                 }
                 yield return Path.Combine(workingDirectory, file);
-                if(!file.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
+                if(!file.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
                     yield return Path.Combine(workingDirectory, file + ".exe");
             }
 
@@ -609,8 +609,8 @@ namespace OpenTap.Package
                 .Where(p => p.Name != package.Name)
                 .SelectMany(p => p.Files)
                 .Select(f => f.RelativeDestinationPath)
-                .Distinct(StringComparer.InvariantCultureIgnoreCase)
-                .ToHashSet(StringComparer.InvariantCultureIgnoreCase);
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
             try
             {

--- a/Shared/OperatingSystem.cs
+++ b/Shared/OperatingSystem.cs
@@ -52,7 +52,7 @@ namespace OpenTap
                 var process = Process.Start(startInfo);
                 process.WaitForExit(1000);
                 var uname = process.StandardOutput.ReadToEnd();
-                return uname.ToLowerInvariant().Contains("darwin");
+                return uname.ToUpperInvariant().Contains("DARWIN");
             }
             catch
             {

--- a/sdk/OpenTap.Sdk.New/NewPackageReference.cs
+++ b/sdk/OpenTap.Sdk.New/NewPackageReference.cs
@@ -88,7 +88,7 @@ namespace OpenTap.Sdk.New
             foreach (var grp in itemGroups)
             {
                 var existingElem = grp.Elements("OpenTapPackageReference")
-                    .Where(elem => string.Equals(elem.Attribute("Reference")?.Value ?? "True", (!NoReference).ToString(), StringComparison.InvariantCultureIgnoreCase))
+                    .Where(elem => string.Equals(elem.Attribute("Reference")?.Value ?? "True", (!NoReference).ToString(), StringComparison.OrdinalIgnoreCase))
                     .FirstOrDefault(elem => elem.Attribute("Include")?.Value == PackageName);
                 
                 if (existingElem != null)


### PR DESCRIPTION
It is (almost) always correct to use ordinal comparisons, but OpenTAP mostly uses invariant comparisons.

See linked issue for relevant resources

Closes #1819
