### PR TITLE
1945 merge complex types

### DIFF
--- a/Engine.UnitTests/AnnotationTest.cs
+++ b/Engine.UnitTests/AnnotationTest.cs
@@ -1889,23 +1889,6 @@ namespace OpenTap.UnitTests
             Assert.AreNotEqual(obj1.Items, obj2.Items);
         }
 
-        [Test]
-        public void AddExternalParameterWarning()
-        {
-            var obj1 = new TestStepWithLists();
-            var obj2 = new TestStepWithLists();
-            var plan = new TestPlan();
-            plan.ChildTestSteps.Add(obj1);
-            plan.ChildTestSteps.Add(obj2);
-            var member= TypeData.GetTypeData(obj1).GetMember(nameof(obj1.Items));
-            plan.ExternalParameters.Add(obj1, member, "items");
-            
-            // produces warning, does not add since the item type is not compatible.
-            var ext = plan.ExternalParameters.Add(obj2, member, "items");
-            Assert.AreEqual(1, ext.Properties.Count());
-
-        }
-
         public class MemberWithException
         {
             public class SubThing

--- a/Engine.UnitTests/ParameterTests.cs
+++ b/Engine.UnitTests/ParameterTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 using OpenTap.Plugins.BasicSteps;
@@ -159,6 +160,180 @@ public class ParameterTests
                 {
                     step.Name = "doesn't matter";
                     (step as DelayStep).DelaySecs = 123;
+                }
+            }
+        }
+    }
+    
+    public class StepEmbeddingComplexLists : TestStep
+    {
+        public List<ComplexType> ComplexList { get; set; } = [];
+        [EmbedProperties] public EmbeddedClass Emb { get; set; } = new();
+        public override void Run() { }
+    }
+
+    public class EmbeddedClass : ValidatingObject
+    {
+        public List<ComplexType> ComplexList { get; set; } = [];
+    }
+
+    public class ComplexType
+    {
+        public int X { get; set; }
+        public string Y { get; set; }
+    }
+
+    [Test]
+    public void TestMergingComplexParameters()
+    {
+        var plan = new TestPlan();
+        var seq = new SequenceStep();
+
+        plan.ChildTestSteps.Add(seq);
+        StepEmbeddingComplexLists[] steps = [new(), new(), new()];
+        seq.ChildTestSteps.AddRange(steps);
+
+        var a = AnnotationCollection.Annotate(steps);
+        { // 1. merge ComplexList on the parent step
+            var param = a.GetMember("ComplexList");
+            var ico = param.GetIcon(IconNames.ParameterizeOnParent);
+            ico.Get<IMethodAnnotation>().Invoke();
+        }
+        
+        { // 2. merge Emb.ComplexList on test plan
+            var param = a.GetMember("Emb.ComplexList");
+            var ico = param.GetIcon(IconNames.ParameterizeOnTestPlan);
+            ico.Get<IMethodAnnotation>().Invoke();
+        }
+
+        static void AddComplexElement(AnnotationCollection mem, int x, string y)
+        {
+            var proxy = mem.Get<ICollectionAnnotation>();
+            var item = proxy.NewElement();
+            var ov = item.Get<IObjectValueAnnotation>();
+            var v = (ComplexType)ov.Value;
+            v.X = x;
+            v.Y = y;
+            proxy.AnnotatedElements = proxy.AnnotatedElements.Append(item);
+        }
+
+        { // 3. populate the parameter on the parent step
+            var aSeq = AnnotationCollection.Annotate(seq);
+            var mem = aSeq.GetMember("Parameters \\ ComplexList");
+
+            AddComplexElement(mem, 1, "Param 1");
+            AddComplexElement(mem, 2, "Param 2");
+            AddComplexElement(mem, 3, "Param 3");
+            aSeq.Write();
+
+            // Verify parameters are merged correctly
+            foreach (var step in steps)
+            {
+                Assert.That(step.ComplexList.Count, Is.EqualTo(3));
+                Assert.That(step.ComplexList[0].Y, Is.EqualTo("Param 1"));
+                Assert.That(step.ComplexList[1].Y, Is.EqualTo("Param 2"));
+                Assert.That(step.ComplexList[2].Y, Is.EqualTo("Param 3"));
+            }
+        }
+        
+        { // 4. populate the parameter on the test plan
+            var aPlan = AnnotationCollection.Annotate(plan);
+            var mem = aPlan.GetMember("Emb.ComplexList");
+
+            AddComplexElement(mem, 4, "Plan 4");
+            AddComplexElement(mem, 5, "Plan 5");
+            AddComplexElement(mem, 6, "Plan 6");
+            aPlan.Write();
+
+            // Verify parameters are merged correctly
+            foreach (var step in steps)
+            {
+                Assert.That(step.Emb.ComplexList.Count, Is.EqualTo(3));
+                Assert.That(step.Emb.ComplexList[0].Y, Is.EqualTo("Plan 4"));
+                Assert.That(step.Emb.ComplexList[1].Y, Is.EqualTo("Plan 5"));
+                Assert.That(step.Emb.ComplexList[2].Y, Is.EqualTo("Plan 6"));
+            }
+        }
+
+        { // 5. Verify that everything works correctly after serialization
+            var ser = new TapSerializer();
+            var str = ser.SerializeToString(plan);
+            plan = (TestPlan)ser.DeserializeFromString(str);
+            seq = (SequenceStep)plan.ChildTestSteps[0];
+            Assert.That(ser.Errors, Is.Empty);
+            steps = plan.ChildTestSteps[0].ChildTestSteps.Cast<StepEmbeddingComplexLists>().ToArray();
+            Assert.That(steps.Length, Is.EqualTo(3));
+
+            foreach (var step in steps)
+            {
+                Assert.That(step.ComplexList.Count, Is.EqualTo(3));
+                Assert.That(step.ComplexList[0].Y, Is.EqualTo("Param 1"));
+                Assert.That(step.ComplexList[1].Y, Is.EqualTo("Param 2"));
+                Assert.That(step.ComplexList[2].Y, Is.EqualTo("Param 3"));
+
+                Assert.That(step.Emb.ComplexList.Count, Is.EqualTo(3));
+                Assert.That(step.Emb.ComplexList[0].Y, Is.EqualTo("Plan 4"));
+                Assert.That(step.Emb.ComplexList[1].Y, Is.EqualTo("Plan 5"));
+                Assert.That(step.Emb.ComplexList[2].Y, Is.EqualTo("Plan 6"));
+            }
+
+            { // Remove elements from the parameterized list and verify the changes are propagated correctly
+                var aSeq = AnnotationCollection.Annotate(seq);
+                var mem = aSeq.GetMember("Parameters \\ ComplexList");
+                var col = mem.Get<ICollectionAnnotation>();
+                col.AnnotatedElements = col.AnnotatedElements.Skip(1);
+                aSeq.Write();
+
+                foreach (var step in steps)
+                {
+                    Assert.That(step.ComplexList.Count, Is.EqualTo(2));
+                    Assert.That(step.ComplexList[0].Y, Is.EqualTo("Param 2"));
+                    Assert.That(step.ComplexList[1].Y, Is.EqualTo("Param 3"));
+                }
+
+                { // Verify that modifications to properties of list elements are propagated
+                    aSeq.Read();
+                    col = mem.Get<ICollectionAnnotation>();
+                    var col1 = (ComplexType)col.AnnotatedElements.First().Get<IObjectValueAnnotation>().Value;
+                    col1.Y = "Modified";
+                    aSeq.Write();
+
+                    foreach (var step in steps)
+                    {
+                        Assert.That(step.ComplexList.Count, Is.EqualTo(2));
+                        Assert.That(step.ComplexList[0].Y, Is.EqualTo("Modified"));
+                        Assert.That(step.ComplexList[1].Y, Is.EqualTo("Param 3"));
+                    }
+                }
+            }
+            
+            { // Repeat the same tests for parameters merged on the test plan
+                var aPlan = AnnotationCollection.Annotate(plan);
+                var mem = aPlan.GetMember("Emb.ComplexList");
+                var col = mem.Get<ICollectionAnnotation>();
+                col.AnnotatedElements = col.AnnotatedElements.Take(2);
+                aPlan.Write();
+
+                foreach (var step in steps)
+                {
+                    Assert.That(step.Emb.ComplexList.Count, Is.EqualTo(2));
+                    Assert.That(step.Emb.ComplexList[0].Y, Is.EqualTo("Plan 4"));
+                    Assert.That(step.Emb.ComplexList[1].Y, Is.EqualTo("Plan 5"));
+                }
+
+                { // Verify that modifications to properties of list elements are propagated
+                    aPlan.Read();
+                    col = mem.Get<ICollectionAnnotation>();
+                    var col2 = (ComplexType)col.AnnotatedElements.Last().Get<IObjectValueAnnotation>().Value;
+                    col2.Y = "Modified 2";
+                    aPlan.Write();
+
+                    foreach (var step in steps)
+                    {
+                        Assert.That(step.Emb.ComplexList.Count, Is.EqualTo(2));
+                        Assert.That(step.Emb.ComplexList[0].Y, Is.EqualTo("Plan 4"));
+                        Assert.That(step.Emb.ComplexList[1].Y, Is.EqualTo("Modified 2"));
+                    }
                 }
             }
         }

--- a/Engine/ExternalParameters.cs
+++ b/Engine/ExternalParameters.cs
@@ -139,10 +139,10 @@ namespace OpenTap
             {
                 // merge occured.
                 // See similar code in ExternalParameterSerializer.
-                if (ParameterManager.UnmergableListType(newParameter))
+                if (ParameterManager.UnmergableListType(plan, newParameter))
                 {
                     setting.Unparameterize(newParameter, step);
-                    log.Warning("Unable merge parameters {0}, since their types do not support it.", Name);
+                    log.Warning("Unable to merge parameters {0}, since their types do not support it.", Name);
                 }
             }
         

--- a/Engine/ParameterManager.cs
+++ b/Engine/ParameterManager.cs
@@ -414,17 +414,22 @@ namespace OpenTap
             Parameterize(scope, s.Member, source, parameterUserRequest.SelectedName);
         }
 
