### PR TITLE
Update Order xml comments

### DIFF
--- a/Engine/Annotations/Annotation.cs
+++ b/Engine/Annotations/Annotation.cs
@@ -38,7 +38,7 @@ namespace OpenTap
         string[] Group { get; }
         /// <summary> Name displayed by the UI. </summary>
         string Name { get; }
-        /// <summary> Optional integer that ranks items and groups in ascending order relative to other items/groups. 
+        /// <summary> Optional double that ranks items and groups in ascending order relative to other items/groups. 
         /// Default is -10000. For a group, the order is the average order of the elements inside the group. 
         /// Any double value is allowed. Items with same order are ranked alphabetically.
         /// </summary>

--- a/Engine/DisplayAttribute.cs
+++ b/Engine/DisplayAttribute.cs
@@ -32,7 +32,7 @@ namespace OpenTap
         /// <summary> The language of this attribute..</summary>
         public CultureInfo Language { get; }
 
-        /// <summary> Optional integer that ranks items and groups in ascending order relative to other items/groups. 
+        /// <summary> Optional double that ranks items and groups in ascending order relative to other items/groups. 
         /// Default is -10000. For a group, the order is the average order of the elements inside the group. 
         /// Any double value is allowed. Items with same order are ranked alphabetically.
         /// </summary>
@@ -73,7 +73,7 @@ namespace OpenTap
         /// <param name="Name">Name displayed by the UI.</param>
         /// <param name="Description"> Optional text that provides a description of the item. Consider using HelpLinkAttribute if a link to documentation is needed. </param>
         /// <param name="Group"> Optional text used to group displayed items. Use 'Groups' if more than one level of grouping is needed. </param>
-        /// <param name="Order"> Optional integer that ranks items and groups in ascending order relative to other items/groups. Default is defined by DisplayAttribute.DefaultOrder. 
+        /// <param name="Order"> Optional double that ranks items and groups in ascending order relative to other items/groups. Default is defined by DisplayAttribute.DefaultOrder. 
         /// For a group, the order is the average order of the elements inside the group. Any double value is allowed. Items with same order are ranked alphabetically. </param>
         /// <param name="Collapsed"> Boolean setting that indicates whether a group's default appearance is collapsed. Default is 'false' (group is expanded). </param>
         /// <param name="Groups"> Optional array of text strings to specify multiple levels of grouping. Use 'Group' if only one level of grouping is needed. </param>
@@ -97,7 +97,7 @@ namespace OpenTap
         /// <param name="Name">Name displayed by the UI.</param>
         /// <param name="Description"> Optional text that provides a description of the item. Consider using HelpLinkAttribute if a link to documentation is needed. </param>
         /// <param name="Group"> Optional text used to group displayed items. Use 'Groups' if more than one level of grouping is needed. </param>
-        /// <param name="Order"> Optional integer that ranks items and groups in ascending order relative to other items/groups. Default is defined by DisplayAttribute.DefaultOrder. 
+        /// <param name="Order"> Optional double that ranks items and groups in ascending order relative to other items/groups. Default is defined by DisplayAttribute.DefaultOrder. 
         /// For a group, the order is the average order of the elements inside the group. Any double value is allowed. Items with same order are ranked alphabetically. </param>
         /// <param name="Collapsed"> Boolean setting that indicates whether a group's default appearance is collapsed. Default is 'false' (group is expanded). </param>
         /// <param name="Groups"> Optional array of text strings to specify multiple levels of grouping. Use 'Group' if only one level of grouping is needed. </param>


### PR DESCRIPTION
The XML comment for Order incorrectly states that it is an integer when it is a double.

Let's fix this.

Closes #1991 