### PR TITLE
fix: broken headline formatting in PDF version of Developer Guide

### DIFF
--- a/doc/Developer Guide/Annotations/Readme.md
+++ b/doc/Developer Guide/Annotations/Readme.md
@@ -48,6 +48,6 @@ The following are the most commonly implemented types of annotations:
  The static method ```AnnotationCollection.Annotate``` is used to build the AnnotationCollection object. A plugin type called an "annotator" (```IAnnotator```) is the definition of classes that can be used to provide annotations for a given object. To use custom annotations an ```IAnnotator``` must be implemented to specify where the custom annotations should be inserted. A number of annotators exist and they need to be applied in a specific order, therefore the ```IAnnotator.Priority``` Property is used to control the order in which annotations are being applied. Normally, this value should just be set to '1'.
  
   
- ## Custom Controls and Annotations
+## Custom Controls and Annotations
  
  Various GUI implementations support writing new custom controls. To support this it might also be necessary to create custom annotation types. Both things are possible, but it is generally discouraged, since existing GUIs cannot know about these new annotations. If new annotation types or new types of controls are needed we encourage starting a discussion on the OpenTAP repository at [https://github.com/opentap/opentap](https://github.com/opentap/opentap). This way, we can ensure that plugins are broadly supported across multiple user interfaces.

--- a/doc/Developer Guide/Introduction/Readme.md
+++ b/doc/Developer Guide/Introduction/Readme.md
@@ -12,5 +12,6 @@ Development requires the following software:
 
 ## Suggested Resources
 VISA driver e.g. Keysight I/O libraries for instrument communication
+
 ### PathWave Test Automation
 Together with OpenTAP it is recommended to use a Graphical User Interface. Keysight Technologies offers both an enterprise and community version of [PathWave Test Automation Developer's System](https://www.keysight.com/find/tapinstall) that provides a highly flexible graphical user interface and code examples.


### PR DESCRIPTION
Fixes: https://github.com/opentap/opentap/issues/2221

I hope that this PR fixes the problems reported in issue mentioned above. I need the checks to run before I can see if it works since I don't have access to the OpenTAP plugin which builds the PDF in CI.