### PR TITLE
Revert to previously SearchAsync implementation

### DIFF
--- a/Engine/PluginManager.cs
+++ b/Engine/PluginManager.cs
@@ -247,7 +247,8 @@ namespace OpenTap
         {
             searchTask.Reset();
             CacheState.OnUpdated();
-            return TapThread.StartAwaitable(Search);  
+            TapThread.Start(Search);  
+            return Task.Run(() => GetSearcher());        
         }
         
         ///<summary>Searches for plugins.</summary>


### PR DESCRIPTION
Plugins that add ICustomPackageData types aren’t loaded in time, causing XML deserialization to produce MissingPackageData for subsequent package installs. Reverting to the previous synchronous search behavior fixes the issue.

Closes #2202 