### PR TITLE
fix: break conditions not triggered for steps using defer

### DIFF
--- a/Engine.UnitTests/BreakConditionTest.cs
+++ b/Engine.UnitTests/BreakConditionTest.cs
@@ -337,6 +337,51 @@ namespace OpenTap.Engine.UnitTests
             }
         }
 
+        public class TestStepThatFails : TestStep
+        {
+            public bool ResultsDefer { get; set; } = true;
+
+            public override void Run()
+            {
+                UpgradeVerdict(Verdict.Fail);
+                if (ResultsDefer) 
+                {
+                    Results.Defer(Sleep);
+                }
+            }
+
+            static void Sleep()
+            {
+                TapThread.Sleep(1000);
+            }
+        }
+
+        public class TestStepThatSucceeds : TestStep
+        {
+            internal bool DidExecute = false;
+            public override void Run()
+            {
+                UpgradeVerdict(Verdict.Pass);
+                DidExecute = true;
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestBreakConditionsOnDefer(bool doDefer)
+        {
+            var plan = new TestPlan();
+            var failStep = new TestStepThatFails() { ResultsDefer = doDefer };
+            var successStep = new TestStepThatSucceeds();
+            BreakConditionProperty.SetBreakCondition(failStep, BreakCondition.BreakOnFail | BreakCondition.BreakOnError);
+            plan.ChildTestSteps.Add(failStep);
+            plan.ChildTestSteps.Add(successStep);
+
+            var run = plan.Execute();
+            Assert.That(run.Verdict, Is.EqualTo(Verdict.Fail));
+            Assert.That(successStep.DidExecute, Is.False);
+        }
+
         [Test]
         public void TestStepThrowsException()
         {

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -208,7 +208,11 @@ namespace OpenTap
                     var run = step.DoRun(planRun, planRun);
                     if (!run.Skipped)
                         runs.Add(run);
-                    if (run.BreakConditionsSatisfied())
+                    // if `step` finished with deferred actions, its verdict will not be propagated to
+                    // the `run` object until the defer queue has been flushed. To work around this
+                    // problem, we check break conditions against the step verdict instead of the run verdict.
+                    // It is technically possible that a deferred action resets the verdict, but this is not supported by break conditions.
+                    if (run.BreakConditionsSatisfied(step.Verdict))
                     {
                         var breakingRun = getBreakingRun(run);
                         addBreakResult(breakingRun);

--- a/Engine/TestStepRun.cs
+++ b/Engine/TestStepRun.cs
@@ -335,10 +335,8 @@ namespace OpenTap
         
         #endregion
 
-        /// <summary> Returns true if the break conditions are satisfied for the test step run.</summary>
-        public bool BreakConditionsSatisfied()
+        internal bool BreakConditionsSatisfied(Verdict verdict)
         {
-            var verdict = Verdict;
             if (OutOfRetries 
                 || (verdict == Verdict.Fail && BreakCondition.HasFlag(BreakCondition.BreakOnFail)) 
                 || (verdict == Verdict.Error && BreakCondition.HasFlag(BreakCondition.BreakOnError))
@@ -348,6 +346,12 @@ namespace OpenTap
                 return true;
             }
             return false;
+        }
+
+        /// <summary> Returns true if the break conditions are satisfied for the test step run.</summary>
+        public bool BreakConditionsSatisfied()
+        {
+            return BreakConditionsSatisfied(Verdict);
         }
         
         internal bool OutOfRetries { get; set; }


### PR DESCRIPTION
this happened because Step verdicts are propagated to StepRun objects in the Defer queue if there are pending defers, meaning it is not yet set when we check for break conditions.

We can fix this by checking against the verdict on the Step object instead.

This also highlights another problem though, namely that we don't check break conditions if the verdict is upgraded during Defer(), but that seems like much more of an edge case than break conditions being completely ignored when using Defer.

Closes #2387