### PR TITLE
Avoid loading step type in call to AllowChild

### DIFF
--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -829,6 +829,9 @@ namespace OpenTap
                         plugin.Display = attrInstance;
                     }
                         break;
+                    case "OpenTap.AllowAsChildInAttribute":
+                        plugin.HasAllowAsChildInAttributes = true;
+                        break;
                     case "OpenTap.HelpLinkAttribute":
                     {
                         var valueString = attr.DecodeValue(new CustomAttributeTypeProvider(AllTypes));

--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -801,6 +801,7 @@ namespace OpenTap
                     attributeFullName = GetFullName(CurrentReader, ctor.Parent);
                 }
 
+                plugin.HasAllowAsChildInAttributes = false;
                 switch (attributeFullName)
                 {
                     case "System.Runtime.Versioning.SupportedOSPlatformAttribute":

--- a/Engine/Reflection/ReflectionDataExtensions.cs
+++ b/Engine/Reflection/ReflectionDataExtensions.cs
@@ -125,6 +125,10 @@ namespace OpenTap
                 {
                     return (T)(object)td.HelpLink;
                 }
+                if (typeof(T) == typeof(AllowAsChildInAttribute) && !td.HasAllowAsChildInAttributes) 
+                {
+                    return default;
+                }
             }
 
             var attributes = mem.Attributes;

--- a/Engine/Reflection/ReflectionDataExtensions.cs
+++ b/Engine/Reflection/ReflectionDataExtensions.cs
@@ -125,7 +125,7 @@ namespace OpenTap
                 {
                     return (T)(object)td.HelpLink;
                 }
-                if (typeof(T) == typeof(AllowAsChildInAttribute) && !td.HasAllowAsChildInAttributes) 
+                if (typeof(T) == typeof(AllowAsChildInAttribute) && td.HasAllowAsChildInAttributes.HasValue && td.HasAllowAsChildInAttributes.Value == false) 
                 {
                     return default;
                 }

--- a/Engine/TypeData.cs
+++ b/Engine/TypeData.cs
@@ -86,7 +86,7 @@ namespace OpenTap
         }
 
         /// <summary>
-        /// Gets.the HelpLinkAttribute for this type. Null if the type does not have a HelpLinkAttribute
+        /// Gets the HelpLinkAttribute for this type. Null if the type does not have a HelpLinkAttribute
         /// </summary>
         public HelpLinkAttribute HelpLink
         {
@@ -111,6 +111,13 @@ namespace OpenTap
             }
             internal set => helpLink = value;
         }
+
+        /// <summary>
+        /// Indicates whether or not this type has one or more [AllowAsChildIn] attributes.
+        /// If this is not the case, we can avoid loading the type to read its attributes when checking
+        /// if a test step can be inserted as the child of another test step.
+        /// </summary>
+        internal bool HasAllowAsChildInAttributes { get; set; }
 
         /// <summary> Gets a list of base types (including interfaces) </summary>
         internal ICollection<TypeData> BaseTypes => baseTypes;

--- a/Engine/TypeData.cs
+++ b/Engine/TypeData.cs
@@ -117,7 +117,7 @@ namespace OpenTap
         /// If this is not the case, we can avoid loading the type to read its attributes when checking
         /// if a test step can be inserted as the child of another test step.
         /// </summary>
-        internal bool HasAllowAsChildInAttributes { get; set; }
+        internal bool? HasAllowAsChildInAttributes { get; set; }
 
         /// <summary> Gets a list of base types (including interfaces) </summary>
         internal ICollection<TypeData> BaseTypes => baseTypes;


### PR DESCRIPTION
By tracking whether or not a step has the AllowAsChildInAttribute defined, we can selectively load test steps only if it is actually required to determine if a step can be inserted as a child step of another step.

If a step actually defines the attribute it is non-trivial to determine without actually loading the type, so this optimization only applies when a step does not define the attribute, which is the vast majority of cases.

Closes #2383 