### PR TITLE
docs: remove duplicate sentence

### DIFF
--- a/doc/Developer Guide/Plugin Packaging and Versioning/Readme.md
+++ b/doc/Developer Guide/Plugin Packaging and Versioning/Readme.md
@@ -62,7 +62,7 @@ The root element of the configuration file is `Package` and it supports the foll
 The configuration files can also contain certain elements. These elements add additional information about the package and can have their own attributes.
 
 #### Description Element
-The **Description** element can be used to write a short description about the plugin. Custom elements like `Organization` or `Status` can be added the provide additional highlighted information. For example:
+The **Description** element can be used to write a short description about the plugin. Custom elements like `Organization` or `Status` can be added the provide additional highlighted information.
 For example:
 ```xml
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
https://doc.opentap.io/Developer%20Guide/Plugin%20Packaging%20and%20Versioning/Readme.html#elements-in-the-configuration-file contains a duplicate sentence. This PR removes one instance of the sentence.

<img width="1699" height="1846" alt="grafik" src="https://github.com/user-attachments/assets/78616d5c-a7da-4dfd-a2c1-33730f1b9aeb" />
