### PR TITLE
2019 Mixin Improvements

### DIFF
--- a/Engine.UnitTests/MixinTests.cs
+++ b/Engine.UnitTests/MixinTests.cs
@@ -504,8 +504,80 @@ namespace OpenTap.UnitTests
             var mixin = MixinFactory.LoadMixin(step, new TestUnhandledExceptionMixinBuilder());
             var run = plan.Execute();
             Assert.That(run.Verdict, Is.EqualTo(expectedVerdict));
-
         }
+
+
+
+        class ExecutedStep : TestStep
+        {
+
+            public bool Executed;
+            public override void Run()
+            {
+                Executed = true;
+            }
+        }
+        class PreJumpSkipStep : ExecutedStep
+        {
+            public class JumpMixin : ITestStepPreRunMixin
+            {
+
+                public ITestStep NextStep;
+                public void OnPreRun(TestStepPreRunEventArgs eventArgs)
+                {
+                    eventArgs.TestStep.StepRun.SuggestedNextStep = NextStep.Id;
+                }
+            }
+            [EmbedProperties]
+            public JumpMixin Jump { get; } = new JumpMixin();
+        }
+
+        class ExceptionPreMixinStep : ExecutedStep
+        {
+            public class ExceptionMixin : ITestStepPreRunMixin
+            {
+                public void OnPreRun(TestStepPreRunEventArgs eventArgs)
+                {
+                    eventArgs.TestStep.StepRun.Exception = new Exception("!!");
+                }
+            }
+            [EmbedProperties]
+            public ExceptionMixin Exception { get; } = new ExceptionMixin();
+        }
+
+        [Test]
+        public void TestMixinPreJumpToStep()
+        {
+            var step1 = new PreJumpSkipStep();
+            var step2 = new ExecutedStep();
+            var step3 = new ExecutedStep();
+            var step4 = new ExecutedStep();
+            step1.Jump.NextStep = step3;
+            var plan = new TestPlan();
+            plan.ChildTestSteps.AddRange([step1, step2, step3, step4]);
+            plan.Execute();
+            Assert.IsFalse(step1.Executed);
+            Assert.IsFalse(step2.Executed);
+            Assert.IsTrue(step3.Executed);
+            Assert.IsTrue(step4.Executed);
+        }
+
+        [Test]
+        public void TestMixinExceptionPreStep()
+        {
+            var step1 = new ExceptionPreMixinStep();
+            var step2 = new ExecutedStep();
+            var step3 = new ExecutedStep();
+            var plan = new TestPlan();
+            plan.ChildTestSteps.AddRange([step1, step2, step3]);
+            var run = plan.Execute();
+            Assert.IsFalse(step1.Executed);
+            Assert.IsFalse(step2.Executed);
+            Assert.IsFalse(step3.Executed);
+            Assert.AreEqual(Verdict.Error, run.Verdict);
+        }
+
+
     }
 
     public class MixinTest : IMixin, ITestStepPostRunMixin, ITestStepPreRunMixin, IAssignOutputMixin

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -624,7 +624,10 @@ namespace OpenTap
             {
                 BreakOfferedEventArgs args = new BreakOfferedEventArgs(stepRun, isTestStepStarting);
                 plan.OnBreakOffered(args);
-                stepRun.SuggestedNextStep = args.JumpToStep;
+
+                // stepRun.SuggestedNextStep might have been set by something else.
+                if(args.JumpToStep != null)
+                    stepRun.SuggestedNextStep = args.JumpToStep;
             }
         }
         /// <summary>
@@ -991,7 +994,9 @@ namespace OpenTap
                         planRun.AddTestStepRunStart(stepRun);
                         try
                         {
-                            Step.Run();
+                            // exception set by pre-run mixin?
+                            if(stepRun.Exception == null)
+                                Step.Run();
                         }
                         catch (Exception ex)
                         {

--- a/Package.UnitTests/Image/Workflows.cs
+++ b/Package.UnitTests/Image/Workflows.cs
@@ -174,7 +174,7 @@ namespace OpenTap.Image.Tests
             Console.WriteLine($"Second deploy (uninstall): {stopwatch.ElapsedMilliseconds} ms");
 
             var uninstallLog = logListener.allLog.ToString();
-            StringAssert.DoesNotContain("Error", uninstallLog, $"Errors in uninstall log:\n {uninstallLog}");
+            Assert.That(logListener.ErrorMessage, Is.Empty);
             StringAssert.Contains("Starting uninstall step 'tap package list -i'", uninstallLog, $"Errors in uninstall log:\n {uninstallLog}");
 
             var installation = tempInstall.Installation;


### PR DESCRIPTION
- Allow mixins to jump to a test step from a prerun mixin. This was not possible before because breakoffered always overwrite with null or something else.

- Allow mixins to set an exception and avoid the test step from being executed.

Close #2019, #2018 