### PR TITLE
allow parameterizing [Output] properties onto parent scopes

### DIFF
--- a/Engine.UnitTests/ScopeParametersTest.cs
+++ b/Engine.UnitTests/ScopeParametersTest.cs
@@ -1025,5 +1025,62 @@ namespace OpenTap.UnitTests
             Assert.AreEqual(123.0, consumer2.SeenValue,
                 "The consumer did not observe the value from the parameterized output after round-tripping through the serializer.");
         }
+        
+        class SelectOutputFromUserInput : IUserInputInterface, IUserInterface
+        {
+            public bool WasInvoked;
+            public string SelectName { get; set; }
+            public void RequestUserInput(object dataObject, TimeSpan Timeout, bool modal)
+            {
+                var datas = AnnotationCollection.Annotate(dataObject);
+                var selectedName = datas.GetMember("Output");
+                var avail = selectedName.Get<IAvailableValuesAnnotationProxy>();
+                Assert.That(avail.AvailableValues.Count(), Is.EqualTo(1));
+                WasInvoked = true;
+            }
+
+            public void NotifyChanged(object obj, string property) { }
+        }
+
+        [TestCase(IconNames.ParameterizeOnParent)]
+        [TestCase(IconNames.ParameterizeOnTestPlan)]
+        public void TestCanParameterizeOutput(string scope)
+        {
+            using var _ = Session.Create(SessionOptions.OverlayComponentSettings);
+            var singleInput = new SelectOutputFromUserInput();
+            UserInput.SetInterface(singleInput);
+            
+            var plan = new TestPlan();
+            var parentStep = new SequenceStep();
+            var outputStep = new OutputProducerStep();
+            var inputStep = new OutputConsumerStep();
+
+            plan.ChildTestSteps.Add(parentStep);
+            parentStep.ChildTestSteps.Add(outputStep);
+            plan.ChildTestSteps.Add(inputStep);
+
+            var a = AnnotationCollection.Annotate(outputStep);
+            var oMem = a.GetMember(nameof(outputStep.Measurement));
+            var menu = oMem.Get<MenuAnnotation>().MenuItems.ToLookup(m => m.Get<IIconAnnotation>().IconName);
+            Assert.That(menu[IconNames.ParameterizeOnParent].Count(), Is.EqualTo(1));
+            Assert.That(menu[IconNames.Parameterize].Count(), Is.EqualTo(1));
+            Assert.That(menu[IconNames.ParameterizeOnTestPlan].Count(), Is.EqualTo(1)); 
+            menu[scope].Single().Get<IMethodAnnotation>().Invoke();
+
+            var a2 = AnnotationCollection.Annotate(inputStep);
+            var iMem = a2.GetMember(nameof(inputStep.Value));
+            var menu2 = iMem.Get<MenuAnnotation>().MenuItems.ToLookup(m => m.Get<IIconAnnotation>().IconName);
+            Assert.That(menu2[IconNames.AssignOutput].Count(), Is.EqualTo(1));
+            Assert.That(singleInput.WasInvoked, Is.False);
+            menu2[IconNames.AssignOutput].Single().Get<IMethodAnnotation>().Invoke();
+            Assert.That(singleInput.WasInvoked, Is.True);
+
+            outputStep.MeasurementToProduce = 123;
+            plan.Execute();
+            Assert.That(inputStep.Value, Is.EqualTo(123));
+            outputStep.MeasurementToProduce = 456;
+            plan.Execute();
+            Assert.That(inputStep.Value, Is.EqualTo(456));
+        }
     }
 }

--- a/Engine.UnitTests/ScopeParametersTest.cs
+++ b/Engine.UnitTests/ScopeParametersTest.cs
@@ -957,10 +957,6 @@ namespace OpenTap.UnitTests
             var parameter = outputMember.Parameterize(seq, producer, paramName);
             Assert.IsNotNull(parameter);
 
