### PR TITLE
re-add opentap.dll reference in nuget package

### DIFF
--- a/nuget/OpenTAP.nuspec
+++ b/nuget/OpenTAP.nuspec
@@ -12,9 +12,13 @@
     </description>
     <copyright>Copyright 2012-2019</copyright>
     <tags>OpenTAP</tags>
+    <references>
+    	<reference file="OpenTap.dll"/>
+    </references>
     <license type="expression">MPL-2.0</license>
   </metadata>
   <files>
+    <file src="build/runtimes/win-x64/OpenTap.dll" target="lib/netstandard2.0" />
     <file src="build/**/*" exclude="**\.*"/>
   </files>
 </package>

--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -52,12 +52,6 @@
     <PackagePayloadFiles Include="$(OpenTapDocsDir)\**\*"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="OpenTap">
-      <HintPath>$(OutDir)OpenTap.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
   <Target Name="CopyOpenTapPayloadFiles"
           Inputs="@(PackagePayloadFiles)"
           Outputs="@(PackagePayloadFiles -> '$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"


### PR DESCRIPTION
This change only worked in some build types, but caused issues especially in multi-stage builds and transitive nuget dependencies