### PR TITLE
2264 --log set between CliAction ctor and Execute

### DIFF
--- a/Cli/TapEntry.cs
+++ b/Cli/TapEntry.cs
@@ -55,6 +55,7 @@ internal class TapEntry
         AppDomain.CurrentDomain.ProcessExit += (s, e) => cliTraceListener.Flush();
 
         PluginManager.Search();
+        SessionLogs.SetLogPathFromEngineSettings();
         DebuggerAttacher.TryAttach();
         CliActionExecutor.Execute();
     }

--- a/Engine/Cli/CliActionExecutor.cs
+++ b/Engine/Cli/CliActionExecutor.cs
@@ -190,27 +190,6 @@ namespace OpenTap.Cli
                 return (int)ExitCodes.UnknownCliAction;
             }
 
-            try
-            {
-                // setup logging to be relative to the executing assembly.
-                // at this point SessionLogs.Initialize has already been called (PluginManager.Load).
-                // so the log is already being saved at a different location.
-                var logpath = EngineSettings.Current.SessionLogPath.Expand(date: Process.GetCurrentProcess().StartTime);
-                bool isPathRooted = Path.IsPathRooted(logpath);
-                if (isPathRooted == false)
-                {
-                    var dir = ExecutorClient.ExeDir;
-                    logpath = Path.Combine(dir, logpath);
-                }
-
-                SessionLogs.Rename(logpath);
-            }
-            catch (Exception e)
-            {
-                log.Error("Path defined in Engine settings contains invalid characters: {0}", EngineSettings.Current.SessionLogPath);
-                log.Debug(e);
-            }
-
             // Find selected command
             var actionTree = new CliActionTree();
             var selectedcmd = actionTree.GetSubCommand(args);

--- a/Engine/PluginManager.cs
+++ b/Engine/PluginManager.cs
@@ -281,7 +281,18 @@ namespace OpenTap
                 if (isLoaded) return;
                 isLoaded = true;
 
-                SessionLogs.Initialize();
+                if (!SessionLogs.TryGetCommandLinePath(out string path))
+                {
+                    path = SessionLogs.GetDefaultPath();
+                }
+                try
+                {
+                    SessionLogs.Initialize(path);
+                }
+                catch
+                {
+                    SessionLogs.Initialize(SessionLogs.GetDefaultPath());
+                }
 
                 string tapEnginePath = Assembly.GetExecutingAssembly().Location;
                 if(String.IsNullOrEmpty(tapEnginePath))

--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -52,6 +52,30 @@ namespace OpenTap
             }
         }
 
+        internal static bool TryGetCommandLinePath(out string path)
+        {
+            string[] args = Environment.GetCommandLineArgs();
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                string arg = args[i];
+                if (arg == "--log")
+                {
+                    path = args[i + 1];
+                    return true;
+                }
+            }
+
+            path = null;
+            return false;
+        }
+
+        internal static string GetDefaultPath()
+        {
+            string timestamp = Process.GetCurrentProcess().StartTime.ToString("yyyy-MM-dd HH-mm-ss");
+            string pathEnding = $"SessionLog {timestamp}";
+            return Path.Combine(FileSystemHelper.GetCurrentInstallationDirectory(), "SessionLogs", $"{pathEnding}.txt");
+        }
+
         private static readonly TraceSource log = Log.CreateSource("Session");
 
         /// <summary> The number of files kept at a time. </summary>
@@ -171,6 +195,39 @@ namespace OpenTap
                     log.Debug("Unexpected error while printing system information.");
             }
             Flush();
+        }
+
+        /// <summary>
+        /// Rename session logs path to the one from engine settings.
+        /// Make sure <see cref="PluginManager.Load"/> has been called before calling this method.
+        /// </summary>
+        public static void SetLogPathFromEngineSettings()
+        {
+            if (TryGetCommandLinePath(out _))
+            {
+                return;
+            }
+            
+            try
+            {
+                var logpath = EngineSettings.Current.SessionLogPath.Expand(date: Process.GetCurrentProcess().StartTime);
+                bool isPathRooted = Path.IsPathRooted(logpath);
+                if (isPathRooted == false)
+                {
+                    var dir = ExecutorClient.ExeDir;
+                    logpath = Path.Combine(dir, logpath);
+                }
+
+                if (Path.GetFullPath(logpath) != Path.GetFullPath(GetSessionLogFilePath()))
+                {
+                    Rename(logpath);
+                }
+            }
+            catch (Exception e)
+            {
+                log.Error("Path defined in Engine settings contains invalid characters: {0}", EngineSettings.Current.SessionLogPath);
+                log.Debug(e);
+            }
         }
 
         /// <summary>

--- a/Shared/ICliActionExtensions.cs
+++ b/Shared/ICliActionExtensions.cs
@@ -123,11 +123,6 @@ namespace OpenTap.Cli
                 return (int)ExitCodes.Success;
             }
 
-            if (!overrides.Contains("log") && args.Contains("log"))
-            {
-                SessionLogs.Rename(args.Argument("log"));
-            }
-
             foreach (var opts in args)
             {
                 if (argToProp.ContainsKey(opts.Key) == false) continue;


### PR DESCRIPTION
Closes #2264

Previously the log path was set 3 times.
First by PluginManager.Load to "tap <timestamp>"
Then by CliActionExecutor from EngineSettings (default "SessionLogs <timestamp>")
Finally by CliActionExtensions from the CLI

It was set in CliActionExtensions because that is where we parse Cli Arguments. However this gave issues if CliActions wanted to use this log in their constructor. Seperately if the application crashes before setting it the log would not be placed where the user would expect it to.

The new system sets it only twice.

First in PluginManager.Load from either arguments or to default "SessionLogs <timestamp>"
Second in TapEntry to the value in EngineSettings, unless the argument --logs was provided.

** Testing **
I ran it locally with and without the argument, with a breakpoint in SessionLogs.rename to see how many times it was called and from which location.

Everything seems to be working as expected.