-            // The parameter is advertised as writable so that serialization treats it normally,
-            // but setting its value is a safe no-op (outputs are written by Run()).
-            Assert.IsTrue(parameter.Writable);
-
             // GetValue on the parameter should reflect the output value on the source.
             producer.Run();
             Assert.AreEqual(42.0, (double)parameter.GetValue(seq));

--- a/Engine.UnitTests/ScopeParametersTest.cs
+++ b/Engine.UnitTests/ScopeParametersTest.cs
@@ -916,19 +916,23 @@ namespace OpenTap.UnitTests
             public override void Run()
             {
                 Measurement = MeasurementToProduce;
+                UpgradeVerdict(Verdict.Pass);
             }
         }
 
         /// <summary>
-        /// Reads a value via a public (writable) property - can be connected to an output via an
-        /// input/output relation, or simply have the value set by a parameter.
+        /// Reads a value into a public (writable) property and records what it saw.
+        /// Can be connected to an output via an InputOutputRelation.
         /// </summary>
         public class OutputConsumerStep : TestStep
         {
             public double Value { get; set; }
+            public double SeenValue { get; private set; } = double.NaN;
+
             public override void Run()
             {
-                Log.Info("Consumed value: {0}", Value);
+                SeenValue = Value;
+                UpgradeVerdict(Verdict.Pass);
             }
         }
 
@@ -936,59 +940,75 @@ namespace OpenTap.UnitTests
         public void ParameterizeOutputOnParentScope()
         {
             // Verify that an [Output] property (with a non-public setter) can be parameterized
-            // onto a parent scope. This exposes the output at the parent scope.
+            // onto a parent scope. This matches the scenario from the issue:
+            //   Sequence
+            //       Producer        <-- has [Output] Measurement
+            //   Consumer             <-- sibling of Sequence, consumes the exposed parameter
+            // The output is exposed on Sequence via parameterization, then connected to
+            // Consumer.Value via an InputOutputRelation.
             var plan = new TestPlan();
             var seq = new SequenceStep();
-            var producer = new OutputProducerStep();
+            var producer = new OutputProducerStep { MeasurementToProduce = 42.0 };
+            var consumer = new OutputConsumerStep();
             seq.ChildTestSteps.Add(producer);
             plan.ChildTestSteps.Add(seq);
+            plan.ChildTestSteps.Add(consumer);
 
             var outputMember = TypeData.GetTypeData(producer).GetMember(nameof(producer.Measurement));
             Assert.IsNotNull(outputMember);
             Assert.IsTrue(outputMember.HasAttribute<OutputAttribute>());
-
-            // Before: the output is not writable via the normal setter.
+            // The output is not writable via the normal setter.
             Assert.IsFalse(outputMember.Writable);
-
-            // Should be considered a valid parameter now despite Writable==false.
+            // But it should be a valid parameter candidate now.
             Assert.IsTrue(ParameterManager.CanParameter(outputMember, new ITestStepParent[] { producer }));
 
             const string paramName = "Exposed Measurement";
             var parameter = outputMember.Parameterize(seq, producer, paramName);
             Assert.IsNotNull(parameter);
 
-            // GetValue on the parameter should reflect the output value on the source.
-            producer.Run();
-            Assert.AreEqual(42.0, (double)parameter.GetValue(seq));
+            // Connect the parameterized output on Sequence to Consumer.Value.
+            var inputMember = TypeData.GetTypeData(consumer).GetMember(nameof(consumer.Value));
+            InputOutputRelation.Assign(consumer, inputMember, seq, parameter);
 
-            // SetValue should be a no-op for the output (no exception, value unchanged).
-            parameter.SetValue(seq, 0.0);
-            Assert.AreEqual(42.0, producer.Measurement);
+            // Run the plan. The producer must produce the value, and it must reach the consumer
+            // through the parameterized output.
+            var run = plan.Execute();
+            Assert.AreEqual(Verdict.Pass, run.Verdict, "Test plan did not pass.");
+            Assert.AreEqual(42.0, consumer.SeenValue,
+                "The consumer did not observe the value from the parameterized output.");
         }
 
         [Test]
         public void ParameterizedOutputSerialization()
         {
-            // Verify that a plan with a parameterized output can be round-tripped through the
-            // serializer and the parameterization is preserved.
+            // Verify that a plan with a parameterized output connected to a consumer can be
+            // round-tripped through the serializer, and executing the deserialized plan still
+            // propagates the output value through the parameterization.
             var plan = new TestPlan();
             var seq = new SequenceStep();
-            var producer = new OutputProducerStep();
+            var producer = new OutputProducerStep { MeasurementToProduce = 123.0 };
+            var consumer = new OutputConsumerStep();
             seq.ChildTestSteps.Add(producer);
             plan.ChildTestSteps.Add(seq);
+            plan.ChildTestSteps.Add(consumer);
 
             const string paramName = "Exposed Measurement";
             var outputMember = TypeData.GetTypeData(producer).GetMember(nameof(producer.Measurement));
-            outputMember.Parameterize(seq, producer, paramName);
+            var parameter = outputMember.Parameterize(seq, producer, paramName);
 
-            // Serialize/deserialize.
+            var inputMember = TypeData.GetTypeData(consumer).GetMember(nameof(consumer.Value));
+            InputOutputRelation.Assign(consumer, inputMember, seq, parameter);
+
+            // Serialize.
             var xml = new TapSerializer().SerializeToString(plan);
             Assert.IsTrue(xml.Contains("Parameter=\"" + paramName + "\""),
                 "Expected the serialized XML to contain the Parameter attribute for the output.");
 
+            // Deserialize.
             var plan2 = (TestPlan)new TapSerializer().DeserializeFromString(xml);
             var seq2 = (SequenceStep)plan2.ChildTestSteps[0];
             var producer2 = (OutputProducerStep)seq2.ChildTestSteps[0];
+            var consumer2 = (OutputConsumerStep)plan2.ChildTestSteps[1];
 
             var param2 = TypeData.GetTypeData(seq2).GetMember(paramName);
             Assert.IsNotNull(param2, "Parameter was not preserved during deserialization.");
@@ -998,9 +1018,12 @@ namespace OpenTap.UnitTests
             Assert.IsTrue(DynamicMember.IsParameterized(outputMember2, producer2),
                 "The output was not restored as parameterized after deserialization.");
 
-            // After running, the parameter should reflect the output value of the producer.
-            producer2.Run();
-            Assert.AreEqual(42.0, (double)param2.GetValue(seq2));
+            // Run the deserialized plan. The input/output relation should still be in place and
+            // the value should propagate from producer -> parameter -> consumer.
+            var run = plan2.Execute();
+            Assert.AreEqual(Verdict.Pass, run.Verdict, "Deserialized test plan did not pass.");
+            Assert.AreEqual(123.0, consumer2.SeenValue,
+                "The consumer did not observe the value from the parameterized output after round-tripping through the serializer.");
         }
     }
 }

