### PR TITLE
template: remove license required comment

### DIFF
--- a/templates/src/project/.template.config/template.json
+++ b/templates/src/project/.template.config/template.json
@@ -135,14 +135,14 @@
       "description": "The default editor to debug with.",
       "choices": [
         {
+          "choice": "Editor",
+          "displayName": "Keysight Test Automation",
+          "description": "Set Keysight Test Automation as the debugging editor."
+        },
+        {
           "choice": "TUI",
           "displayName": "OpenTAP TUI",
           "description": "Set TUI as the debugging editor."
-        },
-        {
-          "choice": "Editor",
-          "displayName": "Keysight Test Automation (License required)",
-          "description": "Set Keysight Test Automation as the debugging editor."
         }
       ]
     },


### PR DESCRIPTION
Since we have communtiy license we can remove the comment about requiring a license.

Also swap the order to indicate that Editor is now the preferred editor

Closes #1893