-        public static bool UnmergableListType(IMemberData property)
+        public static bool UnmergableListType(ITestStepParent scope, IMemberData member)
         {
-            var propertyType = property.TypeDescriptor;
-            // merging IEnumerable is not supported (unless its a string).
+            var propertyType = member.TypeDescriptor;
+            // merging IEnumerable is supported if the element type can be cloned.
+            // This is trivially true for primitives and strings, but not for complex types such as classes.
             if (propertyType.DescendsTo(typeof(IEnumerable)))
             {
                 if (propertyType.IsA(typeof(string)) == false)
                 {
                     var elementType = propertyType.AsTypeData()?.ElementType;
                     if (elementType == null || elementType.IsNumeric == false)
-                        return true;
+                    {
+                        var value = member.GetValue(scope);
+                        var cloner = new ObjectCloner(value);
+                        return !cloner.CanClone(scope, propertyType);
+                    }
                 }
             }
 

--- a/Engine/SerializerPlugins/ExternalParameterSerializer.cs
+++ b/Engine/SerializerPlugins/ExternalParameterSerializer.cs
@@ -75,10 +75,10 @@ namespace OpenTap.Plugins
             if (newParameter.ParameterizedMembers.Skip(1).Any())
             {
                 // merge occured. See similar code in ExternalParameters.
-                if (ParameterManager.UnmergableListType(newParameter))
+                if (ParameterManager.UnmergableListType(parent, newParameter))
                 {
                     member.Unparameterize(newParameter, step);
-                    Log.Warning("Unable merge parameters {0}, since their types do not support it.", parameter);
+                    Log.Warning("Unable to merge parameters {0}, since their types do not support it.", parameter);
                 }
             }
 


### PR DESCRIPTION
This allows merging lists of complex types if the element type can be cloned.

The current parameterization system already allows and supports this, but throws errors during serialization.

This also adds a unittest verifying everything is still correctly connected after serialization, and ensuring that updates to individual properties of elements in lists are propagated correctly.

Closes #1945 