### PR TITLE
Set assembly version info for Tap.Upgrader.exe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,7 @@ jobs:
           $AssemblyInfoFile | Set-Content AssemblyInfo.cs
           cat AssemblyInfo.cs
           Pop-Location
+          cp ./tap/Properties/AssemblyInfo.cs ./Tap.Upgrader/AssemblyInfo.cs
       - name: Build
         run: dotnet build -c Release /p:Platform=${{ matrix.Architecture }}
       - name: cat tap.runtimeconfig.json 


### PR DESCRIPTION
This removes a warning about multiple different versions of Tap.Upgrader being present when installing OpenTAP 9.29.0-rc.1