### PR TITLE
custom arg splitter

### DIFF
--- a/BasicSteps/ProcessStep.cs
+++ b/BasicSteps/ProcessStep.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 
@@ -55,6 +56,124 @@ namespace OpenTap.Plugins.BasicSteps
         [Display("Command Line Arguments", Order: -2.4, Description: "The arguments passed to the program.")]
         [DefaultValue("")]
         public string Arguments { get; set; } = "";
+
+        /* split an argument string into words based on posix shell splitting rules */
+        static string[] ArgSplit(ReadOnlySpan<char> arguments)
+        {
+            char[] args = arguments.ToArray();
+
+            static char escape_char(char ch)
+            {
+                return ch switch
+                {
+                    'a' => '\a',/* alert/bell */
+                    'b' => '\b',/* backspace */
+                    'e' => '\x1b',/* escape */
+                    'f' => '\f',/* form feed */
+                    'n' => '\n',/* newline */
+                    'r' => '\r',/* carriage return */
+                    't' => '\t',/* tab */
+                    'v' => '\v',/* vertical tab */
+                    /* for anything else, just output the character literally.
+                     * It is more correct to throw an exception, but that might break existing test plans. */
+                    _ => ch, 
+                };
+            }
+
+            List<string> result = [];
+            var word = new StringBuilder();
+            /* current quote, or 0 */
+            char quote = (char)0;
+            /* flag set when escape is active */
+            bool inhibit = false;
+            /* flag to signal quote escape behavior.
+             * Specifically, backslash has no effect inside single quotes, unless the initial single quote is preceeded by a dollar sign. */
+            bool inhibit_inhibit = false;
+            /* flag to handle empty quote at end of args */
+            bool word_started = false;
+
+            int cursor = 0;
+
+            void skip_whitespace()
+            {
+                for (; cursor < args.Length && char.IsWhiteSpace(args[cursor]); cursor++);
+            }
+
+            skip_whitespace();
+            while (cursor < args.Length)
+            {
+                word_started = true;
+                char ch = args[cursor];
+                char peek = cursor + 1 < args.Length ? args[cursor+1] : (char)0;
+                if (inhibit)
+                {
+                    inhibit = false;
+                    char esc = escape_char(ch);
+                    word.Append(esc);
+                }
+                /* a string in single quotes preceeded by a dollar sign ($'<string>') behaves like a double-quoted string.
+                 * This is significant because backslashes are not treated as an escape inside normal single-quotes. */
+                else if (quote == 0 && ch == '$' && peek == '\'')
+                {
+                    quote = '\'';
+                    cursor++;
+                }
+                else if (ch == '\\' && !inhibit_inhibit)
+                {
+                    inhibit = true;
+                }
+                else if (quote != 0 && ch != quote)
+                {
+                    word.Append(ch);
+                }
+                else if (quote != 0 && ch == quote)
+                {
+                    quote = (char)0;
+                    inhibit_inhibit = false;
+                }
+                else if (ch == '\'' || ch == '"')
+                {
+                    quote = ch;
+                    inhibit_inhibit = ch == '\'';
+                }
+                else if (char.IsWhiteSpace(ch))
+                {
+                    result.Add(word.ToString());
+                    word_started = false;
+                    word.Clear();
+                    skip_whitespace();
+                    /* don't update cursor twice */
+                    continue;
+                }
+                else
+                {
+                    word.Append(ch);
+                }
+                cursor++;
+            }
+
+            if (quote != 0) throw new Exception("Argument contains unterminated quote.");
+            if (inhibit) throw new Exception("Argument contains trailing escape.");
+
+            if (word_started) result.Add(word.ToString());
+
+            return [.. result];
+        }
+
+        /* join a list of strings into a single escaped argument string which is safe to pass to ProcessStartInfo.Arguments */
+        static string ArgJoin(string[] arguments)
+        {
+            static string quote(string s)
+            {
+                /* escape all double quotes */
+                s = s.Replace("\"", "\\\"");
+                /* if the string contains whitespace or quotes, quote it */
+                if (s.Length == 0 || s.Any(char.IsWhiteSpace) || s.Contains('"')) s = '"' + s + '"';
+                return s;
+            }
+
+            return string.Join(" ", arguments.Select(quote));
+        }
 
         [Display("Working Directory", Order: -2.3, Description: "The directory where the program will be started in.")]
         [DirectoryPath]
@@ -185,12 +304,14 @@ namespace OpenTap.Plugins.BasicSteps
 
             prepend = string.IsNullOrEmpty(LogHeader) ? "" : LogHeader + " ";
 
