### PR TITLE
2210 Image Install ImagePath Usability: Fix

### DIFF
--- a/Package/PackageActions/ImageInstall.cs
+++ b/Package/PackageActions/ImageInstall.cs
@@ -59,7 +59,14 @@ namespace OpenTap.Package
 
             var imageString = ImagePath;
             if (File.Exists(imageString))
+            {
                 imageString = File.ReadAllText(imageString);
+                // If an image file contains \0 its not a valid XML or JSON file.
+                if (imageString.Contains('\0'))
+                    throw new ArgumentException($"Specified file '{ImagePath}' is not a valid JSON or XML file. Consider postfixing the package name with ':version' if applicable.", nameof(ImagePath));
+            }else if (imageString.EndsWith(".xml", StringComparison.OrdinalIgnoreCase) || imageString.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException($"'{ImagePath}' was not found.", nameof(ImagePath));
+
             var imageSpecifier = ImageSpecifier.FromString(imageString);
 
             // image specifies any repositories?


### PR DESCRIPTION
- Added check that verifies that the image file does not contain 0 - this is not a valid XML or JSON file.
- If the file does not exists, but a .json or .xml file was specified it will throw an exception.

Close #2210