### PR TITLE
2233 Component Settings Initialize Error: Fix

### DIFF
--- a/Engine.UnitTests/ComponentSettingsTest.cs
+++ b/Engine.UnitTests/ComponentSettingsTest.cs
@@ -273,5 +273,22 @@ namespace OpenTap.UnitTests
                 }
             }
         }
+
+        [Test]
+        public void TestFaultyInitializeComponentSettings()
+        {
+            Assert.IsNull(ComponentSettings.GetCurrent<FaultyInitializeComponentSettings>());
+
+        }
+        
+        
+    }
+
+    public class FaultyInitializeComponentSettings : ComponentSettings<FaultyInitializeComponentSettings>
+    {
+        public override void Initialize()
+        {
+            throw new Exception("This fails");
+        }
     }
 }

--- a/Engine/ComponentSettingsContext.cs
+++ b/Engine/ComponentSettingsContext.cs
@@ -302,7 +302,16 @@ namespace OpenTap
                     return null;
                 }
 
-                settings.Initialize();
+                try
+                {
+                    settings.Initialize();
+                }
+                catch (Exception e)
+                {
+                    log.Error("Caught exception while initializing an instance of '{0}'", settingsType.FullName);
+                    log.Debug(e);
+                    return null;
+                }
 
                 log.Debug(timer,
                     "No settings file exists for {0}. A new instance with default values has been created.",


### PR DESCRIPTION
Fixed the issue by catching the error and returning null as is expected from the component settings load method.

Added a unit test to verify that it now works.

Close #2233