+            string[] arglist = ArgSplit(Arguments.AsSpan());
+            string arguments = ArgJoin(arglist);
             var process = new Process
             {
                 StartInfo =
                 {
                     FileName = Application,
-                    Arguments = Arguments,
+                    Arguments = arguments,
                     WorkingDirectory = string.IsNullOrEmpty(WorkingDirectory) ? Directory.GetCurrentDirectory() : Path.GetFullPath(WorkingDirectory),
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
@@ -242,7 +363,7 @@ namespace OpenTap.Plugins.BasicSteps
                 using(abortRegistration)
                 {
 
-                    Log.Debug("Starting process {0} with arguments \"{1}\"", Application, Arguments);
+                    Log.Debug("Starting process {0} with arguments \"{1}\"", Application, arguments);
                     // Ensure that all asynchronous processing is completed by calling process.WaitForExit()
                     // Only the overload with no parameters has this guarantee. See remarks at
                     // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=netframework-4.8

--- a/Engine.UnitTests/ProcessStepTest.cs
+++ b/Engine.UnitTests/ProcessStepTest.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace OpenTap.UnitTests
@@ -24,6 +25,21 @@ namespace OpenTap.UnitTests
             }
 
             return (int)ExitCodes.Success;
+        }
+    }
+
+    [Display("print", Groups: new[] { "test", "positionalargs" }, Description: "Prints environment variables.")]
+    public class PrintPositionalArgs : ICliAction
+    {
+        [UnnamedCommandLineArgument(nameof(Positionals))]
+        public string[] Positionals { get; set; } = [];
+        public int Execute(CancellationToken cancellationToken)
+        {
+            for (int i = 0; i < Positionals.Length; i++)
+            {
+                Console.WriteLine($"{i}: <{Positionals[i]}>");
+            }
+            return 0;
         }
     }
     
@@ -76,6 +92,46 @@ namespace OpenTap.UnitTests
 
             var result = plan.Execute();
             Assert.AreEqual(expectedVerdict, result.Verdict);
+        }
+
+        [TestCase(" hello   world ", "hello", "world")]
+        [TestCase("basic-quotes 'quoted string' non-quoted \"another quote\"", "basic-quotes", "quoted string", "non-quoted", "another quote")]
+        [TestCase("'literal \\ backslash'", "literal \\ backslash")]
+        [TestCase("$'quote in \\' dollar string'", "quote in ' dollar string")]
+        [TestCase("\"quote in \\\" normal string\"", "quote in \" normal string")]
+        [TestCase("empty-quotes \"\" '' $''  ", "empty-quotes", "", "", "")]
+        [TestCase("concat-adjacent-quotes \"1\"'2'$'3' ", "concat-adjacent-quotes", "123")]
+        [TestCase("dollar escape \\$'hello'", "dollar", "escape", "$hello")]
+        public void ProcessStepArgumentSplitting(string commandline, params string[] expected)
+        {
+            var plan = new TestPlan();
+            var processStep = new ProcessStep()
+            {
+                Application = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), tapBinary),
+                WorkingDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                Arguments = "test positionalargs print --quiet " + commandline,
+                AddToLog = true,
+            };
+            processStep.EnvironmentVariables.Add(new ProcessStep.EnvironmentVariable { Name = "OPENTAP_COLOR", Value = "never" });
+            plan.Steps.Add(processStep);
+            var run = plan.Execute();
+
+            Regex matchRegex = new("^\\d+: <.*>$", RegexOptions.Compiled);
+            var lines = processStep.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                /* remove opentap noise */
+                .Where(s => matchRegex.IsMatch(s))
+                .ToArray();
+
+            Assert.AreEqual(Verdict.Pass, run.Verdict, processStep.Output);
+            /* verify every argument appears verbatim in the output (including newlines) */
+            for (int i = 0; i < expected.Length; i++)
+            {
+                string exp = expected[i];
+                var actual = $"{i}: <{exp}>";
+                CollectionAssert.Contains(lines, actual);
+            }
+            /* verify there are no trailing arguments */
+            Assert.IsFalse(lines.Any(x => x.StartsWith($"{expected.Length}:")));
         }
 
         [Test]


### PR DESCRIPTION
This implements posix shell semantics. In Windows land, single quotes are not really a thing, but this is not really what users expect.

The best option in my opinion would be to provide an Argument[] array option instead so the user doesn't have to deal with escaping.

In .NET 5+, ProcessStartInfo has ArgumentList option, but since it is not available in netstandard2.0, or even .NET Framework, we must do manual splitting anyway.

Closes #2325