### PR TITLE
stop publishing win-arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -750,11 +750,11 @@ jobs:
         with:
           name: win-x64-package
           path: .
-      - name: Download win-arm64 package
-        uses: actions/download-artifact@v4
-        with:
-          name: win-arm64-package
-          path: .
+      # - name: Download win-arm64 package
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: win-arm64-package
+      #     path: .
       - name: Download Linux arm package
         uses: actions/download-artifact@v4
         with:
@@ -791,7 +791,7 @@ jobs:
           echo "Rename Archives"
           Move-Item OpenTAP.*.x86.Windows.TapPackage OpenTAP.x86.zip 
           Move-Item OpenTAP.*.x64.Windows.TapPackage OpenTAP.x64.zip
-          Move-Item OpenTAP.*.arm64.Windows.TapPackage OpenTAP.arm64.zip
+          # Move-Item OpenTAP.*.arm64.Windows.TapPackage OpenTAP.arm64.zip
           Move-Item OpenTAP.*.Linux.x64.TapPackage OpenTAP.Linux.x64.zip
           Move-Item OpenTAP.*.Linux.arm64.TapPackage OpenTAP.Linux.arm64.zip
           Move-Item OpenTAP.*.MacOS.x64.TapPackage OpenTAP.MacOS.x64.zip
@@ -800,7 +800,7 @@ jobs:
           echo "Expand Archives"
           Expand-Archive OpenTAP.x64.zip -DestinationPath ./nuget/build/runtimes/win-x64 -Force
           Expand-Archive OpenTAP.x86.zip -DestinationPath ./nuget/build/runtimes/win-x86 -Force
-          Expand-Archive OpenTAP.arm64.zip -DestinationPath ./nuget/build/runtimes/win-arm64 -Force
+          # Expand-Archive OpenTAP.arm64.zip -DestinationPath ./nuget/build/runtimes/win-arm64 -Force
           Expand-Archive OpenTAP.Linux.x64.zip -DestinationPath ./nuget/build/runtimes/linux-x64 -Force
           Expand-Archive OpenTAP.Linux.arm64.zip -DestinationPath ./nuget/build/runtimes/linux-arm64 -Force
           Expand-Archive OpenTAP.MacOS.x64.zip -DestinationPath ./nuget/build/runtimes/macos-x64 -Force
@@ -1065,11 +1065,11 @@ jobs:
         with:
           name: win-x64-package
           path: ./publish/
-      - name: Download Windows-arm64 package
-        uses: actions/download-artifact@v4
-        with:
-          name: win-arm64-package
-          path: ./publish/
+      # - name: Download Windows-arm64 package
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: win-arm64-package
+      #     path: ./publish/
       - name: Download MacOS-x64 package
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
We don't need to include this in the release