### PR TITLE
installer taget x64 instead of x86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -849,7 +849,7 @@ jobs:
       - run: mv SDK*TapPackage SDK.TapPackage
         name: Rename SDK
         working-directory: Installer/Assets
-      - run: tap installer create "opentap.installer.xml" -v --target-os win --arch x86
+      - run: tap installer create "opentap.installer.xml" -v --target-os win --arch x64
         working-directory: Installer/Assets
         env:
           TAP_SIGN_ADDRESS: ${{ secrets.TAP_SIGN_ADDRESS_INTERNAL }}


### PR DESCRIPTION
Setting the installer architecture to x86 causes `Environment.ProgramFiles` to return `Program Files (x86)` rather than the expected `Program Files` on a 64bit system. This is what caused the wrong default path, and this also caused the `IsDotnetInstalled `check to always return false. 

Setting the installer to x64 fixes the issues. 

Closes #2153, #2154, and #2146