### PR TITLE
2387 fix defer v2

### DIFF
--- a/Engine.UnitTests/BreakConditionTest.cs
+++ b/Engine.UnitTests/BreakConditionTest.cs
@@ -382,6 +382,24 @@ namespace OpenTap.Engine.UnitTests
             Assert.That(successStep.DidExecute, Is.False);
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestBreakConditionsOnDeferInSequence(bool doDefer)
+        {
+            var plan = new TestPlan();
+            var seq = new SequenceStep();
+            var failStep = new TestStepThatFails() { ResultsDefer = doDefer };
+            var successStep = new TestStepThatSucceeds();
+            BreakConditionProperty.SetBreakCondition(failStep, BreakCondition.BreakOnFail | BreakCondition.BreakOnError);
+            plan.ChildTestSteps.Add(seq);
+            seq.ChildTestSteps.Add(failStep);
+            seq.ChildTestSteps.Add(successStep);
+
+            var run = plan.Execute();
+            Assert.That(run.Verdict, Is.EqualTo(Verdict.Fail));
+            Assert.That(successStep.DidExecute, Is.False);
+        }
+
         [Test]
         public void TestStepThrowsException()
         {

--- a/Engine/TestPlanExecution.cs
+++ b/Engine/TestPlanExecution.cs
@@ -216,7 +216,7 @@ namespace OpenTap
                     {
                         var breakingRun = getBreakingRun(run);
                         addBreakResult(breakingRun);
-                        run.LogBreakCondition();
+                        run.LogBreakCondition(step.Verdict);
                         break;
                     }
 

--- a/Engine/TestStep.cs
+++ b/Engine/TestStep.cs
@@ -766,9 +766,9 @@ namespace OpenTap
                         }
                         // if skip to next step, don't add it to the wait queue.
                     }
-                    if (run.BreakConditionsSatisfied())
+                    if (run.BreakConditionsSatisfied(stepI.Verdict))
                     {
-                        run.LogBreakCondition();
+                        run.LogBreakCondition(stepI.Verdict);
                         if (throwOnBreak)
                         {
                             if (run.Exception != null)
@@ -864,18 +864,23 @@ namespace OpenTap
                 step.UpgradeVerdict(run.Verdict);
             }
 
-            if (run.BreakConditionsSatisfied())
+            if (run.BreakConditionsSatisfied(step.Verdict))
             {
-                run.LogBreakCondition();
-                if(run.Verdict == Verdict.Error && throwOnBreak)
+                run.LogBreakCondition(step.Verdict);
+                if (throwOnBreak)
                     run.ThrowDueToBreakConditions();
             }
             return run;
         }
 
+        internal static void LogBreakCondition(this TestStepRun run, Verdict verdict)
+        {
+            Log.CreateSource("TestStep").Debug( $"Break issued from '{run.TestStepName}' due to verdict {verdict}. See Break Conditions settings.");
+        }
+
         internal static void LogBreakCondition(this TestStepRun run)
         {
-            Log.CreateSource("TestStep").Debug( $"Break issued from '{run.TestStepName}' due to verdict {run.Verdict}. See Break Conditions settings.");
+            LogBreakCondition(run, run.Verdict);
         }
 
         internal static string GetStepPath(this ITestStep Step)


### PR DESCRIPTION
this fixes an issue with breaking from e.g. Sequence step, which uses
RunChildSteps() for executing child steps observed by @brandon-tan-keysight 

Closes https://github.com/opentap/opentap/issues/2430