### PR TITLE
Make Run Program step accept any file extension

### DIFF
--- a/BasicSteps/ProcessStep.cs
+++ b/BasicSteps/ProcessStep.cs
@@ -49,7 +49,7 @@ namespace OpenTap.Plugins.BasicSteps
         [Display("Application", Order: -2.5,
             Description:
             "The path to the program. It should contain either a relative path to OpenTAP installation folder or an absolute path to the program.")]
-        [FilePath(FilePathAttribute.BehaviorChoice.Open, "exe")]
+        [FilePath(FilePathAttribute.BehaviorChoice.Open)]
         public string Application { get; set; } = "";
 
         [Display("Command Line Arguments", Order: -2.4, Description: "The arguments passed to the program.")]


### PR DESCRIPTION
Historically we only accepted .exe files because we only supported windows, but on Linux and Mac, executable files can have any file extension. When using ShellExecute, Windows can also open a file with any file extension with the default handler for that extension (pdf, html, url, etc)

Closes #1937