### PR TITLE
    2048 Allow Edit Test Plan While Paused.

### DIFF
--- a/Engine.UnitTests/TestPlanTest.cs
+++ b/Engine.UnitTests/TestPlanTest.cs
@@ -1281,6 +1281,39 @@ namespace OpenTap.Engine.UnitTests
             }
         }
 
+        class CheckAllowEditStep : OpenTap.TestStep
+        {
+            public bool? allowedEdit;
+            public override void Run()
+            {
+                allowedEdit = GetParent<TestPlan>().AllowEdit;
+                UpgradeVerdict(Verdict.Pass);
+
+            }
+        }
+
+        [Test]
+        public void EditWhileBreak([Values(true,false)] bool allowEdit)
+        {
+            var plan = new TestPlan();
+            CheckAllowEditStep checkStep = new CheckAllowEditStep();
+            plan.ChildTestSteps.Add(checkStep);
+            plan.BreakOffered += PlanOnBreakOffered;
+            plan.AllowEditWhilePaused = allowEdit;
+            bool? allowedEdit = false;
+            void PlanOnBreakOffered(object sender, BreakOfferedEventArgs e)
+            {
+                allowedEdit = plan.AllowEdit;
+            }
+            Assert.AreEqual(Verdict.Pass, plan.Execute().Verdict);
+
+            // allow edit while paused and AllowEditWhilePaused is true.
+            Assert.AreEqual(allowEdit, allowedEdit);
+
+            // never allow edit while running.
+            Assert.AreEqual(false, checkStep.allowedEdit);
+        }
+
         [Test]
         public void DutPromptMetadataTest()
         {

--- a/Engine/MixinMemberMenuModel.cs
+++ b/Engine/MixinMemberMenuModel.cs
@@ -15,22 +15,17 @@ namespace OpenTap
 
         IMemberData IMemberMenuModel.Member => member;
         
-        public bool TestPlanLocked
-        {
-            get
-            {
-                var plan2 = Source.OfType<ITestStepParent>()
-                    .Select(step => step is TestPlan plan ? plan : step.GetParent<TestPlan>()).FirstOrDefault();
-                return (plan2?.IsRunning ?? false) || (plan2?.Locked ?? false);
-            }
-        }
+        public bool TestPlanAllowsEdit => Source
+            .OfType<ITestStepParent>()
+            .FirstNonDefault(step => step as TestPlan ?? step.GetParent<TestPlan>())
+            ?.AllowEdit ?? true;
 
         public bool StepLocked => Source.OfType<ITestStep>().Any(x => x.ChildTestSteps.IsReadOnly);
         
         [Display("Modify Mixin...", "Modify custom setting.", Order: 2.0, Group: "Mixins")]
         [Browsable(true)]
         [IconAnnotation(IconNames.ModifyMixin)]
-        [EnabledIf(nameof(TestPlanLocked), false)]
+        [EnabledIf(nameof(TestPlanAllowsEdit), true)]
         [EnabledIf(nameof(StepLocked), false, HideIfDisabled = true)]
         public void ModifyMixin()
         {
@@ -88,7 +83,7 @@ namespace OpenTap
         [Display("Remove Mixin", "Remove custom setting.", Order: 2.0, Group: "Mixins")]
         [Browsable(true)]
         [IconAnnotation(IconNames.RemoveMixin)]
-        [EnabledIf(nameof(TestPlanLocked), false)]
+        [EnabledIf(nameof(TestPlanAllowsEdit), true)]
         [EnabledIf(nameof(StepLocked), false, HideIfDisabled = true)]
         public void RemoveMixin()
         {

--- a/Engine/MixinMenuModel.cs
+++ b/Engine/MixinMenuModel.cs
@@ -6,19 +6,14 @@ namespace OpenTap
     {
         readonly ITypeData type;
 
-        public bool TestPlanLocked
-        {
-            get
-            {
-                var plan2 = source.OfType<ITestStepParent>()
-                    .Select(step => step is TestPlan plan ? plan : step.GetParent<TestPlan>()).FirstOrDefault();
-                return (plan2?.IsRunning ?? false) || (plan2?.Locked ?? false);
-            }
-        }
+        public bool TestPlanAllowsEdit => source
+            .OfType<ITestStepParent>()
+            .FirstNonDefault(step => step as TestPlan ?? step.GetParent<TestPlan>())
+            ?.AllowEdit ?? true;
         
         public MixinMenuModel(ITypeData type) => this.type = type;
         bool? showMixins;
-        public bool ShowMixins => (showMixins ??= (MixinFactory.GetMixinBuilders(type).Any()))&& !TestPlanLocked;
+        public bool ShowMixins => (showMixins ??= (MixinFactory.GetMixinBuilders(type).Any())) && TestPlanAllowsEdit;
         public bool StepLocked => source.OfType<ITestStep>().Any(x => x.IsReadOnly);
         
         [Display("Add Mixin...", "Add a new mixin.", Order: 2.0, Group: "Mixins")]

--- a/Engine/TestPlan.cs
+++ b/Engine/TestPlan.cs
@@ -161,6 +161,19 @@ namespace OpenTap
         [AnnotationIgnore]
         public bool IsRunning => CurrentRun != null;
 
+        /// <summary>
+        /// Can be set to true to allow editing the test plan while it's paused.
+        /// </summary>
+        /// <remarks>This is set to non-editorbrowsable to avoid it being modified from a test step.</remarks>
+        [AnnotationIgnore]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AllowEditWhilePaused { get; set; }
+
+        /// <summary>
+        /// Gets if the test plan is currently editable. This will never be true if the test plan is running(not paused) or locked.
+        /// </summary>
+        public bool AllowEdit => !Locked && (!IsRunning ||  (IsRunning && IsInBreak && AllowEditWhilePaused));
+
         /// <summary> </summary>
         public TestPlan()
         {


### PR DESCRIPTION
    - Added API to allow editing the test plan while its paused.

    - Added support for parameters and mixins.

Close #2048 