--- a/Engine.UnitTests/ScopeParametersTest.cs
+++ b/Engine.UnitTests/ScopeParametersTest.cs
@@ -902,6 +902,109 @@ namespace OpenTap.UnitTests
             // all the values should be inserted at the same key location.
             Assert.AreEqual(1, dict.Count);
         }
-        
+
+        /// <summary>
+        /// Test step exposing an [Output] whose setter is non-public, as is typical for outputs.
+        /// </summary>
+        public class OutputProducerStep : TestStep
+        {
+            [Output]
+            public double Measurement { get; private set; }
+
+            public double MeasurementToProduce { get; set; } = 42.0;
+
+            public override void Run()
+            {
+                Measurement = MeasurementToProduce;
+            }
+        }
+
+        /// <summary>
+        /// Reads a value via a public (writable) property - can be connected to an output via an
+        /// input/output relation, or simply have the value set by a parameter.
+        /// </summary>
+        public class OutputConsumerStep : TestStep
+        {
+            public double Value { get; set; }
+            public override void Run()
+            {
+                Log.Info("Consumed value: {0}", Value);
+            }
+        }
+
+        [Test]
+        public void ParameterizeOutputOnParentScope()
+        {
+            // Verify that an [Output] property (with a non-public setter) can be parameterized
+            // onto a parent scope. This exposes the output at the parent scope.
+            var plan = new TestPlan();
+            var seq = new SequenceStep();
+            var producer = new OutputProducerStep();
+            seq.ChildTestSteps.Add(producer);
+            plan.ChildTestSteps.Add(seq);
+
+            var outputMember = TypeData.GetTypeData(producer).GetMember(nameof(producer.Measurement));
+            Assert.IsNotNull(outputMember);
+            Assert.IsTrue(outputMember.HasAttribute<OutputAttribute>());
+
+            // Before: the output is not writable via the normal setter.
+            Assert.IsFalse(outputMember.Writable);
+
+            // Should be considered a valid parameter now despite Writable==false.
+            Assert.IsTrue(ParameterManager.CanParameter(outputMember, new ITestStepParent[] { producer }));
+
+            const string paramName = "Exposed Measurement";
+            var parameter = outputMember.Parameterize(seq, producer, paramName);
+            Assert.IsNotNull(parameter);
+
+            // The parameter is advertised as writable so that serialization treats it normally,
+            // but setting its value is a safe no-op (outputs are written by Run()).
+            Assert.IsTrue(parameter.Writable);
+
+            // GetValue on the parameter should reflect the output value on the source.
+            producer.Run();
+            Assert.AreEqual(42.0, (double)parameter.GetValue(seq));
+
+            // SetValue should be a no-op for the output (no exception, value unchanged).
+            parameter.SetValue(seq, 0.0);
+            Assert.AreEqual(42.0, producer.Measurement);
+        }
+
+        [Test]
+        public void ParameterizedOutputSerialization()
+        {
+            // Verify that a plan with a parameterized output can be round-tripped through the
+            // serializer and the parameterization is preserved.
+            var plan = new TestPlan();
+            var seq = new SequenceStep();
+            var producer = new OutputProducerStep();
+            seq.ChildTestSteps.Add(producer);
+            plan.ChildTestSteps.Add(seq);
+
+            const string paramName = "Exposed Measurement";
+            var outputMember = TypeData.GetTypeData(producer).GetMember(nameof(producer.Measurement));
+            outputMember.Parameterize(seq, producer, paramName);
+
+            // Serialize/deserialize.
+            var xml = new TapSerializer().SerializeToString(plan);
+            Assert.IsTrue(xml.Contains("Parameter=\"" + paramName + "\""),
+                "Expected the serialized XML to contain the Parameter attribute for the output.");
+
+            var plan2 = (TestPlan)new TapSerializer().DeserializeFromString(xml);
+            var seq2 = (SequenceStep)plan2.ChildTestSteps[0];
+            var producer2 = (OutputProducerStep)seq2.ChildTestSteps[0];
+
+            var param2 = TypeData.GetTypeData(seq2).GetMember(paramName);
+            Assert.IsNotNull(param2, "Parameter was not preserved during deserialization.");
+            Assert.IsInstanceOf<ParameterMemberData>(param2);
+
+            var outputMember2 = TypeData.GetTypeData(producer2).GetMember(nameof(producer2.Measurement));
+            Assert.IsTrue(DynamicMember.IsParameterized(outputMember2, producer2),
+                "The output was not restored as parameterized after deserialization.");
+
+            // After running, the parameter should reflect the output value of the producer.
+            producer2.Run();
+            Assert.AreEqual(42.0, (double)param2.GetValue(seq2));
+        }
     }
 }

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -290,10 +290,8 @@ namespace OpenTap
         /// if the first member is an int, subsequent members can be other numeric types or string as well. </summary>
         public ITypeData TypeDescriptor => member.TypeDescriptor;
 
