### PR TITLE
2307 TestStepAbortIssue: fix

### DIFF
--- a/Engine.UnitTests/ResultTest.cs
+++ b/Engine.UnitTests/ResultTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.ComponentModel;
 using System.Threading;
 using NUnit.Framework;
 using OpenTap.Engine.UnitTests;
@@ -383,5 +384,142 @@ namespace OpenTap.UnitTests
             }
         }
         
+        [Display("Throwing Property Instrument")]
+        public class ThrowingPropertyInstrument : Instrument
+        {
+            [Browsable(false)]
+            [System.Xml.Serialization.XmlIgnore]
+            public bool ShouldThrow { get; set; }
+
+            [Display("Value")]
+            public double Value
+            {
+                get
+                {
+                    if (ShouldThrow)
+                        throw new InvalidOperationException("Device is detached");
+                    return 42.0;
+                }
+                set { }
+            }
+
+            public override void Open() { base.Open(); ShouldThrow = false; }
+            public override void Close() { ShouldThrow = false; base.Close(); }
+        }
+
+        [Display("Throwing Property Step")]
+        public class ThrowingPropertyStep : TestStep
+        {
+            public ThrowingPropertyInstrument Instrument { get; set; }
+
+            public override void Run()
+            {
+                Instrument.ShouldThrow = true;
+                UpgradeVerdict(Verdict.Pass);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that an exception thrown from an instrument property getter during
+        /// post-Run() ResultParameters.UpdateParams() gives the step Verdict.Error but
+        /// does not bypass break conditions — sibling steps still execute.
+        /// Reproduces GitHub issue #2307.
+        /// </summary>
+        [Test]
+        public void PropertyGetterExceptionInUpdateParamsGivesErrorVerdictAndRespectBreakConditions()
+        {
+            var instrument = new ThrowingPropertyInstrument();
+            InstrumentSettings.Current.Add(instrument);
+            try
+            {
+                var plan = new TestPlan();
+                var sequence = new SequenceStep();
+                plan.ChildTestSteps.Add(sequence);
+
+                var throwingStep = new ThrowingPropertyStep { Instrument = instrument };
+                // Set break condition to "Do not break" so sibling steps still run.
+                BreakConditionProperty.SetBreakCondition(throwingStep, (BreakCondition)0);
+                sequence.ChildTestSteps.Add(throwingStep);
+
+                var logStep = new LogStep();
+                sequence.ChildTestSteps.Add(logStep);
+
+                var rl = new RecordAllResultListener();
+                var run = plan.Execute(new[] { rl });
+
+                var stepRuns = rl.Runs.Values.OfType<TestStepRun>().ToList();
+
+                // The throwing step should have Verdict.Error from the property getter exception.
+                var throwingRun = stepRuns.FirstOrDefault(r => r.TestStepId == throwingStep.Id);
+                Assert.IsNotNull(throwingRun, "Throwing step run should exist");
+                Assert.AreEqual(Verdict.Error, throwingRun.Verdict,
+                    "Throwing step should get Verdict.Error from property getter exception in UpdateParams");
+
+                // The log step should still have been executed (break conditions respected).
+                var logRun = stepRuns.FirstOrDefault(r => r.TestStepId == logStep.Id);
+                Assert.IsNotNull(logRun, "Log step should have been executed — break conditions must be respected");
+
+                // The plan verdict should be Error (propagated from the step).
+                Assert.AreEqual(Verdict.Error, run.Verdict);
+            }
+            finally
+            {
+                InstrumentSettings.Current.Remove(instrument);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when a property getter throws during TestStepRun construction
+        /// (GetParams), the step gets Verdict.Error and does not execute Run().
+        /// </summary>
+        [Test]
+        public void PropertyGetterExceptionInGetParamsGivesErrorVerdictWithoutRunning()
+        {
+            var instrument = new ThrowingPropertyInstrument { ShouldThrow = true };
+            InstrumentSettings.Current.Add(instrument);
+            try
+            {
+                var plan = new TestPlan();
+                var throwingStep = new ThrowingPropertyStep { Instrument = instrument };
+                plan.ChildTestSteps.Add(throwingStep);
+
+                var rl = new RecordAllResultListener();
+                var run = plan.Execute(new[] { rl });
+
+                // The step should have a run with Verdict.Error.
+                var stepRuns = rl.Runs.Values.OfType<TestStepRun>().ToList();
+                var throwingRun = stepRuns.FirstOrDefault(r => r.TestStepId == throwingStep.Id);
+                Assert.IsNotNull(throwingRun, "Step run should still be created even with property getter error");
+                Assert.AreEqual(Verdict.Error, throwingRun.Verdict,
+                    "Step should get Verdict.Error when GetParams encounters a property getter exception");
+            }
+            finally
+            {
+                InstrumentSettings.Current.Remove(instrument);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that ResultParameters.GetParams handles property getter exceptions
+        /// gracefully — returns parameters for non-failing properties and does not throw.
+        /// </summary>
+        [Test]
+        public void GetParamsHandlesPropertyGetterException()
+        {
+            var instrument = new ThrowingPropertyInstrument { ShouldThrow = true };
+            InstrumentSettings.Current.Add(instrument);
+            try
+            {
+                var step = new ThrowingPropertyStep { Instrument = instrument };
+                // GetParams reads properties including instrument properties.
+                // Should not throw even though the instrument property getter throws.
+                var parameters = ResultParameters.GetParams(step);
+                Assert.IsNotNull(parameters);
+            }
+            finally
+            {
+                InstrumentSettings.Current.Remove(instrument);
+            }
+        }
     }
 }

--- a/Engine/ResultListener.cs
+++ b/Engine/ResultListener.cs
@@ -303,6 +303,7 @@ namespace OpenTap
     /// </summary>
     public class ResultParameters : IReadOnlyList<ResultParameter>
     {
+        static readonly TraceSource log = OpenTap.Log.CreateSource("ResultParameters");
         struct resultParameter
         {
             public string Name;
@@ -374,7 +375,7 @@ namespace OpenTap
 
         static void getMetadataFromObject(object res, string nestedName, ICollection<ResultParameter> output)
         {
-            GetPropertiesFromObject(res, output, nestedName, true);
+            GetPropertiesFromObject(res, output, out _, nestedName, true);
         }
 
         /// <summary>
@@ -585,22 +586,35 @@ namespace OpenTap
 
         
         
-        static void GetPropertiesFromObject(object obj, ICollection<ResultParameter> output, string namePrefix = "", bool metadataOnly = false, ITypeData type = null)
+        static void GetPropertiesFromObject(object obj, ICollection<ResultParameter> output, out Exception error, string namePrefix = "", bool metadataOnly = false, ITypeData type = null)
         {
+            error = null;
             if (obj == null)
                 return;
             type ??= TypeData.GetTypeData(obj);
             foreach (var (prop, group, name, metadata) in ParameterCache.GetParametersMap(type, metadataOnly))
             {
-                object value = prop.GetValue(obj);
+                object value;
+                try
+                {
+                    value = prop.GetValue(obj);
+                }
+                catch (Exception ex)
+                {
+                    log.Warning("Error reading property '{0}' from '{1}': {2}", prop.Name, type.Name, ex.Message);
+                    log.Debug(ex);
+                    error ??= ex;
+                    continue;
+                }
                 if (value == null)
                     continue;
                 GetParams(group, namePrefix + name, value, metadata, output);
             }
         }
 
-        internal static void UpdateParams(ResultParameters parameters, object obj, string namePrefix = "", ITypeData type = null)
+        internal static void UpdateParams(ResultParameters parameters, object obj, out Exception error, string namePrefix = "", ITypeData type = null)
         {
+            error = null;
             if (obj == null)
                 return;
             type ??= TypeData.GetTypeData(obj);
@@ -609,7 +623,18 @@ namespace OpenTap
             {
                 if (prop.GetAttribute<MetaDataAttribute>()?.Frozen == true) continue; 
                 var name = namePrefix + _name;
-                object value = prop.GetValue(obj);
+                object value;
+                try
+                {
+                    value = prop.GetValue(obj);
+                }
+                catch (Exception ex)
+                {
+                    log.Warning("Error reading property '{0}' from '{1}': {2}", prop.Name, type.Name, ex.Message);
+                    log.Debug(ex);
+                    error ??= ex;
+                    continue;
+                }
                 if (value == null)
                     continue;
                 
@@ -617,7 +642,8 @@ namespace OpenTap
                 {
                     string resval = value.ToString();
                     parameters.Overwrite(name, resval, group, metadata);
-                    UpdateParams(parameters, value, name);
+                    UpdateParams(parameters, value, out var nestedError, name);
+                    error ??= nestedError;
                     continue;
                 }
                 
@@ -635,16 +661,21 @@ namespace OpenTap
         /// Returns a <see cref="ResultParameters"/> list with one entry for every setting of the inputted 
         /// TestStep.
         /// </summary>
-        internal static ResultParameters GetParams(ITestStep step, ITypeData type = null)
+        internal static ResultParameters GetParams(ITestStep step, ITypeData type, out Exception error)
         {
             if (step == null)
                 throw new ArgumentNullException(nameof(step));
             var parameters = new List<ResultParameter>(5);
-            GetPropertiesFromObject(step, parameters, type: type);
+            GetPropertiesFromObject(step, parameters, out error, type: type);
             
             if (parameters.Count == 0)
                 return new ResultParameters();
             return new ResultParameters(parameters);
+        }
+        
+        internal static ResultParameters GetParams(ITestStep step, ITypeData type = null)
+        {
+            return GetParams(step, type, out _);
         }
         
         /// <summary>

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -950,6 +950,10 @@ namespace OpenTap
             {
                 TestStepPath = Step.GetStepPath()
             };
+            if (readInputsError != null)
+            {
+                stepRun.Exception = readInputsError;
+            }
 
             // evaluate pre run mixins
             var prerun = TestStepPreRunEvent.Invoke(Step);
@@ -992,8 +996,6 @@ namespace OpenTap
                         TapThread.Current.AbortToken);
                     try
                     {
-                        if (readInputsError != null)
-                            ExceptionDispatchInfo.Capture(readInputsError).Throw();
                         
                         if (Step is TestStep _step)
                             _step.Results = new ResultSource(stepRun, Step.PlanRun);

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -250,7 +250,12 @@ namespace OpenTap
         internal void StartStepRun()
         {
             if (Verdict != Verdict.NotSet)
-                throw new ArgumentOutOfRangeException(nameof(Verdict), "StepRun.StartStepRun has already been called once.");
+            {
+                if(Exception == null)   
+                    Exception = new ArgumentOutOfRangeException(nameof(Verdict),
+                        "StepRun.StartStepRun has already been called once.");
+            }
+
             StepThread = TapThread.Current;
             StartTime = DateTime.Now;
             StartTimeStamp = Stopwatch.GetTimestamp();

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -261,7 +261,11 @@ namespace OpenTap
         {
             
             // update values in the run. 
-            ResultParameters.UpdateParams(Parameters, step);
+            ResultParameters.UpdateParams(Parameters, step, out var updateError);
+            if (updateError != null)
+            {
+                step.Verdict = Verdict.Error;
+            }
             
             Duration = runDuration; // Requires update after TestStepRunStart and before TestStepRunCompleted
             UpgradeVerdict(step.Verdict);
@@ -283,13 +287,15 @@ namespace OpenTap
             TestStepName = step.GetFormattedName();
             stepTypeData = TypeData.GetTypeData(step);
             TestStepTypeName = stepTypeData.AsTypeData().AssemblyQualifiedName;
-            Parameters = ResultParameters.GetParams(step, stepTypeData);
+            Parameters = ResultParameters.GetParams(step, stepTypeData, out var paramError);
+            if (paramError != null)
+                Exception = paramError;
             Verdict = Verdict.NotSet;
         }
         
         internal void UpdateParams()
         {
-            ResultParameters.UpdateParams(Parameters, _step, type: stepTypeData);
+            ResultParameters.UpdateParams(Parameters, _step, out _, type: stepTypeData);
         }
         
         /// <summary>

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -249,13 +249,6 @@ namespace OpenTap
         /// <summary>  Called by TestStep.DoRun before running the step. </summary>
         internal void StartStepRun()
         {
-            if (Verdict != Verdict.NotSet)
-            {
-                if(Exception == null)   
-                    Exception = new ArgumentOutOfRangeException(nameof(Verdict),
-                        "StepRun.StartStepRun has already been called once.");
-            }
-
             StepThread = TapThread.Current;
             StartTime = DateTime.Now;
             StartTimeStamp = Stopwatch.GetTimestamp();


### PR DESCRIPTION
- Added catching exceptions from GetPropertiesFromObject and setting Error or exception on the test step run.
- Added unit test to verify the issue.

Close #2307 