### PR TITLE
Improve templates slightly less

### DIFF
--- a/templates/src/project/.template.config/template.json
+++ b/templates/src/project/.template.config/template.json
@@ -130,8 +130,8 @@
     "Editor": {
       "type": "parameter",
       "datatype": "choice",
-      "defaultValue": "TUI",
       "replaces": "TapEditor",
+      "defaultValue": "Editor",
       "description": "The default editor to debug with.",
       "choices": [
         {

--- a/templates/src/project/.vscode/Editor.Launch.json
+++ b/templates/src/project/.vscode/Editor.Launch.json
@@ -9,7 +9,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
-      "program": "Editor.exe",
+      "program": "Editor.dll",
       "cwd": "${workspaceFolder}/bin/debug/",
       "console": "externalTerminal",
       "stopAtEntry": false

--- a/templates/src/project/.vscode/Editor.Launch.json
+++ b/templates/src/project/.vscode/Editor.Launch.json
@@ -10,8 +10,8 @@
       "request": "launch",
       "preLaunchTask": "build",
       "program": "Editor.dll",
-      "cwd": "${workspaceFolder}/bin/debug/",
-      "console": "externalTerminal",
+      "cwd": "${workspaceFolder}/bin/Debug/",
+      "console": "integratedTerminal",
       "stopAtEntry": false
     }
   ]

--- a/templates/src/project/.vscode/TUI.Launch.json
+++ b/templates/src/project/.vscode/TUI.Launch.json
@@ -9,7 +9,7 @@
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
-      "program": "tap.exe",
+      "program": "tap.dll",
       "args": [ "tui" ],
       "cwd": "${workspaceFolder}/bin/Debug/",
       "console": "externalTerminal",

--- a/templates/src/project/ProjectName.csproj
+++ b/templates/src/project/ProjectName.csproj
@@ -19,18 +19,6 @@
     <CreateOpenTapPackage>true</CreateOpenTapPackage>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)' == 'WINDOWS_NT' AND '$(Configuration)' == 'Debug'">
-    <!--
-      We target .NET Framework in debug builds when debugging with the WPF Editor due to a bug in Visual Studio's debugger.
-      The debugger assumes that netstandard projects should be debugged as .NET Core apps, and thus launches a .NET Core debugger
-      which fails to attach because tap.exe is a .NET Framework application.
-
-      To ensure maximum compatibility, we recommend targetting netstandard2.0 in release builds, unless you need specific
-      APIs that are not available in netstandard2.0.
-    -->
-    <TargetFramework>net9</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="OpenTAP" Version="$(GitVersion)" />
   </ItemGroup>

--- a/templates/src/project/Properties/Editor.LaunchSettings.json
+++ b/templates/src/project/Properties/Editor.LaunchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Debug with editor": {
       "commandName": "Executable",
-      "executablePath": "./Editor.exe",
+      "executablePath": "./Editor.dll",
       "dotnetRunMessages": true
     }
   }

--- a/templates/src/project/Properties/Editor.LaunchSettings.json
+++ b/templates/src/project/Properties/Editor.LaunchSettings.json
@@ -1,6 +1,11 @@
 {
   "profiles": {
-    "Debug with editor": {
+    "Debug with Editor (Windows)": {
+      "commandName": "Executable",
+      "executablePath": "./Editor.exe",
+      "dotnetRunMessages": true
+    },
+    "Debug with Editor (Linux/MacOS)": {
       "commandName": "Executable",
       "executablePath": "./Editor.dll",
       "dotnetRunMessages": true

--- a/templates/src/project/Properties/TUI.LaunchSettings.json
+++ b/templates/src/project/Properties/TUI.LaunchSettings.json
@@ -1,9 +1,15 @@
 {
   "profiles": {
-    "Debug with editor": {
+    "Debug with TUI (Windows)": {
       "commandName": "Executable",
+      "executablePath": "tap.exe",
       "commandLineArgs": "tui",
+      "dotnetRunMessages": true
+    },
+    "Debug with TUI (Linux/MacOS)": {
+      "commandName": "Executable",
       "executablePath": "tap.dll",
+      "commandLineArgs": "tui",
       "dotnetRunMessages": true
     }
   }

--- a/templates/src/project/Properties/TUI.LaunchSettings.json
+++ b/templates/src/project/Properties/TUI.LaunchSettings.json
@@ -1,15 +1,9 @@
 {
   "profiles": {
-    "Debug with editor (Windows)": {
+    "Debug with editor": {
       "commandName": "Executable",
       "commandLineArgs": "tui",
-      "executablePath": "tap.exe",
-      "dotnetRunMessages": true
-    },
-    "Debug with editor (Linux / Mac)": {
-      "commandName": "Executable",
-      "commandLineArgs": "tap.dll tui",
-      "executablePath": "dotnet",
+      "executablePath": "tap.dll",
       "dotnetRunMessages": true
     }
   }


### PR DESCRIPTION
* Make .vscode launch configs cross-platform (possible now because of .NET9)
* Set default editor to Editor (thanks to community edition)
* Remove Visual Studio workaround from .csproj file (not needed because of .NET 9)
* Add Rider launch config for Linux/MacOS