### PR TITLE
tap.sh: don't suggest adding user to root group

### DIFF
--- a/LinuxInstall/tap.sh
+++ b/LinuxInstall/tap.sh
@@ -52,6 +52,9 @@ else
   # If the user cannot write to the installation, OpenTAP will not work correctly.
   # Instead, we should give a hint about how to resolve the issue.
   TapDllGroupOwner="$(stat -c "%G" "$TapDllDir")"
-  echo "User $USER does not have write access in the OpenTAP installation at '$TapDllDir'."
-  echo "This installation belongs to the group '$TapDllGroupOwner'. The user can be added to this group with the command 'usermod -a -G $TapDllGroupOwner $USER'."
+  echo "User $USER does not have write access in the OpenTAP installation at '$TapDllDir':"
+  echo "This installation belongs to $TapDllGroupOwner"
+  if [ "$TapDllGroupOwner" = "opentap" ]; then
+    echo "Add $USER to $TapDllGroupOwner with the command 'usermod -aG $TapDllGroupOwner $USER'."
+  fi
 fi


### PR DESCRIPTION
This message was intended to help the user add themselves to the 'opentap' group, which is created by some version of SmartInstaller.

But if the installation is created in some other way, this suggestion is potentially dangerous

Closes #1971 