### PR TITLE
PluginSerializer: ensure double roundtrip parsing works

### DIFF
--- a/.gitversion
+++ b/.gitversion
@@ -4,7 +4,7 @@
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
 
-version = 9.28.0
+version = 9.28.1
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.


### PR DESCRIPTION
We previously assumed these values will always be valid since they are generated by OpenTAP, but it seems there are problematic plugins in the wild

CLoses #1951