### PR TITLE
update copyright years

### DIFF
--- a/Engine/Translation/ITranslationProvider.cs
+++ b/Engine/Translation/ITranslationProvider.cs
@@ -1,4 +1,4 @@
-//            Copyright Keysight Technologies 2012-2025
+//            Copyright Keysight Technologies 2012-2026
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@ Additional licenses for OpenTAP dependencies are contained within their dependen
 ------------------------------------------------
 
 OpenTAP
-© Keysight Technologies 2012-2025
+© Keysight Technologies 2012-2026
 ------------------------------------------------
 Mozilla Public License
 Version 2.0

--- a/Shared/AssemblyInfo.cs
+++ b/Shared/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-//            Copyright Keysight Technologies 2012-2025
+//            Copyright Keysight Technologies 2012-2026
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
@@ -9,7 +9,7 @@ using System.Reflection;
 // associated with an assembly.
 [assembly: AssemblyCompany("Keysight Technologies")]
 [assembly: AssemblyProduct("OpenTAP")]
-[assembly: AssemblyCopyright("© Keysight Technologies 2012-2025")]
+[assembly: AssemblyCopyright("© Keysight Technologies 2012-2026")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Shared/ExecutorInterop.cs
+++ b/Shared/ExecutorInterop.cs
@@ -1,4 +1,4 @@
-//            Copyright Keysight Technologies 2012-2025
+//            Copyright Keysight Technologies 2012-2026
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.

--- a/doc/API Documentation/doxyfile.md
+++ b/doc/API Documentation/doxyfile.md
@@ -4,5 +4,5 @@ The API documentation contains detailed information about each element in OpenTA
 
 For information on using the OpenTAP SDK, please see the OpenTAP Developer Guide and the SDK examples in the OpenTAP installation folder. 
 
-© Copyright Keysight Technologies 2012-2023
+© Copyright Keysight Technologies 2012-2026
 

--- a/doc/Developer Guide/Introduction/Notices.md
+++ b/doc/Developer Guide/Introduction/Notices.md
@@ -16,7 +16,7 @@ THE MATERIAL CONTAINED IN THIS DOCUMENT IS PROVIDED "AS IS," AND IS SUBJECT TO B
 Technology Licenses
 -------------------
 The hardware and/or software described in this document are furnished under a license and may be used or copied only in accordance with the terms of such license.
-© Keysight Technologies, Inc. 2015, 2016, 2017, 2018, 2019, 2020, 2024
+© Keysight Technologies, Inc. 2015, 2016, 2017, 2018, 2019, 2020, 2024, 2026
 Keysight Technologies, Inc. 
 900 South Taft Avenue Loveland, CO, 80537-6378 USA
 

--- a/sdk/Examples/PluginDevelopment/Advanced Examples/MenuModelExample.cs
+++ b/sdk/Examples/PluginDevelopment/Advanced Examples/MenuModelExample.cs
@@ -1,4 +1,4 @@
-﻿//Copyright 2012-2021 Keysight Technologies
+﻿//Copyright 2012-2026 Keysight Technologies
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.

--- a/sdk/Examples/PluginDevelopment/ResultListeners/ExampleResultListener.cs
+++ b/sdk/Examples/PluginDevelopment/ResultListeners/ExampleResultListener.cs
@@ -1,4 +1,4 @@
-//Copyright 2012-2023 Keysight Technologies
+//Copyright 2012-2026 Keysight Technologies
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.

--- a/sdk/Examples/PluginDevelopment/ResultListeners/ZipArtifactsResultListener.cs
+++ b/sdk/Examples/PluginDevelopment/ResultListeners/ZipArtifactsResultListener.cs
@@ -1,4 +1,4 @@
-﻿//Copyright 2012-2023 Keysight Technologies
+﻿//Copyright 2012-2026 Keysight Technologies
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.

--- a/sdk/Examples/PluginDevelopment/TestSteps/Attributes/DefaultValueExample.cs
+++ b/sdk/Examples/PluginDevelopment/TestSteps/Attributes/DefaultValueExample.cs
@@ -1,4 +1,4 @@
-﻿//Copyright 2012-2021 Keysight Technologies
+﻿//Copyright 2012-2026 Keysight Technologies
 //
 //Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.

--- a/sdk/OpenTap.Sdk.New/TranslateAction.cs
+++ b/sdk/OpenTap.Sdk.New/TranslateAction.cs
@@ -1,4 +1,4 @@
-//            Copyright Keysight Technologies 2012-2025
+//            Copyright Keysight Technologies 2012-2026
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Updating copyright years. Note that the reported garbage character in issue #2580 is an artifact of xCHM. The symbol displays correctly on Windows.

This is not worth fixing since we are moving away from CHM.