### PR TITLE
Fix resource annotation

### DIFF
--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -2203,11 +2203,13 @@ namespace OpenTap.UnitTests
             var availableDuts = getAvailable(nameof(step.DUT));
             var availableBoth = getAvailable(nameof(step.Both)); 
             
-            Assert.AreEqual(1, availableInstruments.Length);
-            CollectionAssert.Contains(availableInstruments, ins);
+            Assert.AreEqual(2, availableInstruments.Length);
+            CollectionAssert.Contains(availableBoth, ins);
+            CollectionAssert.Contains(availableBoth, dut);
             
-            Assert.AreEqual(1, availableDuts.Length);
-            CollectionAssert.Contains(availableDuts, dut);
+            Assert.AreEqual(2, availableDuts.Length);
+            CollectionAssert.Contains(availableBoth, ins);
+            CollectionAssert.Contains(availableBoth, dut);
             
             Assert.AreEqual(2, availableBoth.Length);
             CollectionAssert.Contains(availableBoth, ins);

--- a/Engine.UnitTests/DutInstrumentInheritanceTest.cs
+++ b/Engine.UnitTests/DutInstrumentInheritanceTest.cs
@@ -1,0 +1,88 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace OpenTap.UnitTests;
+
+public class DutInstrumentInheritanceTest
+{
+    public interface IDutInstrument : IDut, IInstrument
+    {
+    }
+
+    public abstract class ItemResource : Resource
+    {
+    }
+
+    public class ItemInstrument : ItemResource, IInstrument
+    {
+        public override string ToString()
+        {
+            return "Instrument Item";
+        }
+    }
+
+    public class ItemDut : ItemResource, IDut
+    {
+        public override string ToString()
+        {
+            return "Dut Item";
+        }
+    }
+
+    public class ItemTestStep : TestStep
+    {
+        // Can take either the dut or instrument variant
+        public ItemResource Resource { get; set; }
+        public override void Run()
+        {
+        }
+    }
+
+    [Test]
+    public void TestStepResourceAssignability()
+    {
+        using var session = Session.Create(SessionOptions.OverlayComponentSettings);
+        var ins = new ItemInstrument();
+        var dut = new ItemDut();
+        InstrumentSettings.Current.Add(ins);
+        DutSettings.Current.Add(dut);
+            
+        var plan = new TestPlan(); 
+        var step = new ItemTestStep();
+        plan.ChildTestSteps.Add(step);
+
+        var a = AnnotationCollection.Annotate(step);
+        var mem = a.GetMember(nameof(step.Resource));
+        { // Verify that both the dut and the instrument variant can be assigned to the step resource
+            var avail = mem.Get<IAvailableValuesAnnotation>().AvailableValues.Cast<object>().ToArray();
+
+            Assert.That(avail.Length, Is.EqualTo(2));
+            Assert.That(avail, Contains.Item(dut));
+            Assert.That(avail, Contains.Item(ins));
+        }
+
+        { // Verify that the resource can be reassigned using StringValueAnnotations
+            var sv = mem.Get<IStringValueAnnotation>();
+            { // resource should be ins
+                step.Resource = ins;
+                a.Read();
+                Assert.That(step.Resource, Is.EqualTo(ins));
+                Assert.That(sv.Value, Is.EqualTo(ins.ToString()));
+            }
+            { // resource should be dut
+                sv.Value = dut.ToString();
+                a.Write();
+                a.Read();
+                Assert.That(step.Resource, Is.EqualTo(dut));
+                Assert.That(sv.Value, Is.EqualTo(dut.ToString()));
+            }
+            { // and back to ins
+                sv.Value = ins.ToString();
+                a.Write();
+                a.Read();
+                Assert.That(step.Resource, Is.EqualTo(ins));
+                Assert.That(sv.Value, Is.EqualTo(ins.ToString()));
+            }
+        }
+    } 
+}

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -2208,7 +2208,8 @@ namespace OpenTap
             {
                 get
                 {
-                    var x = ComponentSettingsList.GetContainers(baseType).Select(x => x.Cast<object>())
+                    // We need all items (from any container) which can be assigned to a property of type baseType.
+                    var x = ComponentSettingsList.GetAllContainers().Select(x => x.Cast<object>())
                         .SelectMany(x => x);
                     var cv = a.Get<IObjectValueAnnotation>()?.Value as IResource;
                     var result = x.Where(y => y.GetType().DescendsTo(baseType)).ToList();

--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -2208,8 +2208,9 @@ namespace OpenTap
             {
                 get
                 {
-                    // We need all items (from any container) which can be assigned to a property of type baseType.
-                    var x = ComponentSettingsList.GetAllContainers().Select(x => x.Cast<object>())
+                    // We need all items (from any resource container) which can be assigned to a property of type baseType.
+                    var x = ComponentSettingsList.GetResourceContainers()
+                        .Select(x => x.Cast<object>())
                         .SelectMany(x => x);
                     var cv = a.Get<IObjectValueAnnotation>()?.Value as IResource;
                     var result = x.Where(y => y.GetType().DescendsTo(baseType)).ToList();

--- a/Engine/ComponentSettings.cs
+++ b/Engine/ComponentSettings.cs
@@ -135,11 +135,14 @@ namespace OpenTap
             return (IList)m.GetValue(null, null);
         }
 
-        internal static IEnumerable<IList> GetContainers(Type T)
+        internal static IEnumerable<IList> GetAllContainers()
         {
-            foreach (var m in getGetCurrentMethodsForContainer(T))
+            foreach (Type key in typeHandlers.Keys)
             {
-                yield return (IList)m.GetValue(null, null);
+                Type compSetType = typeHandlers[key];
+                PropertyInfo prop = compSetType.GetProperty("Current", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+                if (prop != null)
+                    yield return (IList)prop.GetValue(null, null);
             }
         }
 

--- a/Engine/ComponentSettings.cs
+++ b/Engine/ComponentSettings.cs
@@ -116,11 +116,22 @@ namespace OpenTap
                 {
 
                     Type compSetType = typeHandlers[key];
-                    PropertyInfo prop = compSetType.GetProperty("Current", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
-                    if (prop != null)
+                    if (GetCurrentProp(compSetType) is { } prop)
                         yield return prop;
                 }
             }
+        }
+
+        private static PropertyInfo GetCurrentProp(Type compSetType)
+        {
+            return compSetType.GetProperty("Current", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy); 
+        }
+        
+        private static IList GetCurrent(Type compSetType)
+        {
+            if (GetCurrentProp(compSetType) is {} prop)
+                return (IList)prop.GetValue(null, null);
+            return null;
         }
         
         /// <summary>
@@ -135,14 +146,14 @@ namespace OpenTap
             return (IList)m.GetValue(null, null);
         }
 
-        internal static IEnumerable<IList> GetAllContainers()
+        internal static IEnumerable<IList> GetResourceContainers()
         {
             foreach (Type key in typeHandlers.Keys)
             {
+                if (!key.DescendsTo(typeof(IResource))) continue;
                 Type compSetType = typeHandlers[key];
-                PropertyInfo prop = compSetType.GetProperty("Current", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
-                if (prop != null)
-                    yield return (IList)prop.GetValue(null, null);
+                if (GetCurrent(compSetType) is IList lst) 
+                    yield return lst;
             }
         }
 


### PR DESCRIPTION
This fixes an issue with available values for resources in some inheritance scenarios where the base type is an IResource, but not an IInstrument or an IDut.