### PR TITLE
Improve templates

### DIFF
--- a/templates/src/project/.template.config/template.json
+++ b/templates/src/project/.template.config/template.json
@@ -130,7 +130,6 @@
     "Editor": {
       "type": "parameter",
       "datatype": "choice",
-      "replaces": "TapEditor",
       "defaultValue": "Editor",
       "description": "The default editor to debug with.",
       "choices": [
@@ -145,6 +144,24 @@
           "description": "Set Keysight Test Automation as the debugging editor."
         }
       ]
+    },
+    "EditorSwitch": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "TapEditor",
+      "parameters": {
+        "evaluator": "C++",
+        "cases": [
+          {
+            "condition": "(Editor == \"Editor\")",
+            "value": "Include=\"Editor\" version=\"9\""
+          },
+          {
+            "condition": "(Editor == \"TUI\")",
+            "value": "Include=\"TUI\" version=\"1\""
+          }
+        ]
+      }
     },
     "TUIRegex": {
       "type": "generated",

--- a/templates/src/project/ProjectName.csproj
+++ b/templates/src/project/ProjectName.csproj
@@ -7,7 +7,6 @@
     <TargetFrameworkIdentifier></TargetFrameworkIdentifier>
     <TargetFrameworkVersion></TargetFrameworkVersion>
     <TargetFramework>net9</TargetFramework>
-    <DebugWith>TapEditor</DebugWith>
   </PropertyGroup>
     
   <PropertyGroup>
@@ -23,12 +22,8 @@
     <PackageReference Include="OpenTAP" Version="$(GitVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DebugWith)' == 'TUI' AND '$(Configuration)' == 'Debug'">
-    <OpenTapPackageReference Include="TUI" version="1"/>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(DebugWith)' == 'Editor' AND '$(Configuration)' == 'Debug'">
-    <OpenTapPackageReference Include="Editor" version="9"/>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <OpenTapPackageReference TapEditor />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Make .vscode templates cross-platform (possible now because of .NET9)
* Clean up output .csproj file by selecting Editor at template creation time
* Set default editor to KS8400 (thanks to community edition)
* Remove Visual Studio workaround from .csproj file (not needed because of .NET 9)
* Add Rider launch config for Linux/MacOS