### PR TITLE
Package platform dependent runtime config

### DIFF
--- a/Shared/tap.runtimeconfig.WindowsDesktop.json
+++ b/Shared/tap.runtimeconfig.WindowsDesktop.json
@@ -1,0 +1,11 @@
+{
+  "runtimeOptions": {
+    "framework": {
+      "name": "Microsoft.WindowsDesktop.App",
+      "version": "9.0.0"
+    },
+    
+    "applyPatches": true,
+    "rollForwardOnNoCandidateFx": 2 
+  }
+}

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,6 @@
     <Owner>OpenTAP</Owner>
     <!-- Common files  -->
     <Files Condition="$(Debug) == false">
-        <File Path="tap.runtimeconfig.json"/>
         <File Path="tap.dll">
             <SetAssemblyInfo Attributes="Version" />
             <Sign Certificate="Keysight Technologies, Inc" Condition="$(Sign)==true"/>
@@ -42,7 +41,6 @@
     </Files>
     <!-- For debug builds. Includes debugging symbols and puts all the DLLs in the OpenTAP root directory.  -->
     <Files Condition="$(Debug) == true">
-        <File Path="tap.runtimeconfig.json"/>
         <File Path="tap.dll"/>
         <File Path="tap.pdb"/>  
         <File Path="OpenTap.dll"/>
@@ -56,7 +54,11 @@
         <File Path="Packages/OpenTAP/Tap.Upgrader.pdb" SourcePath="Tap.Upgrader.pdb"/>
     </Files>
     <!-- Windows only files -->
+    <Files Condition="$(Platform) != Windows">
+        <File Path="tap.runtimeconfig.json" SourcePath="../../Shared/tap.runtimeconfig.json" />
+    </Files>
     <Files Condition="$(Platform) == Windows">
+        <File Path="tap.runtimeconfig.json" SourcePath="../../Shared/tap.runtimeconfig.WindowsDesktop.json" />
         <File Path="tap.exe">
             <Sign Certificate="Keysight Technologies, Inc" Condition="$(Sign)==true"/>
         </File>

--- a/tap/tap.csproj
+++ b/tap/tap.csproj
@@ -15,7 +15,14 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(OS)'=='Windows_NT'">
+    <Content Include="..\Shared\tap.runtimeconfig.WindowsDesktop.json">
+      <Link>tap.runtimeconfig.json</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(OS)'!='Windows_NT'">
     <Content Include="..\Shared\tap.runtimeconfig.json">
       <Link>tap.runtimeconfig.json</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>


### PR DESCRIPTION
This fixes an issue causing a lot of type resolution errors to occur when installing packages which depend on WPF / PresentationCore APIs