### PR TITLE
2176 IsConnected Changed Property Notify:Fix

### DIFF
--- a/Engine/Resource.cs
+++ b/Engine/Resource.cs
@@ -116,8 +116,9 @@ namespace OpenTap
             get { return isConnected; }
             set
             {
+                if(value == isConnected) return;
                 isConnected = value;
-                OnPropertyChanged("IsConnected");
+                OnPropertyChanged(nameof(IsConnected));
             }
         }
 


### PR DESCRIPTION
Added check so that the property changed event is only raised when the new state is different from the old.

Close #2176 