### PR TITLE
Limitation of SecureString

### DIFF
--- a/Engine.UnitTests/SecureStringSerializerTest.cs
+++ b/Engine.UnitTests/SecureStringSerializerTest.cs
@@ -23,5 +23,18 @@ namespace OpenTap.Engine.UnitTests
             var inst2 = (SomeInstrument)new TapSerializer().DeserializeFromString(xml, TypeData.GetTypeData(inst));
             Assert.AreEqual(inst.Password.ToString(), inst2.Password.ToString());
         }
+
+        [TestCase("01234567890123456789")]
+        [TestCase("ThisPasswordIsDefinitelyLongerThanOneAesBlock")]
+        public void SerializationTestLongPassword(string password)
+        {
+            SomeInstrument inst = new SomeInstrument();
+            foreach (char c in password)
+                inst.Password.AppendChar(c);
+
+            string xml = new TapSerializer().SerializeToString(inst);
+            var inst2 = (SomeInstrument)new TapSerializer().DeserializeFromString(xml, TypeData.GetTypeData(inst));
+            Assert.AreEqual(password, inst2.Password.ConvertToUnsecureString());
+        }
     }
 }

--- a/Engine/SerializerPlugins/SecureStringSerializer.cs
+++ b/Engine/SerializerPlugins/SecureStringSerializer.cs
@@ -63,9 +63,11 @@ namespace OpenTap.Plugins
                         using (ICryptoTransform decryptor = aesAlgo.CreateDecryptor(keyBytes, iv))
                         {
                             using (CryptoStream reader = new CryptoStream(inputStream, decryptor, CryptoStreamMode.Read))
+                            using (MemoryStream decryptedStream = new MemoryStream())
                             {
-                                output = new byte[inputAsBytes.Length];
-                                decryptedBytesCount = reader.Read(output, 0, output.Length);
+                                reader.CopyTo(decryptedStream);
+                                output = decryptedStream.ToArray();
+                                decryptedBytesCount = output.Length;
                                 result = Encoding.UTF8.GetString(output, 0, decryptedBytesCount);
                             }
                         }


### PR DESCRIPTION
https://forum.opentap.io/t/limitation-of-securestring/2691

I’ve noticed issues with SecureString when the string or password exceeds 16 characters. It works fine as long as the application remains open, but upon restarting, I only retrieve the first 16 characters instead of the full string.

Example:
Set Passwort: “12345678901234567890”
Passwort after restart: “1234567890123456”