### PR TITLE
GatherPackages: throw if result cannot be downloaded

### DIFF
--- a/Package/Image/ImageIdentifier.cs
+++ b/Package/Image/ImageIdentifier.cs
@@ -320,6 +320,16 @@ namespace OpenTap.Package
                 log.Info($"Downloading {package.Name} version {package.Version} from {rm.Url}");
                 rm.DownloadPackage(package, filename, token);
             }
+            else if (package.PackageSource is InstalledPackageDefSource)
+            {
+                throw new Exception(
+                    $"Unable to download package {package.Name} since it is only available as an installed package.");
+            }
+            else
+            {
+                throw new Exception(
+                    $"Unable to downlaod package {package.Name} because its source type '{package.PackageSource.GetType().Name}' is not supported.");
+            }
         }
 
         private static string CachedLocation(PackageDef package)

--- a/Package/PackageActionHelpers.cs
+++ b/Package/PackageActionHelpers.cs
@@ -204,7 +204,16 @@ namespace OpenTap.Package
             gatheredPackages = gatheredPackages
                 .Select(x => directlyReferencesPackages.FirstOrDefault(y => y.Name == x.Name && y.Version == x.Version) ?? x)
                 .ToList();
-            return gatheredPackages.ToList();
+
+            var unavailablePackages =
+                gatheredPackages.Where(x => x.PackageSource is InstalledPackageDefSource).ToArray();
+            if (unavailablePackages.Any())
+            {
+                var str = string.Join("', '", unavailablePackages.Select(x => x.Name));
+                throw new Exception($"The following packages are not available: '{str}'");
+            }
+
+            return gatheredPackages;
         }
 
         internal static List<string> DownloadPackages(string destinationDir, List<PackageDef> PackagesToDownload, List<string> filenames = null, Action<int, string> progressUpdate = null, bool ignoreCache = false)


### PR DESCRIPTION
Throw a proper exception if a requested package cannot be downloaded / installed

Previously, the exception would happen in other weird places when OpenTAP actually tries to download the resolved packages.

Closes #1965 