-        /// <summary> If this member is writable. Usually true for parameters.
-        /// This is also true when the inner member is an output so that the parameterization
-        /// can be serialized, even though SetValue acts as a no-op in that case. </summary>
-        public bool Writable => member.Writable || member.HasAttribute<OutputAttribute>();
+        /// <summary> If this member is writable. Usually true for parameters.</summary>
+        public bool Writable => member.Writable;
         /// <summary> If this member is readable. Usually true for parameters. </summary>
         public bool Readable => member.Readable;
         /// <summary> The declared name of this parameter. This parameter can be referred to by this name. It may contain spaces etc. </summary>

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -260,10 +260,16 @@ namespace OpenTap
 
             var cloner = new ObjectCloner(value);
 
-            member.SetValue(source, cloner.Clone(true, source, member.TypeDescriptor));
+            // When the inner member is an output (or otherwise not writable), we cannot assign
+            // a value to it through the normal setter. Such members are written by the step's Run
+            // method. Skip writing rather than throw, so that parameterized outputs behave as
+            // "read-through" views from the source to the parameter.
+            if (member.Writable)
+                member.SetValue(source, cloner.Clone(true, source, member.TypeDescriptor));
 
             foreach (var (addContext, addMember) in additionalMembers)
             {
+                if (addMember.Writable == false) continue;
                 var cloned = cloner.Clone(false, addContext, addMember.TypeDescriptor);
                 if (cloned != null)
                     addMember.SetValue(addContext, cloned); // This will throw an exception if it is not assignable.
@@ -284,8 +290,10 @@ namespace OpenTap
         /// if the first member is an int, subsequent members can be other numeric types or string as well. </summary>
         public ITypeData TypeDescriptor => member.TypeDescriptor;
 
-        /// <summary> If this member is writable. Usually true for parameters.</summary>
-        public bool Writable => member.Writable;
+        /// <summary> If this member is writable. Usually true for parameters.
+        /// This is also true when the inner member is an output so that the parameterization
+        /// can be serialized, even though SetValue acts as a no-op in that case. </summary>
+        public bool Writable => member.Writable || member.HasAttribute<OutputAttribute>();
         /// <summary> If this member is readable. Usually true for parameters. </summary>
         public bool Readable => member.Readable;
         /// <summary> The declared name of this parameter. This parameter can be referred to by this name. It may contain spaces etc. </summary>

--- a/Engine/ParameterManager.cs
+++ b/Engine/ParameterManager.cs
@@ -507,9 +507,14 @@ namespace OpenTap
             if (property.HasAttribute<UnparameterizableAttribute>())
                 return false;
 
+            // Outputs may have non-public setters (Writable==false), but we still want to
+            // allow parameterizing them so that the output value can be made accessible at a
+            // parent scope. See OutputAttribute.
+            bool isOutput = property.HasAttribute<OutputAttribute>();
             foreach (var x in steps)
             {
-                if (property.Readable == false || property.Writable == false) return false;
+                if (property.Readable == false) return false;
+                if (property.Writable == false && !isOutput) return false;
                 if (x is ITestStep step && step.IsReadOnly)
                     return false;
                 if (checkTestPlan && x is TestPlan) return false;

--- a/Engine/SerializerPlugins/ExternalParameterSerializer.cs
+++ b/Engine/SerializerPlugins/ExternalParameterSerializer.cs
@@ -144,6 +144,13 @@ namespace OpenTap.Plugins
             Guid.TryParse(elem.Attribute(Scope)?.Value, out Guid scope);
             if (!loadScopeParameter(scope, step, member, parameter))
                 Serializer.DeferLoad(() => loadScopeParameter(scope, step, member, parameter));
+
+            // For parameterized outputs we only need to restore the parameterization relation.
+            // The value itself is not serialized (see Serialize above) and the output does not
+            // have a public setter, so attempting to deserialize a value would fail.
+            if (member != null && member.Writable == false && member.HasAttribute<OutputAttribute>())
+                return true;
+
             if (scope != Guid.Empty) return false;
             var plan = Serializer.SerializerStack.OfType<TestPlanSerializer>().FirstOrDefault()?.Plan;
             if (plan == null)
@@ -247,6 +254,15 @@ namespace OpenTap.Plugins
             elem.SetAttributeValue(Parameter, parentMember.parameterMember.Name);
             if (parentMember.parameterParent is ITestStep parentStep)
                 elem.SetAttributeValue(Scope, parentStep.Id.ToString());
+
+            // For parameterized outputs, we only serialize the fact that the output is
+            // parameterized (the Parameter/Scope attributes); we do NOT serialize the value
+            // because outputs are written by the step during a run, not by the user/serializer.
+            // Also, outputs typically have non-public setters so the value could not be
+            // round-tripped anyway.
+            if (member.Writable == false && member.HasAttribute<OutputAttribute>())
+                return true;
+
             // skip
             try
             {

--- a/Engine/SerializerPlugins/ObjectSerializer.cs
+++ b/Engine/SerializerPlugins/ObjectSerializer.cs
@@ -191,7 +191,15 @@ namespace OpenTap.Plugins
                             int hits = 0;
                             foreach (var p in propertyMatches)
                             {
-                                if (p.Writable || p.HasAttribute<XmlIgnoreAttribute>())
+                                // Non-writable [Output] properties can still appear in XML when they are
+                                // parameterized on a parent scope - we need to match them here so that
+                                // the ExternalParameterSerializer plugin gets a chance to read the
+                                // Parameter/Scope attributes and reconstruct the parameterization.
+                                bool isOutputWithParameter = p.Writable == false
+                                                             && p.HasAttribute<OutputAttribute>()
+                                                             && (element2.Attribute("Parameter") != null ||
+                                                                 element2.Attribute("external") != null);
+                                if (p.Writable || p.HasAttribute<XmlIgnoreAttribute>() || isOutputWithParameter)
                                 {
                                     property = p;
                                     hits++;
@@ -312,7 +320,15 @@ namespace OpenTap.Plugins
                                                 property = t2.GetMembers().FirstOrDefault(x => x.Name == elementName);
                                         }
                                         catch { }
-                                        if (property == null || property.Writable == false)
+                                        if (property == null)
+                                        {
+                                            continue;
+                                        }
+                                        bool isOutputWithParameter = property.Writable == false
+                                                                     && property.HasAttribute<OutputAttribute>()
+                                                                     && (propertyElement.Attribute("Parameter") != null ||
+                                                                         propertyElement.Attribute("external") != null);
+                                        if (property.Writable == false && !isOutputWithParameter)
                                         {
                                             continue;
                                         }
@@ -821,7 +837,16 @@ namespace OpenTap.Plugins
                     foreach (IMemberData subProp in properties)
                     {
                         if (subProp.HasAttribute<XmlIgnoreAttribute>()) continue;
-                        if (subProp.Readable && subProp.Writable && null == subProp.GetAttribute<XmlAttributeAttribute>())
+                        // Normally we skip non-writable properties (they cannot be deserialized),
+                        // but an [Output] property that is parameterized on a parent scope must still
+                        // emit its XML element so that the parameterization attribute can be written.
+                        // The value is not serialized - see ExternalParameterSerializer.
+                        bool isParameterizedOutput = subProp.Readable
+                                                     && subProp.Writable == false
+                                                     && subProp.HasAttribute<OutputAttribute>()
+                                                     && obj is ITestStepParent parameterizedOutputOwner
+                                                     && DynamicMember.IsParameterized(subProp, parameterizedOutputOwner);
+                        if (subProp.Readable && (subProp.Writable || isParameterizedOutput) && null == subProp.GetAttribute<XmlAttributeAttribute>())
                         {
                             var oldProp = CurrentMember;
                             CurrentMember = subProp;


### PR DESCRIPTION


Outputs typically have non-public setters, which caused them to fail the Writable check used in parameterization and serialization. This made it impossible to expose an output at a parent scope so it could be consumed by sibling steps (e.g. Retry > Measure, then Log Result Step).

- IsValidParameter: accept [Output] members even when not writable
- ParameterMemberData: treat parameter as writable for outputs; SetValue is a safe no-op for non-writable inner members
- Serializer: emit Parameter/Scope attributes on parameterized outputs without serializing the value (outputs are written by Run)
- Deserializer: match non-writable outputs with a Parameter= attribute so the parameterization is restored


Close #2266