### PR TITLE
make OpenTapPackageReference non-private

### DIFF
--- a/Package.UnitTests/UninstallContextTest.cs
+++ b/Package.UnitTests/UninstallContextTest.cs
@@ -6,6 +6,7 @@ using System.Runtime.Versioning;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using NUnit.Framework;
+using OpenTap.EngineUnitTestUtils;
 
 namespace OpenTap.Package.UnitTests;
 
@@ -16,6 +17,9 @@ public class UninstallContextTest
     [Test]
     public void TestDeleteFile()
     {
+        using var _ = Session.Create(SessionOptions.RedirectLogging);
+        var ll = new TestTraceListener();
+        Log.AddListener(ll);
         var uninstallContext = UninstallContext.Create(Installation.Current);
 
         // initially verify that all the files exist.
@@ -40,6 +44,9 @@ public class UninstallContextTest
         }
         
         uninstallContext.UndoAllDeletions();
+
+        Assert.That(ll.ErrorMessage, Is.Empty);
+        Assert.That(ll.WarningMessage, Is.Empty);
 
         Assert.That(string.Join(",", stillExistingFiles), Is.Empty);
         

--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -106,8 +106,12 @@
 
     <!-- Generate a list of all packages that should be referenced -->
     <ItemGroup>
-      <OpenTapPackagesToReference Include="@(AdditionalOpenTapPackage->WithMetadataValue('Reference', 'true'))"/>
-      <OpenTapPackagesToReference Include="@(OpenTapPackageReference)" Exclude="@(OpenTapPackageReference->WithMetadataValue('Reference', 'false'))"/>
+      <OpenTapPackagesToReference Include="@(AdditionalOpenTapPackage->WithMetadataValue('Reference', 'true'))">
+        <Private Condition="'%(AdditionalOpenTapPackage.Private)' == ''">false</Private>
+      </OpenTapPackagesToReference>
+      <OpenTapPackagesToReference Include="@(OpenTapPackageReference)" Exclude="@(OpenTapPackageReference->WithMetadataValue('Reference', 'false'))">
+        <Private Condition="'%(OpenTapPackageReference.Private)' == ''">false</Private>
+      </OpenTapPackagesToReference>
     </ItemGroup>
 
     <!-- Generate a list of xml files for packages that should be referenced. 
@@ -164,7 +168,7 @@
         <!-- This is not required because OpenTAP's resolver can still find them in their subdirectories, and including -->
         <!-- them in the output folder triggers warnings about duplicate assemblies. It also breaks other features in debug builds -->
         <!-- such as InstallationCurrent.FindPackageContaining{Type/File}(); -->
-        <Private>false</Private>
+        <Private>%(Private)</Private>
       </Reference>
     </ItemGroup>
   </Target>
@@ -198,3 +202,4 @@
   </Target>
 
 </Project>
+

--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -159,7 +159,13 @@
     </AddAssemblyReferencesFromPackage>
     <Touch Files="$(MSBuildThisFileFullPath)"/>
     <ItemGroup>
-      <Reference Include="@(_OpenTapPackagesReferences-> '$(OutDir)%(Identity)')"/>
+      <Reference Include="@(_OpenTapPackagesReferences-> '$(OutDir)%(Identity)')">
+        <!-- setting private to false stops the compiler from copying the assembly into the root of the build directory. -->
+        <!-- This is not required because OpenTAP's resolver can still find them in their subdirectories, and including -->
+        <!-- them in the output folder triggers warnings about duplicate assemblies. It also breaks other features in debug builds -->
+        <!-- such as InstallationCurrent.FindPackageContaining{Type/File}(); -->
+        <Private>false</Private>
+      </Reference>
     </ItemGroup>
   </Target>
 

--- a/sdk/OpenTap.Sdk.MSBuild/AddAssemblyReferencesFromPackageTask.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/AddAssemblyReferencesFromPackageTask.cs
@@ -101,6 +101,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
         internal const string DefaultInclude = "**";
 
         internal string PackageName { get; }
+        internal bool Private { get; } = false;
         private ITaskItem TaskItem { get; }
         private AddAssemblyReferencesFromPackage Owner { get; set; }
 
@@ -110,6 +111,9 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             this.Owner = owner;
             TaskItem = item;
             PackageName = item.ItemSpec;
