### PR TITLE
restore previous default session log naming behavior

### DIFF
--- a/Engine/PluginManager.cs
+++ b/Engine/PluginManager.cs
@@ -281,17 +281,20 @@ namespace OpenTap
                 if (isLoaded) return;
                 isLoaded = true;
 
-                if (!SessionLogs.TryGetCommandLinePath(out string path))
+                if (SessionLogs.TryGetCommandLinePath(out string path))
                 {
-                    path = SessionLogs.GetDefaultPath();
+                    try
+                    {
+                        SessionLogs.Initialize(path);
+                    }
+                    catch
+                    {
+                        SessionLogs.Initialize();
+                    }
                 }
-                try
+                else
                 {
-                    SessionLogs.Initialize(path);
-                }
-                catch
-                {
-                    SessionLogs.Initialize(SessionLogs.GetDefaultPath());
+                    SessionLogs.Initialize();
                 }
 
                 string tapEnginePath = Assembly.GetExecutingAssembly().Location;

--- a/Engine/SessionLogs.cs
+++ b/Engine/SessionLogs.cs
@@ -69,13 +69,6 @@ namespace OpenTap
             return false;
         }
 
-        internal static string GetDefaultPath()
-        {
-            string timestamp = Process.GetCurrentProcess().StartTime.ToString("yyyy-MM-dd HH-mm-ss");
-            string pathEnding = $"SessionLog {timestamp}";
-            return Path.Combine(FileSystemHelper.GetCurrentInstallationDirectory(), "SessionLogs", $"{pathEnding}.txt");
-        }
-
         private static readonly TraceSource log = Log.CreateSource("Session");
 
         /// <summary> The number of files kept at a time. </summary>


### PR DESCRIPTION
This can be tested by running 'tap timinganalyzer' for example, and verifying there is a session log file named TimingAnalyzer*.txt in SessionLogs

Closes #2360