### PR TITLE
Workqueue deadlock

### DIFF
--- a/Engine.UnitTests/ResultTest.cs
+++ b/Engine.UnitTests/ResultTest.cs
@@ -352,6 +352,64 @@ namespace OpenTap.UnitTests
             Assert.AreEqual("Y", dutComment.Value);
         }
 
+        class MyResultListener : ResultListener
+        {
+            public int OpenCount = 0;
+            public int CloseCount = 0;
+            public override void Close()
+            {
+                CloseCount++;
+            }
+            public override void Open()
+            {
+                OpenCount++;
+            }
+
+            public override void OnResultPublished(Guid stepRunID, ResultTable result) { }
+            public override void OnTestPlanRunCompleted(TestPlanRun planRun, Stream logStream) { }
+            public override void OnTestPlanRunStart(TestPlanRun planRun) { }
+            public override void OnTestStepRunCompleted(TestStepRun stepRun) { }
+            public override void OnTestStepRunStart(TestStepRun stepRun) { }
+        }
+        class MyStep : TestStep
+        {
+            public override void Run()
+            {
+                Results.Publish("myresults", [.. Enumerable.Range(0, 500).Select(x => x.ToString())], [.. Enumerable.Range(0, 500).OfType<IConvertible>()]);
+                UpgradeVerdict(Verdict.Pass);
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestWorkQueueDisposed(bool open)
+        {
+            var l = new MyResultListener();
+            using var _ = Session.Create(SessionOptions.OverlayComponentSettings);
+            ResultSettings.Current.Add(l);
+            var plan = new TestPlan();
+            plan.ChildTestSteps.Add(new MyStep());
+            if (open) plan.Open();
+
+            var r1 = plan.Execute();
+            Assert.That(r1.Verdict, Is.EqualTo(Verdict.Pass));
+
+            var r2 = plan.Execute();
+            Assert.That(r2.Verdict, Is.EqualTo(Verdict.Pass));
+
+            if (open)
+            {
+                plan.Close();
+                Assert.That(l.OpenCount == 1);
+                Assert.That(l.CloseCount == 1);
+            }
+            else
+            {
+                Assert.That(l.OpenCount == 2);
+                Assert.That(l.CloseCount == 2);
+            }
+        }
+
         [Test]
         public void TestResultsOptimizeBug()
         {

--- a/Engine/TestPlanRun.cs
+++ b/Engine/TestPlanRun.cs
@@ -274,10 +274,14 @@ namespace OpenTap
                 }
             }, blocking: true);
 
-            // now clean up the result listener workers and wait for them to end.
-            foreach (var kw in resultWorkers)
+            // composite runs will reuse their result workers, and should not be disposed.
+            if (!IsCompositeRun)
             {
-                kw.Value.Dispose();
+                // now clean up the result listener workers and wait for them to end.
+                foreach (var kw in resultWorkers)
+                {
+                    kw.Value.Dispose();
+                }
             }
 
             foreach (var kw in resultWorkers)

--- a/Engine/WorkQueue.cs
+++ b/Engine/WorkQueue.cs
@@ -170,6 +170,7 @@ namespace OpenTap
         /// <summary> Enqueue a new piece of work to be handled in the future. </summary>
         internal void EnqueueWork(IInvokable f)
         {
+            if (disposed) throw new ObjectDisposedException(nameof(WorkQueue));
             while (addSemaphore.CurrentCount >= semaphoreMaxCount - 10)
             {
                 // #4246: this is incredibly rare, but can happen if millions of results are pushed at once.
@@ -193,11 +194,17 @@ namespace OpenTap
                 }
             }
         }
+
+        private bool disposed = false;
         
         /// <summary> Give the thread back to the thread manager.</summary>
         public void Dispose()
         {
-            cancel.Cancel(false);
+            if (!disposed)
+            {
+                disposed = true;
+                cancel.Cancel(false);
+            }
         }
 
         /// <summary> Waits for the workqueue to become empty. </summary>


### PR DESCRIPTION
this fixes a race condition which occurs when a disposed workqueue is
reused in composite runs.

Closes #2371 