### PR TITLE
2352 2351 output parameter improvements

### DIFF
--- a/Engine.UnitTests/ScopeParametersTest.cs
+++ b/Engine.UnitTests/ScopeParametersTest.cs
@@ -949,8 +949,10 @@ namespace OpenTap.UnitTests
             var plan = new TestPlan();
             var seq = new SequenceStep();
             var producer = new OutputProducerStep { MeasurementToProduce = 42.0 };
+            var producer2 = new OutputProducerStep { MeasurementToProduce = 52.0 };
             var consumer = new OutputConsumerStep();
             seq.ChildTestSteps.Add(producer);
+            seq.ChildTestSteps.Add(producer2);
             plan.ChildTestSteps.Add(seq);
             plan.ChildTestSteps.Add(consumer);
 
@@ -960,12 +962,15 @@ namespace OpenTap.UnitTests
             // The output is not writable via the normal setter.
             Assert.IsFalse(outputMember.Writable);
             // But it should be a valid parameter candidate now.
-            Assert.IsTrue(ParameterManager.CanParameter(outputMember, new ITestStepParent[] { producer }));
+            Assert.IsTrue(ParameterManager.CanParameter(outputMember, [producer]));
+            Assert.IsFalse(ParameterManager.CanParameter(outputMember, [producer, producer2]));
 
             const string paramName = "Exposed Measurement";
             var parameter = outputMember.Parameterize(seq, producer, paramName);
             Assert.IsNotNull(parameter);
 
+            Assert.Throws<Exception>(() => outputMember.Parameterize(seq, producer2, paramName));
+            
             // Connect the parameterized output on Sequence to Consumer.Value.
             var inputMember = TypeData.GetTypeData(consumer).GetMember(nameof(consumer.Value));
             InputOutputRelation.Assign(consumer, inputMember, seq, parameter);

--- a/Engine/Cli/RunCliAction.cs
+++ b/Engine/Cli/RunCliAction.cs
@@ -331,6 +331,9 @@ namespace OpenTap.Cli
             {
                 if (member.Get<IMemberAnnotation>()?.Member is ParameterMemberData param)
                 {
+                    if (!param.Writable)
+                        continue; // parameterized output
+                    
                     var multiValues = member.Get<IMultiSelectAnnotationProxy>()?.SelectedValues;
                     string printStr = "";
                     if (multiValues != null)

--- a/Engine/Cli/RunCliAction.cs
+++ b/Engine/Cli/RunCliAction.cs
@@ -326,7 +326,23 @@ namespace OpenTap.Cli
         private void PrintExternalParameters(TraceSource log)
         {
             var annotation = AnnotationCollection.Annotate(Plan).Get<IMembersAnnotation>();
-            log.Info("Listing {0} External Test Plan Parameters:", Plan.ExternalParameters.Entries.Count);
+            
+            
+            int count = 0;
+            
+            // count the parameters for showing to the user.
+            foreach (var member in annotation.Members)
+            {
+                if (member.Get<IMemberAnnotation>()?.Member is ParameterMemberData param)
+                {
+                    if (!param.Writable)
+                        continue; // parameterized output
+                    count += 1;
+                }
+            }
+
+            log.Info("Listing {0} External Test Plan Parameters:", count);
+            
             foreach (var member in annotation.Members)
             {
                 if (member.Get<IMemberAnnotation>()?.Member is ParameterMemberData param)

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -301,6 +301,8 @@ namespace OpenTap
         {
             if (source == newSource && newMember == member)
                 throw new Exception("Member is already parameterized.");
+            if (Writable == false && member.HasAttribute<OutputAttribute>())
+                throw new Exception("Output parameters cannot be combined.");
             
             parameterMembers = parameterMembers.Add(newSource, newMember);
         }

--- a/Engine/DynamicMemberTypeDataProvider.cs
+++ b/Engine/DynamicMemberTypeDataProvider.cs
@@ -302,7 +302,7 @@ namespace OpenTap
             if (source == newSource && newMember == member)
                 throw new Exception("Member is already parameterized.");
             if (Writable == false && member.HasAttribute<OutputAttribute>())
-                throw new Exception("Output parameters cannot be combined.");
+                throw new Exception("Output parameters cannot be merged.");
             
             parameterMembers = parameterMembers.Add(newSource, newMember);
         }

--- a/Engine/ParameterManager.cs
+++ b/Engine/ParameterManager.cs
@@ -212,6 +212,13 @@ namespace OpenTap
                                 yield break;
                             }
                         }
+
+                        if (member.Writable == false && member.HasAttribute<OutputAttribute>())
+                        {
+                            var error = $"Output properties cannot be merged.";
+                            yield return (error, error);
+                            yield break;
+                        }
                         if( cloner.CanClone(step, member.TypeDescriptor) == false)
                         {
                             var error = $"Cannot merge properties of this kind.";
@@ -511,6 +518,9 @@ namespace OpenTap
             // allow parameterizing them so that the output value can be made accessible at a
             // parent scope. See OutputAttribute.
             bool isOutput = property.HasAttribute<OutputAttribute>();
+            if (isOutput && steps.Length > 1)
+                return false; // multiple outputs cannot be combined in a parameter.
+            
             foreach (var x in steps)
             {
                 if (property.Readable == false) return false;


### PR DESCRIPTION
- Excluded read-only parameters from being shown in the CLI.
- Added checks for read-only and output attribute for paramerization related code.
- Modified test to add error cases.

Close #2352, #2351