### PR TITLE
fix: tap package verify now passes in bin/Debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1059,6 +1059,11 @@ jobs:
         working-directory: ./Packages/SDK/Examples
       - run: dotnet build -c Release
         working-directory: ./Packages/SDK/Examples
+      - name: verify
+        working-directory: ./Packages/SDK/Examples
+        run: |
+          ./bin/Debug/tap package verify OpenTAP
+          ./bin/Release/tap package verify OpenTAP
 
 
   Build-SDK-Linux:
@@ -1090,6 +1095,11 @@ jobs:
         working-directory: ./Packages/SDK/Examples
       - run: dotnet build -c Release
         working-directory: ./Packages/SDK/Examples
+      - name: verify
+        working-directory: ./Packages/SDK/Examples
+        run: |
+          ./bin/Debug/tap package verify OpenTAP
+          ./bin/Release/tap package verify OpenTAP
 
   Build-SDK-Windows:
     runs-on: windows-2022
@@ -1121,3 +1131,8 @@ jobs:
         working-directory: ./Packages/SDK/Examples
       - run: dotnet build -c Release
         working-directory: ./Packages/SDK/Examples
+      - name: verify
+        working-directory: ./Packages/SDK/Examples
+        run: |
+          ./bin/Debug/tap package verify OpenTAP
+          ./bin/Release/tap package verify OpenTAP

--- a/nuget/build/OpenTap.targets
+++ b/nuget/build/OpenTap.targets
@@ -60,6 +60,13 @@
           DestinationFiles="@(PackagePayloadFiles -> '$(OutDir)%(RecursiveDir)%(Filename)%(Extension)')"/>
   </Target>
 
+    <!-- This is a workaround for a cosmetic issue caused by dotnet overwriting OpenTap.dll with the shared lib/netstandard2.0/OpenTap.dll variant during build, causing 'tap package verify' to fail.
+        NOTE: This does not need to run on Windows because the opentap library dll matches the binary from the package. -->
+    <Target Condition="'$(IsWindows)' != 'true'" Name="CopyOpenTapDll" AfterTargets="_CopyFilesMarkedCopyLocal" >
+    <Copy SourceFiles="$(OpenTapRuntimeDir)\OpenTap.dll"
+          DestinationFiles="$(OutDir)OpenTap.dll"/>
+  </Target>
+
   <Target Name="CleanOpenTapPayloadFiles"
           Condition="'$(CleanOpenTapPayloadFiles)' != 'false' And
                      '$(OutDir)' != '' And


### PR DESCRIPTION
This happens because dotnet automatically copies referenced assemblies to the output folder, thereby overwriting the files copied by the CopyOpenTapPayloadFiles target

Closes #208
Closes #487