### PR TITLE
Pages.yml fix plus CI cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,56 +144,6 @@ jobs:
           retention-days: 5
           path: API
 
-  Build-Pages:
-    runs-on:
-      group: OpenTAP-SpokeVPC
-      labels:  [Linux, X64]
-    container: ghcr.io/opentap/oci-images/build-dotnet:latest
-    needs:
-      - Build-ApiDoc
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Prepare
-        run: rm 'doc/User Guide/Readme.md' 'doc/Developer Guide/Readme.md'
-      - name: Download API Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: doc-api-html
-          path: API
-      - name: Setup Node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: "doc/package-lock.json"
-      - name: Install dependencies
-        run: npm ci
-        working-directory: doc
-      # This is needed because the router wants to serve index.html as the default page
-      - name: Rename Index
-        run: mv Readme.md index.md
-        working-directory: doc
-      - name: Build with VitePress
-        run: npm run docs:build
-        working-directory: doc
-      - name: Copy API
-        run: cp -r API public/api
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
-        if: startsWith(github.ref, 'refs/tags/v')
-        with:
-          publish_dir: public
-          deploy_key: ${{ secrets.PAGES_DEPLOY_TOKEN }}
-          publish_branch: main
-          external_repository: opentap/opentap.github.io
-      - name: Upload artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: pages
-          retention-days: 5
-          path: public
-
   Build-Linux:
     runs-on:
       group: OpenTAP-SpokeVPC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
        group: OpenTAP-SpokeVPC
        labels:  [Linux, X64]
     outputs:
-      gitlab_registry_token_is_set: ${{ steps.check_GITLAB_REGISTRY_TOKEN.outputs.is_set }}
       ks8500_repo_token_is_set: ${{ steps.check_KS8500_REPO_TOKEN.outputs.is_set }}
       sign_is_set: ${{ steps.check_sign.outputs.is_set }}
     steps:
@@ -49,16 +48,6 @@ jobs:
         name: Check whether KS8500_REPO_TOKEN is set
         run: |
           if [ -z "${{ secrets.KS8500_REPO_TOKEN }}" ]; then
-            echo "Not set"
-            echo "is_set=false" >> $GITHUB_OUTPUT
-          else
-            echo "Set"
-            echo "is_set=true" >> $GITHUB_OUTPUT
-          fi
-      - id: check_GITLAB_REGISTRY_TOKEN
-        name: Check whether GITLAB_REGISTRY_TOKEN is set
-        run: |
-          if [ -z "${{ secrets.GITLAB_REGISTRY_TOKEN }}" ]; then
             echo "Not set"
             echo "is_set=false" >> $GITHUB_OUTPUT
           else
@@ -110,8 +99,6 @@ jobs:
           path: sdk/Examples/OpenTAP Developer Guide.pdf
 
   Build-ApiDoc:
-    needs: CheckSecrets
-    if: needs.CheckSecrets.outputs.gitlab_registry_token_is_set == 'true'
     runs-on:
       group: OpenTAP-SpokeVPC
       labels:  [Linux, X64]

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,50 +3,15 @@ name: Pages
 on: workflow_dispatch
 
 jobs:
-  CheckSecrets:
-    runs-on: ubuntu-latest
-    environment: sign
-    outputs:
-      gitlab_registry_token_is_set: ${{ steps.check_GITLAB_REGISTRY_TOKEN.outputs.is_set }}
-      sign_is_set: ${{ steps.check_sign.outputs.is_set }}
-    steps:
-      - id: check_GITLAB_REGISTRY_TOKEN
-        name: Check whether GITLAB_REGISTRY_TOKEN is set
-        run: |
-          if [ -z "${{ secrets.GITLAB_REGISTRY_TOKEN }}" ]; then
-            echo "Not set"
-            echo "is_set=false" >> $GITHUB_OUTPUT
-          else
-            echo "Set"
-            echo "is_set=true" >> $GITHUB_OUTPUT
-          fi
-      - id: check_sign
-        name: Check whether sign secrets are set
-        run: |
-          if [ -z "${{ secrets.SIGN_SERVER_CERT }}" -o \
-               -z "${{ secrets.TAP_SIGN_ADDRESS }}" -o \
-               -z "${{ secrets.TAP_SIGN_AUTH }}"    -o \
-               -z "${{ secrets.S3_KEY_ID }}"        -o \
-               -z "${{ secrets.S3_SECRET }}" ]; then
-            echo "Not set"
-            echo "is_set=false" >> $GITHUB_OUTPUT
-          else
-            echo "Set"
-            echo "is_set=true" >> $GITHUB_OUTPUT
-          fi
-
   Build-ApiDoc:
-    needs: CheckSecrets
-    if: needs.CheckSecrets.outputs.gitlab_registry_token_is_set == 'true'
-    runs-on: ubuntu-latest
+    runs-on:
+      group: OpenTAP-SpokeVPC
+      labels:  [Linux, X64]
     container:
-      image: registry.gitlab.com/opentap/buildrunners/doxygen:alpine
-      credentials:
-        username: github
-        password: ${{ secrets.GITLAB_REGISTRY_TOKEN}}
+      image: ghcr.io/opentap/oci-images/build-doxygen:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: |
           mkdir Help API
           ver=$(grep ^version .gitversion | sed 's/version[ ]*=[ ]*//' | cut -d. -f 1-2)
@@ -55,17 +20,9 @@ jobs:
           cd "doc/API Documentation"
           doxygen Doxyfile
           cd apiref/html
-          chmcmd index.hhp
-          mv OpenTapApiReference.chm $rootdir/Help/
           cp -r . $rootdir/API/
-      - name: Upload binaries (CHM)
-        uses: actions/upload-artifact@v4
-        with:
-          name: doc-api-chm
-          retention-days: 5
-          path: Help/OpenTapApiReference.chm
       - name: Upload binaries (HTML)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: doc-api-html
           retention-days: 5
@@ -77,18 +34,18 @@ jobs:
       - Build-ApiDoc
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Prepare
         run: rm 'doc/User Guide/Readme.md' 'doc/Developer Guide/Readme.md'
       - name: Download API Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: doc-api-html
           path: API
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: "doc/package-lock.json"
       - name: Install dependencies
@@ -104,14 +61,14 @@ jobs:
       - name: Copy API
         run: cp -r API public/api
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           publish_dir: public
           deploy_key: ${{ secrets.PAGES_DEPLOY_TOKEN }}
           publish_branch: main
           external_repository: opentap/opentap.github.io
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pages
           retention-days: 5


### PR DESCRIPTION
Various CI cleanup tasks

* Fix pages.yml not building since Github deprecated node v20
* Remove checks related to our old gitlab docker images
* Deleted pages build job from the main ci.yml since it doesn't work, and should be triggered manually anyway