### PR TITLE
exclude tap.exe from files in use check

### DIFF
--- a/Package/Installer.cs
+++ b/Package/Installer.cs
@@ -287,7 +287,12 @@ namespace OpenTap.Package
 
         private void WaitForPackageFilesFreeWindows(List<string> packagePaths)
         {
-            var allfiles = packagePaths.SelectMany(PluginInstaller.FilesInPackage).ToArray();
+            var allfiles = packagePaths.SelectMany(PluginInstaller.FilesInPackage)
+                .Except(x =>
+                    Path.GetFileName(x).Equals("tap.exe", StringComparison.OrdinalIgnoreCase) ||
+                    Path.GetFileName(x).Equals("tap.dll", StringComparison.OrdinalIgnoreCase)
+                )
+                .ToArray();
 
             retry:
             var procs = RestartManager.GetProcessesUsingFiles(allfiles);


### PR DESCRIPTION
This fixes an issue preventing OpenTAP from self-upgrading

CLoses #1921 