### PR TITLE
Handle termination character in ScpiInstrument

### DIFF
--- a/Engine/ScpiInstrument.cs
+++ b/Engine/ScpiInstrument.cs
@@ -643,6 +643,10 @@ namespace OpenTap
 
                     return text;
                 }
+                else if (firstChar == TerminationCharacter)
+                {
+                    return firstChar.ToString();
+                }
                 else
                 {
                     string theRest = LockRetry(() => ReadString());


### PR DESCRIPTION
Handle the case in a SOCKET connection where an instrument might not have any data to return, but needs to send a response to a query (e.g. returning a list that is empty). The Termination Character is recognized as the end of the data and no further reads are sent.

This should have similar behavior on a serial instrument since it also does not have an out-of-band end indicator (EOI).

This only takes effect when the Termination Character is enabled (default is disabled)