### PR TITLE
Fix confusion of forwards and backwards slashes

### DIFF
--- a/doc/Developer Guide/Translating/Readme.md
+++ b/doc/Developer Guide/Translating/Readme.md
@@ -225,6 +225,55 @@ public class DialogStep : TestStep
 
 ```
 
+## Distributing translations
+
+If you own the package, we recommend bundling your translation files directly
+in the package. This solves the problem of language files potentially getting
+out of sync with the source files by ensuring the translation files always
+match the installed version of the package, and ensures that the translations
+are always available when your package is installed. See example:
+
+```xml
+<Package Name="MyPackage">
+  <Files>
+    <!-- You can include the neutral file if you want, but it is not required, and OpenTAP will ignore it -->
+    <!-- <File Path="Languages/MyPackage.resx"/> -->
+    <File Path="Languages/MyPackage.de.resx"/>
+    <File Path="Languages/MyPackage.fr.resx"/>
+    <File Path="Packages/MyPackage/MyPackage.dll"/>
+  </Files>
+</Package>
+```
+
+If you do not own the package you are translating, things get a bit more
+tricky. If possible, you can reach out to the package maintainers and add a
+pull request with your translations, but be aware that they may not accept your
+translation.
+
+Alternatively, you can add additional translations for other packages in your
+own plugin, or even create a new package which only contains translations:
+
+```xml
+<Package Name="OpenTAP German Language Pack">
+  <Description>This package adds german translation for OpenTAP types.</Description>
+  <Dependencies>
+    <!-- Manually add a dependency on the package you are translating. This
+    communicates that your translations were created for this version of
+    OpenTAP, and that strings added after 9.29.0 may not be translated. -->
+    <PackageDependency Package="OpenTAP" Version="^9.29.0" />
+  </Dependencies>
+  <Files>
+    <!-- You could call this file "OpenTAP.de.resx", but this introduces the
+    risks of name collisions if OpenTAP added native german support in a future
+    update. By using a more specific name, collisions are avoided. -->
+    <File Path="Languages/OpenTAP German Language Pack.de.resx"/>
+  </Files>
+```
+
+If there are multiple translations of the same string, the choice is not
+currently defined, so you should not make assumptions about which string will
+be chosen as this could easily change in a new OpenTAP version.
+
 ## Translation tips
 
 This section is dedicated to some general tips about working with translations in OpenTAP.

--- a/sdk/OpenTap.Sdk.New/TranslateAction.cs
+++ b/sdk/OpenTap.Sdk.New/TranslateAction.cs
@@ -114,9 +114,11 @@ public class TranslateAction : ICliAction
             types.AddRange(add);
         }
 
+        static string normalizePath(string path) => path.Replace('\\', '/');
         var typesSources = types.Select(x => Path.GetFullPath(TypeData.GetTypeDataSource(x).Location))
             .Where(x => x.StartsWith(install.Directory, StringComparison.OrdinalIgnoreCase))
             .Select(x => x.Substring(install.Directory.Length + 1))
+            .Select(normalizePath)
             .ToArray();
 
         var outdir = Path.GetDirectoryName(outputFileName);
@@ -124,7 +126,7 @@ public class TranslateAction : ICliAction
             Directory.CreateDirectory(outdir);
 
         var writer = new ResXWriter(outputFileName);
-        var packageFiles = new HashSet<string>(pkg.Files.Select(x => x.FileName), StringComparer.OrdinalIgnoreCase);
+        var packageFiles = new HashSet<string>(pkg.Files.Select(x => normalizePath(x.FileName)), StringComparer.OrdinalIgnoreCase);
         List<ITypeData> packageTypes = [];
         for (int i = 0; i < typesSources.Length; i++)
         {
@@ -137,8 +139,14 @@ public class TranslateAction : ICliAction
 
         var typesBySource =
             packageTypes.GroupBy(tp => Path.GetFullPath(TypeData.GetTypeDataSource(tp).Location),
-                StringComparer.OrdinalIgnoreCase);
+                StringComparer.OrdinalIgnoreCase).ToArray();
 
+        if (!typesBySource.Any())
+        { 
+            log.Error($"0 types discovered for package '{Package}'. This is likely a bug.");
+            return 1;
+        }
+        
         foreach (var grp in typesBySource)
         {
             foreach (var type in grp)
@@ -251,24 +259,57 @@ public class TranslateAction : ICliAction
 
     static bool SkipType(ITypeData type)
     {
-        if (type.DescendsTo(typeof(IStringLocalizer))) return false;
-        if (type.DescendsTo(typeof(Enum))) return false;
-        // Skip types that cannot be instantiated if they do not have any members.
-        if (!type.CanCreateInstance && !type.GetMembers().Any(mem => !SkipMem(type, mem)))
-            return true;
-        return false;
+        try
+        {
+            if (type.DescendsTo(typeof(IStringLocalizer)))
+            {
+                if (type.CanCreateInstance) return false;
+                // It is currently a requirement that IStringLocalizer can be instantiated.
+                // In the future, we can improve the string detection algorithm to relax this requirement,
+                // but for now we should warn the user that this will not work.
+                log.Error($"String localizer '{type.Name}' does not have an empty constructor, and will not be translated.");
+                return true;
+            }
+            if (type.DescendsTo(typeof(Enum))) return false; 
+            {
+                var members = type.GetMembers().ToArray();
+                foreach (var mem in members)
+                {
+                    // If at least one member should be translated, we can't skip the type.
+                    if (SkipMem(type, mem) == false)
+                        return false;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // ignore. This can happen for bad typedata implementations. We should just ignore the type in this case
+            // since we can't translate it if we can't enumerate the members.
+            log.Error($"Error reflecting type '{type.Name}'. This type will not be translated.");
+            log.Debug(ex);
+        } 
+        return true;
     }
 
     static bool SkipMem(ITypeData type, IMemberData mem)
     {
-        // If this member is inherited, the translation should happen in the base class.
-        if (!Equals(mem.DeclaringType, type))
+        try
+        {
+            // If this member is inherited, the translation should happen in the base class.
+            if (!Equals(mem.DeclaringType, type))
+                return true;
+            // Skip the member if it is unbrowsable
+            var browsable = mem.GetAttribute<BrowsableAttribute>()?.Browsable;
+            if (browsable != null) return !browsable.Value;
+            // Otherwise skip the member if it is not writable.
+            // This is the primary factor determining whether or not something is visible in most UIs.
+            return !mem.Writable;
+        }
+        catch (Exception ex)
+        { 
+            log.Error($"Error reflecting member '{type.Name}.{mem.Name}'. This member will not be translated.");
+            log.Debug(ex);
             return true;
-        // Skip the member if it is unbrowsable
-        var browsable = mem.GetAttribute<BrowsableAttribute>()?.Browsable;
-        if (browsable != null) return !browsable.Value;
-        // Otherwise skip the member if it is not writable.
-        // This is the primary factor determining whether or not something is visible in most UIs.
-        return !mem.Writable;
+        }
     }
 }


### PR DESCRIPTION
This fixes an issue causing no types to be discovered from some packages in translation template generation