### PR TITLE
1929 Package Validation

### DIFF
--- a/Package/Image/ImageIdentifier.cs
+++ b/Package/Image/ImageIdentifier.cs
@@ -143,7 +143,7 @@ namespace OpenTap.Package
             if (cancellationToken.IsCancellationRequested)
                 throw new OperationCanceledException("Deployment operation cancelled by user");
 
-            var currentPackages = currentInstallation.GetPackages();
+            var currentPackages = currentInstallation.GetPackages(validOnly: true);
 
             var skippedPackages = dependencies.Where(s => currentPackages.Any(p => p.Name == s.Name && p.Version.ToString() == s.Version.ToString())).ToHashSet();
             var modifyOrAdd = dependencies.Where(s => !skippedPackages.Contains(s)).ToList();

--- a/Package/Installation.cs
+++ b/Package/Installation.cs
@@ -234,7 +234,12 @@ namespace OpenTap.Package
         /// Returns package definition list of installed packages in the TAP installation defined in the constructor, and system-wide packages.
         /// Results are cached, and Invalidate must be called if changes to the installation are made by circumventing OpenTAP APIs.
         /// </summary>
-        public List<PackageDef> GetPackages() => new List<PackageDef>(GetPackagesLookup().Values);
+        public List<PackageDef> GetPackages() => GetPackagesLookup().Values.ToList();
+        /// <summary>
+        /// Returns package definition list of installed packages in the TAP installation defined in the constructor, and system-wide packages.
+        /// Results are cached, and Invalidate must be called if changes to the installation are made by circumventing OpenTAP APIs.
+        /// </summary>
+        public List<PackageDef> GetPackages(bool validOnly) => GetPackagesLookup().Values.Where(pkg => pkg.IsValid()).ToList();
 
         /// <summary> Finds an installed package by name. Returns null if the package was not found. </summary>
         public PackageDef FindPackage(string name) => GetPackagesLookup().TryGetValue(name, out var package) ? package : null;
@@ -281,6 +286,7 @@ namespace OpenTap.Package
                         Installation = this,
                         PackageDefFilePath = file
                     };
+
                     if (!plugins.ContainsKey(package.Name))
                     {
                         plugins.Add(package.Name, package);
@@ -302,6 +308,8 @@ namespace OpenTap.Package
                                 $"{string.Join("\n", p.Append(plugins[p.Key]).Select(x => " - " + ((InstalledPackageDefSource)x.PackageSource).PackageDefFilePath))}");
                     }
                 }
+
+
 
                 invalidate = false;
                 packageCache = plugins;

--- a/Package/PackageActions/Install.cs
+++ b/Package/PackageActions/Install.cs
@@ -148,7 +148,7 @@ namespace OpenTap.Package
                             break;
 
                         PackageIdentifier pid = new PackageIdentifier(pkg, vs, Architecture, OS);
-                        var installedPackage = targetInstallation.GetPackages().FirstOrDefault(p => p.Name == pid.Name);
+                        var installedPackage = targetInstallation.GetPackages(validOnly: true).FirstOrDefault(p => p.Name == pid.Name);
                         if (installedPackage != null && pid.Version.Equals(installedPackage.Version))
                         {
                             Log.Info($"Package '{pid.Name}' '{installedPackage.Version}' is already installed.");
@@ -286,7 +286,7 @@ namespace OpenTap.Package
                     }
                 }
 
-                var installationPackages = targetInstallation.GetPackages();
+                var installationPackages = targetInstallation.GetPackages(validOnly: true);
 
                 var overWriteCheckExitCode = CheckForOverwrittenPackages(installationPackages, packagesToInstall,
                     Force || Overwrite, !(NonInteractive || Overwrite));

--- a/Package/PackageActions/List.cs
+++ b/Package/PackageActions/List.cs
@@ -197,10 +197,24 @@ namespace OpenTap.Package
                 var installedPackage = installed.FirstOrDefault(p => p.Name == plugin.Name);
                 var latestPackage = packages.Where(p => p.Name == plugin.Name).OrderByDescending(p => p.Version).FirstOrDefault();
 
-                var installedString = installedPackage == null ? "" : installedPackage.IsValid() ? " - installed" : " - needs reinstall";
-                
-                if (installedPackage != null && installedPackage.IsSystemWide())
-                    installedString += " system-wide";
+                bool isInstalled = installedPackage != null;
+                bool isSystemWide = installedPackage?.IsSystemWide() ?? false;
+                bool isValid = installedPackage?.IsValid() ?? false;
+                string installedString = "";
+                if (isInstalled)
+                {
+                    installedString = "-";
+                    if (isValid)
+                        installedString += " installed";
+                    if(isSystemWide)
+                        installedString += " system-wide";
+                    if (!isValid)
+                    {
+                        if (installedString != "-")
+                            installedString += " -";
+                        installedString += " needs reinstall";
+                    }
+                }
 
                 // string interpolate + format complex to add padding.
                 string logMessage = string.Format($"{{0,-{nameLen}}} - {{1,-{verLen}}}{{2}}", plugin.Name, (installedPackage ?? plugin).Version, installedString);

--- a/Package/PackageActions/List.cs
+++ b/Package/PackageActions/List.cs
@@ -197,7 +197,7 @@ namespace OpenTap.Package
                 var installedPackage = installed.FirstOrDefault(p => p.Name == plugin.Name);
                 var latestPackage = packages.Where(p => p.Name == plugin.Name).OrderByDescending(p => p.Version).FirstOrDefault();
 
-                var installedString = installedPackage == null ? "" : " - installed";
+                var installedString = installedPackage == null ? "" : installedPackage.IsValid() ? " - installed" : " - needs reinstall";
                 
                 if (installedPackage != null && installedPackage.IsSystemWide())
                     installedString += " system-wide";

