### PR TITLE
2062 add dotnet to path

### DIFF
--- a/Shared/ExecutorInterop.cs
+++ b/Shared/ExecutorInterop.cs
@@ -101,6 +101,15 @@ namespace OpenTap
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
+            var dotnet = ExecutorClient.Dotnet;
+            var dotnetDir = Path.GetDirectoryName(dotnet);
+            if (!string.IsNullOrWhiteSpace(dotnetDir))
+            {
+                var path = Environment.GetEnvironmentVariable("PATH") ?? "";
+                path = $"{dotnetDir}{Path.PathSeparator}{path}";
+                // Ensure the directory containing the current dotnet executable appears first in PATH.
+                start.Environment["PATH"] = $"{dotnetDir}{Path.PathSeparator}{path}";
+            }
             if (isolated)
             {
                 start.Environment[EnvVarNames.ParentProcessExeDir] = ExecutorClient.ExeDir;

--- a/Shared/ExecutorInterop.cs
+++ b/Shared/ExecutorInterop.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -199,6 +200,57 @@ namespace OpenTap
                 }
             }
         }
+        
+        public static string Dotnet => _dotnet ??= mineDotnet();
+        private static string _dotnet = null;
+        private static string mineDotnet()
+        {
+            // Ensure dotnet is always assigned. "dotnet' is used as a fallback, in which case the system
+            // will try to resolve it from the current PATH
+
+            // Look for dotnet.exe on windows
+            var executable = Path.DirectorySeparatorChar == '\\' ? "dotnet.exe" : "dotnet";
+            try
+            {
+                // 1. Try to check which `dotnet` instance launched the current application
+                string mainModulePath = Process.GetCurrentProcess().MainModule?.FileName;
+                if (!string.IsNullOrWhiteSpace(mainModulePath) &&
+                    Path.GetFileName(mainModulePath).Equals(executable, StringComparison.OrdinalIgnoreCase))
+                {
+                    return mainModulePath;
+                }
+            }
+            catch
+            {
+                // ignore potential permission errors
+            }
+
+            try
+            {
+                // 2. Find dotnet based on runtime information
+                var runtime = RuntimeEnvironment.GetRuntimeDirectory();
+                if (!string.IsNullOrWhiteSpace(runtime) && Directory.Exists(runtime))
+                {
+                    var dir = new DirectoryInfo(runtime);
+                    while (dir != null)
+                    {
+                        var candidate = System.IO.Path.Combine(dir.FullName, executable);
+                        if (File.Exists(candidate))
+                        {
+                            return candidate;
+                        }
+
+                        dir = dir.Parent;
+                    }
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+
+            return "dotnet";
+        } 
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         static string GetOpenTapDllLocation() => Path.GetDirectoryName(typeof(PluginSearcher).Assembly.Location);


### PR DESCRIPTION
This is kind of a workaround, but I think it is the simplest solution which works reliably across systems.

To verify this solution:

1. Remove dotnet from PATH
2. Run `/path/to/dotnet tap.dll package install CSV`
3. Observe that it doesn't work

Closes #2062