### PR TITLE
2238 Plugin Binary Format Detector: Fix

### DIFF
--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -278,12 +278,12 @@ namespace OpenTap
                     List<AssemblyRef> refNames = new List<AssemblyRef>();
                     using (FileStream str = new FileStream(file, FileMode.Open, FileAccess.Read))
                     {
-                        var binFormat = BinaryFormatDetector.Detect(str, file);
+                        var binFormat = ExecutableFormatDetector.Detect(str, file);
                     
                         if (binFormat != ExecutableFormat.DotNet)
                         {
                             if(binFormat == ExecutableFormat.Unknown)
-                                log.Warning("Skipping assembly '{0}'. Unknown file type.", Path.GetFileName(file));
+                                log.Error("Skipping assembly '{0}'. Unknown file type.", Path.GetFileName(file));
                             // if its a native assembly, it could be a dynamically linked library, disguised as a DLL.
                             return null;
                         }

--- a/Engine/Utils/ExecutableFormatDetector.cs
+++ b/Engine/Utils/ExecutableFormatDetector.cs
@@ -17,7 +17,7 @@ internal enum ExecutableFormat
 }
 
 
-internal static class BinaryFormatDetector
+internal static class ExecutableFormatDetector
 {
     public static ExecutableFormat Detect(FileStream fs, string filePath)
     {


### PR DESCRIPTION
Fixed the issue by detecting is a DLL is a .NET DLL, a PE, Macho (Macos) or ELF(Linux) file. If its a executable binary format but not a .NET we assume that its some kind of shared object file.

Added this as a part of the plugin dll detection. This also simplifies the logic that ignores invalid DLLs.


Close #2238 