--- a/Package/PackageDefinitionSerializerPlugin.cs
+++ b/Package/PackageDefinitionSerializerPlugin.cs
@@ -183,6 +183,9 @@ namespace OpenTap.Package
 
                                 if (prop.Name == "Validation")
                                 {
+                                    if (val == null)
+                                        continue;
+
                                     foreach (var elem in elm.Elements())
                                     {
                                         elem.Attribute("type").Remove();

--- a/Package/PackageDefinitionSerializerPlugin.cs
+++ b/Package/PackageDefinitionSerializerPlugin.cs
@@ -68,6 +68,27 @@ namespace OpenTap.Package
                             pkg.Location = elm.Value;
 #pragma warning restore 618
                             break;
+                        case "Validation":
+                            foreach (var e in elm.Elements())
+                            {
+                                Validation marker = null;
+                                if (e.Name.LocalName == "FileExists")
+                                {
+                                    marker = new FileExists()
+                                    {
+                                        Path = e.Attribute("Path").Value
+                                    };
+                                }
+                                if (marker != null)
+                                {
+                                    if (pkg.Validation == null)
+                                        pkg.Validation = new();
+                                    pkg.Validation.Add(marker);
+                                }
+
+                            }
+
+                            break;
                         default:
                             var prop = pkg.GetType().GetProperty(elm.Name.LocalName);
                             if (prop != null)
@@ -159,6 +180,14 @@ namespace OpenTap.Package
                             if (obj != null)
                             {
                                 Serializer.Serialize(elm, val, expectedType: prop.TypeDescriptor);
+
+                                if (prop.Name == "Validation")
+                                {
+                                    foreach (var elem in elm.Elements())
+                                    {
+                                        elem.Attribute("type").Remove();
+                                    }
+                                }
                             }
                             SetAllNamespaces(elm, ns);
                             node.Add(elm);

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -539,6 +539,8 @@ namespace OpenTap.Package
         [DefaultValue("package")]
         public string Class { get; set; }
 
+        public List<Validation> Validation { get; set; }
+
         internal bool IsBundle()
         {
             return Class.ToLower() == "bundle" || Class.ToLower() == "solution";
@@ -1041,9 +1043,41 @@ namespace OpenTap.Package
         }
 
         internal PackageSpecifier GetSpecifier() => new PackageSpecifier(Name, Version.AsExactSpecifier(), Architecture, OS);
+
+        internal bool IsValid()
+        {
+            if (Validation != null)
+            {
+                foreach (var marker in Validation)
+                {
+                    if (!marker.IsSatisfied())
+                        return false;
+
+                }
+            }
+            return true;
+        }
     }
 
-    
+    public abstract class Validation
+    {
+        public abstract bool IsSatisfied();
+    }
+
+    public class FileExists : Validation
+    {
+        [XmlAttribute]
+        public string Path { get; set; }
+
+        public override bool IsSatisfied()
+        {
+            var file = Environment.ExpandEnvironmentVariables(Path);
+            return System.IO.File.Exists(file);
+        }
+    }
+
+
+
     // helper class to ignore namespaces when de-serializing
     internal class NamespaceIgnorantXmlTextReader : XmlTextReader
     {

--- a/Package/PackageFile.cs
+++ b/Package/PackageFile.cs
@@ -539,6 +539,9 @@ namespace OpenTap.Package
         [DefaultValue("package")]
         public string Class { get; set; }
 
+        /// <summary>
+        /// Validation objects for validating that the package is correctly installed.
+        /// </summary>
         public List<Validation> Validation { get; set; }
 
         internal bool IsBundle()
@@ -1050,7 +1053,7 @@ namespace OpenTap.Package
             {
                 foreach (var marker in Validation)
                 {
-                    if (!marker.IsSatisfied())
+                    if (!marker.IsValid())
                         return false;
 
                 }
@@ -1059,17 +1062,34 @@ namespace OpenTap.Package
         }
     }
 
+    /// <summary>
+    /// Base class for package validation objects.
+    /// </summary>
     public abstract class Validation
     {
-        public abstract bool IsSatisfied();
+        /// <summary>
+        /// Return true if the package installation is valid.
+        /// </summary>
+        /// <returns>true if the package is correctly installed.</returns>
+        public abstract bool IsValid();
     }
 
+    /// <summary>
+    /// This package validation checks if a file exists.
+    /// </summary>
     public class FileExists : Validation
     {
+        /// <summary>
+        /// The path to the file that have to exist for the package to be correctly installed.
+        /// </summary>
         [XmlAttribute]
         public string Path { get; set; }
 
-        public override bool IsSatisfied()
+        /// <summary>
+        /// Returns true if the file pointed to by Path exists.
+        /// </summary>
+        /// <returns></returns>
+        public override bool IsValid()
         {
             var file = Environment.ExpandEnvironmentVariables(Path);
             return System.IO.File.Exists(file);

--- a/Package/PackageSchema.xsd
+++ b/Package/PackageSchema.xsd
@@ -130,4 +130,24 @@
       <xs:attribute name="Tags" type="xs:string"/>
     </xs:complexType>
   </xs:element>
+
+  <xs:complexType name="Validation" abstract="true"/>
+
+  <xs:complexType name="FileExists">
+    <xs:complexContent>
+      <xs:extension base="Validation">
+        <xs:attribute name="Path" type="xs:string" use="required" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="Validation">
+    <xs:complexType>
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="FileExists" type="FileExists"/>
+      </xs:choice>
+    </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 </xs:schema>


### PR DESCRIPTION
Added support for checking if a file exists for package validation. This is mostly intended to be used by system-wide packages which can be uninstalled/upgraded through other paths than package install/uninstall.

Added unit tests to ensure that it works.

Tested that it works with system wide packages.