### PR TITLE
Update package diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,7 +706,7 @@ jobs:
       - uses: opentap/setup-opentap@v1.0
         with:
           version: 9.21.1
-          packages: 'Package Diff:0.1.0-beta.19+2b1aa952'
+          packages: 'Package Diff:0.1.0-beta.21'
       - name: Download package
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This version should no longer trigger a breaking error when a property setter is added.

Example output:

```
$ tap package diff OpenTAP.9.28.3-rc.1+24df3414.TapPackage
Diffing:
>> OpenTAP|9.28.3-rc.1+24df3414
<< OpenTAP|9.28.2+504225fd

Public Properties:
-Exception OpenTap.TestPlanRun::Exception { public get; }
+Exception OpenTap.TestPlanRun::Exception { public get; public set; }
-Exception OpenTap.TestRun::Exception { public get; }
+Exception OpenTap.TestRun::Exception { public get; public set; }
-Exception OpenTap.TestStepRun::Exception { public get; }
+Exception OpenTap.TestStepRun::Exception { public get; public set; }
```

Notice that the changes are still listed, but are no longer considered breaking