+            var privateMetadata = item.GetMetadata("Private");
+            /* default to private=false, which means the assembly will not be copied to $(OutDir) */
+            Private = string.Equals(privateMetadata, "true", StringComparison.OrdinalIgnoreCase);
             includePatterns = includePatterns.Distinct().Where(x => !string.IsNullOrWhiteSpace(x));
             excludePatterns = excludePatterns.Distinct().Where(x => !string.IsNullOrWhiteSpace(x));
             Globs = includePatterns.Select(x => new GlobWrapper(x, true)).Concat(
@@ -225,7 +229,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
         private Regex dllRx = new Regex("<File +.*Path=\"(?<name>.+\\.dll)\"");
 
         [Output] 
-        public string[] Assemblies { get; set; }
+        public ITaskItem[] Assemblies { get; set; }
 
         [Required]
         public string PackageInstallDir { get; set; }
@@ -254,12 +258,14 @@ namespace Keysight.OpenTap.Sdk.MSBuild
         private string Separator { get; set; }
         private bool ShouldAppendSeparator { get; set; }
 
-        private void WriteItemGroup(IEnumerable<string> assembliesInPackage)
+        private void WriteItemGroup(IEnumerable<string> assembliesInPackage, bool isPrivate)
         {
             Result.AppendLine("  <ItemGroup>");
 
             var OutDir = "$(OutDir)";
             if (ShouldAppendSeparator) OutDir += Separator;
+
+            var privateValue = isPrivate ? "true" : "false";
 
             foreach (var asmPath in assembliesInPackage)
             {
@@ -271,7 +277,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
                  * This is not required because OpenTAP's resolver can still find them in their subdirectories, and including
                  * them in the output folder triggers warnings about duplicate assemblies. It also breaks other features in debug builds
                  * such as InstallationCurrent.FindPackageContaining{Type/File}(); */
-                Result.AppendLine($"      <Private>false</Private>"); 
+                Result.AppendLine($"      <Private>{privateValue}</Private>"); 
                 Result.AppendLine($"      <HintPath>{OutDir}{asm}</HintPath>");
                 Result.AppendLine("    </Reference>");
             }
@@ -311,7 +317,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             // Task instances are sometimes reused by the build engine -- ensure 'document' is reinstantiated
             _document = null;
 
-            Assemblies = new string[] { };
+            Assemblies = [];
             try
             {
                 // Distincting the tasks is not necessary, but it is a much more helpful warning than 
@@ -343,10 +349,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
                     Log.LogMessage($"{task.PackageName} Include=\"{includeGlobString}\" Exclude=\"{excludeGlobString}\"");
                 }
 
-                foreach (var globTask in globTasks)
-                {
-                    HandlePackage(globTask);
-                }
+                Assemblies = [.. globTasks.SelectMany(HandlePackage)];
             }
             catch (Exception e)
             {
@@ -363,7 +366,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             return true;
         }
 
-        private void HandlePackage(GlobTask globTask)
+        private List<ITaskItem> HandlePackage(GlobTask globTask)
         {
             var assembliesInPackage = new List<string>();
 
@@ -373,7 +376,7 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             {
                 globTask.LogWarningWithLineNumber(
                     $"No package named '{globTask.PackageName}'.");
-                return;
+                return [];
             }
 
             var dllsInPackage = dllRx.Matches(File.ReadAllText(packageDefPath)).Cast<Match>()
@@ -411,11 +414,18 @@ namespace Keysight.OpenTap.Sdk.MSBuild
             if (!assembliesInPackage.Any())
             {
                 globTask.LogWarningWithLineNumber($"No references added from package '{globTask.PackageName}'.");
+                return [];
             }
             else
             {
-                WriteItemGroup(assembliesInPackage);
-                Assemblies = Assemblies.Concat(assembliesInPackage).ToArray();
+                WriteItemGroup(assembliesInPackage, globTask.Private);
+                var privateValue = globTask.Private ? "true" : "false";
+                return [.. assembliesInPackage.Select(asm =>
+                {
+                    var item = new TaskItem(asm);
+                    item.SetMetadata("Private", privateValue);
+                    return (ITaskItem)item;
+                })];
             }
         }
 

--- a/sdk/OpenTap.Sdk.MSBuild/AddAssemblyReferencesFromPackageTask.cs
+++ b/sdk/OpenTap.Sdk.MSBuild/AddAssemblyReferencesFromPackageTask.cs
@@ -267,6 +267,11 @@ namespace Keysight.OpenTap.Sdk.MSBuild
                 var asm = Separator == "\\" ? asmPath.Replace("/", Separator) : asmPath.Replace("\\", Separator);
 
                 Result.AppendLine($"    <Reference Include=\"{Path.GetFileNameWithoutExtension(asmPath)}\">");
+                /* setting private to false stops the compiler from copying the assembly into the root of the build directory.
+                 * This is not required because OpenTAP's resolver can still find them in their subdirectories, and including
+                 * them in the output folder triggers warnings about duplicate assemblies. It also breaks other features in debug builds
+                 * such as InstallationCurrent.FindPackageContaining{Type/File}(); */
+                Result.AppendLine($"      <Private>false</Private>"); 
                 Result.AppendLine($"      <HintPath>{OutDir}{asm}</HintPath>");
                 Result.AppendLine("    </Reference>");
             }


### PR DESCRIPTION
this prevents the C# compiler from copying them to the build root, which has a couple of negative consequences:

* causes opentap to emit warnings about duplicate assemblies
* general pluginsearcher slowdown
* breaks the Installation.Current.FindPackageContaining{Type,File} methods

Closes #2314