### PR TITLE
Removed check that caused things not to work token domain had a port.

### DIFF
--- a/Engine/Authentication/AuthenticationSettings.cs
+++ b/Engine/Authentication/AuthenticationSettings.cs
@@ -111,8 +111,6 @@ namespace OpenTap.Authentication
         /// <returns>A preconfigued HttpClient object</returns>
         public HttpClient GetClient(string domain = null, bool withRetryPolicy = false, string baseAddress = null)
         {
-            if (Uri.IsWellFormedUriString(domain, UriKind.Absolute))
-                throw new ArgumentException("Domain should only be the host part of a URI and not a full absolute URI.", nameof(domain));
             var client = new HttpClient(new AuthenticationClientHandler(domain, withRetryPolicy));
             if (baseAddress != null)
             {

--- a/Engine/Authentication/TokenInfo.cs
+++ b/Engine/Authentication/TokenInfo.cs
@@ -55,12 +55,7 @@ namespace OpenTap.Authentication
         public string Domain 
         { 
             get => domain; 
-            set
-            {
-                if (Uri.IsWellFormedUriString(value, UriKind.Absolute))
-                    throw new ArgumentException("Domain should only be the host part of a URI and not a full absolute URI.");
-                domain = value;
-            }
+            set => domain = value;
         }
 
         private Dictionary<string, string> _Claims;

--- a/Package.UnitTests/HttpRepositoryTest.cs
+++ b/Package.UnitTests/HttpRepositoryTest.cs
@@ -1,0 +1,21 @@
+using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OpenTap.Authentication;
+
+namespace OpenTap.Package.UnitTests;
+
+[TestFixture]
+public class HttpRepositoryTest
+{
+
+    [Test]
+    public void TestTokenWithPort()
+    {
+        new TokenInfo("asd", "asd", "localhost:18080");
+        new TokenInfo("asd", "asd", "localhost");
+        new TokenInfo("asd", "asd", "packages.opentap.io");
+        new TokenInfo("asd", "asd", "packages.opentap.io:1111");
+    }
+    
+}


### PR DESCRIPTION
We still probably want to support that domains can differ by port. So the same host can contain multiple token domains.

Another check could probably be made, but I am not sure how to robustly check for that.

Close #2198 