### PR TITLE
2065 / 2064: Hex format and sweep with unit

### DIFF
--- a/Engine.UnitTests/UnitFormatterTest.cs
+++ b/Engine.UnitTests/UnitFormatterTest.cs
@@ -1,0 +1,50 @@
+﻿using System.Globalization;
+using NUnit.Framework;
+namespace OpenTap.UnitTests;
+
+public class UnitFormatterTest
+{
+
+    [TestCase("", "0x", 10, "0xa")]
+    [TestCase("", "0X", 10, "0xA")]
+    [TestCase("", "0x8", 10, "0x0000000a")]
+    [TestCase("", "0X8", 10, "0x0000000A")]
+    [TestCase("", "0x16", 10, "0x000000000000000a")]
+    [TestCase("", "0X16", 10, "0x000000000000000A")]
+    public void TestFormats(string unit, string format, object value, string expected)
+    {
+        var result = UnitFormatter.Format(BigFloat.Convert(value), false, unit, format, CultureInfo.InvariantCulture);
+        Assert.AreEqual(expected, result);
+        BigFloat flt = UnitFormatter.Parse(result, unit, format, CultureInfo.InvariantCulture);
+        var result2 = flt.ConvertTo(value.GetType());
+        Assert.AreEqual(value, result2);
+    }
+
+}
+
+public class StepWithHexProperties : TestStep
+{
+
+    [Unit("", StringFormat: "0x")]
+    public uint X { get; set; } = 0xAABBAABB;
+    [Unit("", StringFormat: "0X")]
+    public int X2 { get; set; } = 0x0ABBAABB;
+    [Unit("", StringFormat:"X")]
+    public int X3 { get; set; }= 0x0ABBAABB;
+    [Unit("", StringFormat:"X8")]
+    public int X4 { get; set; }= 0x0ABBAABB;
+    [Unit("", StringFormat:"0x8")]
+    public int X5 { get; set; }= 0x0ABBAABB;
+    [Unit("", StringFormat:"0X8")]
+    public int X6 { get; set; }= 0x0ABBAABB;
+
+    [Unit("", StringFormat:"0x16")]
+    public ulong X7 { get; set; }= 0x0ABBAABB;
+    [Unit("", StringFormat:"0X16")]
+    public ulong X8 { get; set; }= 0x0ABBAABB;
+
+    public override void Run()
+    {
+
+    }
+}

--- a/Engine/NumberParser.cs
+++ b/Engine/NumberParser.cs
@@ -146,6 +146,8 @@ namespace OpenTap
             {
                 if (format.StartsWith("x", StringComparison.OrdinalIgnoreCase))
                     sb.Append(((long)post_scale.Rounded()).ToString(format, culture));
+                else if (format.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                    sb.Append("0x" + ((long)post_scale.Rounded()).ToString(format.Substring(1), culture));
                 else
                 {
                     try
@@ -171,7 +173,7 @@ namespace OpenTap
             if(unit != null)
                 sb.Append(unit);
         }
-        
+
         public static string Format(BigFloat value, bool prefix, string unit, string format, CultureInfo culture, bool compact = false)
         {
             char level = prefix ? findLevel(value) : ' ';
@@ -185,6 +187,8 @@ namespace OpenTap
             {
                 if (format.StartsWith("x", StringComparison.OrdinalIgnoreCase))
                     final_string = ((long)post_scale.Rounded()).ToString(format, culture);
+                else if (format.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                    final_string = "0x" + ((long)post_scale.Rounded()).ToString(format.Substring(1), culture);
                 else
                 {
                     try

--- a/Engine/UnitAttribute.cs
+++ b/Engine/UnitAttribute.cs
@@ -15,27 +15,27 @@ namespace OpenTap
         /// <summary>
         /// The unit e.g "Hz".
         /// </summary>
-        public string Unit { get; private set; }
+        public string Unit { get; protected set; }
 
         /// <summary>
         /// Whether to use engineering prefix. E.g 1000000 Hz -> 1 MHz
         /// </summary>
-        public bool UseEngineeringPrefix { get; private set; }
+        public bool UseEngineeringPrefix { get; protected set; }
 
         /// <summary>
         /// Pre scaling of values.
         /// </summary>
-        public double PreScaling { get; private set; }
+        public double PreScaling { get; protected set; }
 
         /// <summary>
         /// The format argument to string.Format.
         /// </summary>
-        public string StringFormat { get; private set; } 
+        public string StringFormat { get; protected set; }
 
         /// <summary>
         /// Whether to use ranges to show arrays of numbers. For example, show 1, 2, 3, 4 as 1 : 4.
         /// </summary>
-        public bool UseRanges { get; private set; }
+        public bool UseRanges { get; protected set; }
 
         /// <summary>Constructor for <see cref="UnitAttribute"/>.</summary>
         /// <param name="Unit">The unit e.g "Hz".</param>


### PR DESCRIPTION
- Added support for unit in sweep parameter range. Now units such as s or hz is shown in the ui. Additionally, formatting is applied when the unit asks for it. e.g Hex numbers.

- Added support of prefixing hex numbers with 0x. We already support this in parsing, but now it can also be specified using the special 0x or 0X format specifiers.

-Added unit test to verify the behavior with hex number parsing.

Close #2065, #2064 