### PR TITLE
increase retry rate in tap upgrader

### DIFF
--- a/Tap.Upgrader/Program.cs
+++ b/Tap.Upgrader/Program.cs
@@ -103,7 +103,7 @@ namespace Tap.Upgrader
                 }
                 catch
                 {
-                    Thread.Sleep(TimeSpan.FromSeconds(1));
+                    Thread.Sleep(TimeSpan.FromMilliseconds(100));
                 }
             }
 


### PR DESCRIPTION
This reduces the likelihood that another process using tap.exe after an upgrade is started. The consequences of not updating tap.exe are much more serious after updating to .NET 9 than previously