### PR TITLE
2227 Set enabled in nested sweep: fix

### DIFF
--- a/BasicSteps/SweepRowMemberData.cs
+++ b/BasicSteps/SweepRowMemberData.cs
@@ -45,7 +45,10 @@ class SweepRowMemberData : IMemberData, IParameterMemberData
         // so to support use cases like sweeps of sweeps, they get special treatment here.
         if (value is SweepRow sr)
         {
-            var sr2 = new SweepRow(sr.Loop);
+            var sr2 = new SweepRow(sr.Loop)
+            {
+                Enabled = sr.Enabled
+            };
             foreach (var kv in sr.Values)
                 sr2.Values.Add(kv.Key, CloneIfPossible(kv.Value, context));
             return sr2;


### PR DESCRIPTION
An oversight had caused enabled not to be transferred when sweep rows are cloned. This was fixed by explicitly setting Enabled when cloning the object.

A unit test was added that reproduces the issue unless fixed.


Close #2227