### PR TITLE
fix embedded typedata cache race

### DIFF
--- a/Engine/EmbedPropertiesAttribute.cs
+++ b/Engine/EmbedPropertiesAttribute.cs
@@ -339,18 +339,11 @@ namespace OpenTap
             bool reload = false;
             if (nowKey != 0)
             {
-                if (keyTable.TryGetValue(obj, out var currentKey))
+                var currentKey = keyTable.GetOrCreateValue(obj);
+                if (currentKey.Key != nowKey)
                 {
-                    if (currentKey.Key != nowKey)
-                    {
-                        reload = true;
-                        currentKey.Key = nowKey;
-                    }
-                }
-                else
-                {
-                    keyTable.Add(obj, new KeyBox(){Key = nowKey});
                     reload = true;
+                    currentKey.Key = nowKey;
                 }
             }
             if (reload)


### PR DESCRIPTION
By using GetOrCreateValue(), it should not be possible to obj to be added between the TryGetValue() call and the .Add call