### PR TITLE
fix check for sln/slnx

### DIFF
--- a/sdk/OpenTap.Sdk.New/GenerateProject.cs
+++ b/sdk/OpenTap.Sdk.New/GenerateProject.cs
@@ -171,7 +171,7 @@ namespace OpenTap.Sdk.New
                     dest = dest.CreateSubdirectory(Name);
 
                 int result = DotnetNewSln(Name, dest, cancellationToken);
-                sln = dest.EnumerateFiles("*.sln").FirstOrDefault();
+                sln = dest.EnumerateFiles("*.sln").FirstOrDefault() ?? dest.EnumerateFiles("*.slnx").FirstOrDefault();
                 if (result != 0 || sln == null || !sln.Exists)
                 {
                     return result;


### PR DESCRIPTION
.NET 10 now generates a .slnx file instead of .sln which broke our logic checking if a solution file was created

Closes #2357 