### PR TITLE
Move LICENSE.txt to packages/opentap

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -98,7 +98,7 @@
     </Files>
     <!-- License Texts -->
     <Files>
-        <File Path="LICENSE.txt" />
+        <File Path="Packages/OpenTAP/LICENSE.txt" SourcePath="LICENSE.txt" />
         <File Path="Dependencies/LibGit2Sharp.0.27.0.0/LICENSE.txt"
               SourcePath="libgit2sharp.license.md"/>
         <File Path="Dependencies/Mono.Cecil.0.10.1.0/LICENSE.txt"


### PR DESCRIPTION
Currently our LICENSE.txt is in the root installation directory. When many different plugins are installed, this makes it unclear what the file even applies to. Moving it into Packages/OpenTAP makes it clear that it applies to OpenTAP, and sets a good example for other plugins to follow.

Closes #2069