### PR TITLE
string parsing -> unboxing

### DIFF
--- a/Engine/PluginSearcher.cs
+++ b/Engine/PluginSearcher.cs
@@ -845,7 +845,8 @@ namespace OpenTap
                     case "System.ComponentModel.BrowsableAttribute":
                     {
                         var valueString = attr.DecodeValue(new CustomAttributeTypeProvider());
-                        plugin.IsBrowsable = bool.Parse(valueString.FixedArguments.First().Value.ToString());
+                        if (valueString.FixedArguments.Length == 1 && valueString.FixedArguments[0].Value is bool browsable) 
+                            plugin.IsBrowsable = browsable;
                     }
                         break;
                     default:


### PR DESCRIPTION
the current solution is fragile to the addition of new Browsable constructors, and inefficient since it converts a boxed double to a string and then attempts to parse it back

the new solution checks if the indicated constructor is the variant we expect and safely unboxes the boolean instead