### PR TITLE
Narrow down translation type discovery

### DIFF
--- a/Engine/Translation/TranslationManager.cs
+++ b/Engine/Translation/TranslationManager.cs
@@ -129,7 +129,10 @@ public static class TranslationManager
         language ??= EngineSettings.Current.Language;
         if (language.Equals(NeutralLanguage) || string.IsNullOrWhiteSpace(key))
             return neutral;
-        var fullKey = stringLocalizer.GetType().FullName + $".{key}";
+        var type = stringLocalizer.GetType();
+        if (type.IsGenericType)
+            type = type.GetGenericTypeDefinition();
+        var fullKey = type.FullName + $".{key}";
         return TranslateKey(fullKey, language) ?? neutral;
     }
 

--- a/sdk/OpenTap.Sdk.New/ResXWriter.cs
+++ b/sdk/OpenTap.Sdk.New/ResXWriter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Xml.Linq;
 
 namespace OpenTap.Sdk.New;
@@ -37,7 +38,7 @@ class ResXWriter
         var root = new XElement("root");
         document.Add(root);
 
-        foreach (var kvp in keys)
+        foreach (var kvp in keys.OrderBy(v => v.Key, StringComparer.OrdinalIgnoreCase))
         {
             var ele = new XElement("data");
             ele.SetAttributeValue("name", kvp.Key);

--- a/sdk/OpenTap.Sdk.New/TranslateAction.cs
+++ b/sdk/OpenTap.Sdk.New/TranslateAction.cs
@@ -73,9 +73,17 @@ public class TranslateAction : ICliAction
                     if (mem.TypeDescriptor.Name.StartsWith("System.")
                         || mem.TypeDescriptor.Name.StartsWith("Microsoft."))
                         continue;
-                    if (seen.Add(mem.TypeDescriptor))
+                    if (SkipMem(td, mem))
                     {
-                        recursivelyAddReferencedTypes(mem.TypeDescriptor, seen);
+                        continue;
+                    }
+                    // Always translate the member type if it is embedded.
+                    if (mem.HasAttribute<EmbedPropertiesAttribute>() || SkipType(mem.TypeDescriptor) == false)
+                    {
+                        if (seen.Add(mem.TypeDescriptor))
+                        {
+                            recursivelyAddReferencedTypes(mem.TypeDescriptor, seen);
+                        }
                     }
                 }
             }
@@ -98,7 +106,6 @@ public class TranslateAction : ICliAction
             // We are not interested in creating a different translation for each 
             // variant of a generic type we use. 
             // Remove all instances of generic types, and add a single reference to the generic variant.
-            // TODO: The translation implementation needs to support this. (add test)
             HashSet<TypeData> add = [];
             HashSet<TypeData> remove = [];
             foreach (var type in types)
@@ -264,6 +271,8 @@ public class TranslateAction : ICliAction
             if (type.DescendsTo(typeof(IStringLocalizer)))
             {
                 if (type.CanCreateInstance) return false;
+                // Don't log errors if the type is abstract
+                if (AsTypeData(type)?.Type.IsAbstract == true) return true;
                 // It is currently a requirement that IStringLocalizer can be instantiated.
                 // In the future, we can improve the string detection algorithm to relax this requirement,
                 // but for now we should warn the user that this will not work.
@@ -271,14 +280,13 @@ public class TranslateAction : ICliAction
                 return true;
             }
             if (type.DescendsTo(typeof(Enum))) return false; 
+            
+            var members = type.GetMembers().ToArray();
+            foreach (var mem in members)
             {
-                var members = type.GetMembers().ToArray();
-                foreach (var mem in members)
-                {
-                    // If at least one member should be translated, we can't skip the type.
-                    if (SkipMem(type, mem) == false)
-                        return false;
-                }
+                // If at least one member should be translated, we can't skip the type.
+                if (SkipMem(type, mem) == false)
+                    return false;
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
This removes a lot of unnecessary types from translations by pruning types during the recursive search.

Because we did not previously prune in the type discovery step, we would pick up a lot of unneeded types if they were referenced by private properties or internal types.