### PR TITLE
fix serializing lists of doubles losing precision (#2433)

### DIFF
--- a/Engine.UnitTests/ListSerialization.cs
+++ b/Engine.UnitTests/ListSerialization.cs
@@ -124,6 +124,39 @@ namespace OpenTap.Engine.UnitTests
             Assert.AreEqual(15, step.Dict[""]);
         }
 
+        public class DoubleListStep : TestStep
+        {
+            public List<double> ListOfDouble { get; set; } = new List<double> { double.MinValue, double.MaxValue };
+            public double[] ArrayOfDouble { get; set; } = { double.MinValue, double.MaxValue };
+            public override void Run()
+            {
+            }
+        }
+
+        /// <summary>
+        /// Lists and arrays of doubles must survive a serialization round trip without losing precision,
+        /// also for values that need all 17 significant digits (e.g. double.MinValue/MaxValue). Issue #2433.
+        /// </summary>
+        [Test]
+        public void DoubleListSerializationKeepsPrecision()
+        {
+            var values = new List<double>
+            {
+                double.MinValue, double.MaxValue, double.Epsilon, -double.Epsilon, 1e-308,
+                2.2250738585072014E-308, Math.PI, 0.1, 1.0 / 3, 123456789012345.67, 0.0, 1.0, -1.0
+            };
+
+            var plan = new TestPlan();
+            plan.Steps.Add(new DoubleListStep { ListOfDouble = values, ArrayOfDouble = values.ToArray() });
+            var planXml = plan.SerializeToString();
+
+            var deserialized = (TestPlan)new TapSerializer().DeserializeFromString(planXml);
+            var step = (DoubleListStep)deserialized.ChildTestSteps.First();
+
+            Assert.IsTrue(values.SequenceEqual(step.ListOfDouble), "List<double> changed value.");
+            Assert.IsTrue(values.SequenceEqual(step.ArrayOfDouble), "double[] changed value.");
+        }
+
         public class InstStep : TestStep
         {
             public List<IInstrument> Instrs { get; set; }

--- a/Engine.UnitTests/UnitFormatterTest.cs
+++ b/Engine.UnitTests/UnitFormatterTest.cs
@@ -47,6 +47,9 @@ public class UnitFormatterTest
     [TestCase("2.2250738585072014E-308", 2.2250738585072014E-308)] // smallest normal double.
     [TestCase("2.225073858507201E-308", 2.225073858507201E-308)] // largest subnormal double.
     [TestCase("123456789012345.67", 123456789012345.67)]
+    [TestCase("9007199254740992", 9007199254740992.0)] // 2^53, the largest exactly representable integer.
+    [TestCase("9007199254740993", 9007199254740992.0)] // 2^53+1, a tie that must round down to even.
+    [TestCase("9007199254740995", 9007199254740996.0)] // 2^53+3, a tie that must round up to even.
     [TestCase("0.1", 0.1)]
     [TestCase("0", 0.0)]
     [TestCase("1", 1.0)]

--- a/Engine.UnitTests/UnitFormatterTest.cs
+++ b/Engine.UnitTests/UnitFormatterTest.cs
@@ -35,6 +35,50 @@ public class UnitFormatterTest
         Assert.AreEqual(approxDouble, result, Math.Abs(approxDouble) * 0.00001);
     }
 
+    /// <summary>
+    /// Converting a BigFloat to a double must round to the nearest double, exactly like double.Parse does.
+    /// Issue #2433: it used to truncate, so e.g. double.MaxValue lost its last bit of precision.
+    /// </summary>
+    [TestCase("1.7976931348623157E+308", double.MaxValue)]
+    [TestCase("-1.7976931348623157E+308", double.MinValue)]
+    [TestCase("5E-324", double.Epsilon)]
+    [TestCase("-5E-324", -double.Epsilon)]
+    [TestCase("1E-308", 1e-308)]
+    [TestCase("2.2250738585072014E-308", 2.2250738585072014E-308)] // smallest normal double.
+    [TestCase("2.225073858507201E-308", 2.225073858507201E-308)] // largest subnormal double.
+    [TestCase("123456789012345.67", 123456789012345.67)]
+    [TestCase("0.1", 0.1)]
+    [TestCase("0", 0.0)]
+    [TestCase("1", 1.0)]
+    [TestCase("-1", -1.0)]
+    [TestCase("1E400", double.PositiveInfinity)] // overflow.
+    [TestCase("-1E400", double.NegativeInfinity)]
+    [TestCase("1E-400", 0.0)] // underflow.
+    public void TestBigFloatToDouble(string strValue, double expected)
+    {
+        var bf = new BigFloat(strValue, CultureInfo.InvariantCulture);
+        Assert.AreEqual(expected, bf.ToDouble());
+        Assert.AreEqual(expected, (double)bf);
+        Assert.AreEqual(expected, bf.ConvertTo(typeof(double)));
+    }
+
+    /// <summary> Any double must survive a BigFloat round trip unchanged. Issue #2433. </summary>
+    [Test]
+    public void TestDoubleBigFloatRoundTrip()
+    {
+        var rnd = new Random(2433);
+        var buffer = new byte[8];
+        for (int i = 0; i < 10000; i++)
+        {
+            rnd.NextBytes(buffer);
+            var value = BitConverter.ToDouble(buffer, 0);
+            if (double.IsNaN(value) || double.IsInfinity(value)) continue;
+            var result = BigFloat.Convert(value).ToDouble();
+            if (result != value)
+                Assert.Fail($"{value:R} became {result:R}.");
+        }
+    }
+
     [TestCase("4,5,6", null)]
     [TestCase("1:5", "1,2,3,4,5")]
     [TestCase("1:2:5", "1,3,5")]

--- a/Engine/BigFloat.cs
+++ b/Engine/BigFloat.cs
@@ -633,7 +633,7 @@ namespace OpenTap
 
         public static explicit operator double(BigFloat d)
         {
-            return ((double)d.Numerator) / ((double)d.Denominator);
+            return d.ToDouble();
         }
 
         public static bool operator ==(BigFloat a, BigFloat b)
@@ -866,6 +866,100 @@ namespace OpenTap
             return new BigFloat(Rounded());
         }
 
+        /// <summary> The number of bits needed to represent a non-negative BigInteger. </summary>
+        static int bitLength(BigInteger value)
+        {
+            if (value.IsZero) return 0;
+            var bytes = value.ToByteArray(); // little endian, two's complement.
+            int i = bytes.Length - 1;
+            while (i > 0 && bytes[i] == 0)
+                i--;
+            int bits = i * 8;
+            for (int b = bytes[i]; b != 0; b >>= 1)
+                bits++;
+            return bits;
+        }
+
+        /// <summary>
+        /// Converts the value to the nearest double, rounding half to even, exactly like double.Parse does.
+        /// Note this cannot be done as (double)Numerator / (double)Denominator, since BigInteger to double
+        /// conversions truncate instead of rounding to nearest (losing the last bit of precision for values
+        /// that need all 17 significant digits) and since large numerators/denominators overflow to infinity
+        /// (turning e.g. double.Epsilon into 0).
+        /// </summary>
+        public double ToDouble()
+        {
+            if (Denominator.IsZero)
+            {
+                if (Numerator.IsZero) return double.NaN;
+                return Numerator.Sign > 0 ? double.PositiveInfinity : double.NegativeInfinity;
+            }
+            if (Numerator.IsZero) return 0.0;
+
+            var num = Numerator;
+            var den = Denominator;
+            bool negative = num.Sign < 0;
+            if (negative)
+                num = -num;
+            if (den.Sign < 0)
+            {
+                // Normalize() moves the sign to the numerator, but this is not guaranteed to have been called.
+                negative = !negative;
+                den = -den;
+            }
+
+            // Find q = floor(num / den * 2^shift) such that q has exactly 54 significant bits:
+            // 53 bits for the mantissa of a double plus one extra bit to round by.
+            int shift = 54 - (bitLength(num) - bitLength(den));
+            BigInteger q, rem;
+            while (true)
+            {
+                q = BigInteger.DivRem(shift > 0 ? num << shift : num, shift < 0 ? den << -shift : den, out rem);
+                int qBits = bitLength(q);
+                if (qBits == 54) break;
+                // the first estimate of shift is off by at most one bit, so this loops at most twice.
+                shift += 54 - qBits;
+            }
+
+            // the value is q * 2^-shift, and rem being non-zero means there is a non-zero remainder below that.
+            // Drop the extra bit, or more bits if the result is subnormal - the smallest subnormal double is 2^-1074.
+            int drop = Math.Max(1, shift - 1074);
+            var dropped = q & ((BigInteger.One << drop) - 1);
+            var half = BigInteger.One << (drop - 1);
+            var mantissa = q >> drop;
+            if (dropped > half || (dropped == half && (!rem.IsZero || !mantissa.IsEven)))
+                mantissa += 1; // round to nearest, ties to even.
+
+            int exp = drop - shift; // the value is now mantissa * 2^exp.
+
+            long resultBits;
+            if (mantissa.IsZero)
+                resultBits = 0; // rounded down to zero.
+            else if (exp == -1074)
+            {
+                // Subnormal: the mantissa is the fraction bits directly. If rounding carried the mantissa
+                // into bit 52 (or 53) this conveniently gives the smallest normal value(s) instead.
+                resultBits = (long)mantissa;
+            }
+            else
+            {
+                if (bitLength(mantissa) == 54)
+                {
+                    // rounding up carried into an extra bit.
+                    mantissa >>= 1;
+                    exp++;
+                }
+                long biasedExponent = exp + 1075;
+                if (biasedExponent >= 2047)
+                    return negative ? double.NegativeInfinity : double.PositiveInfinity;
+                resultBits = (biasedExponent << 52) | (long)(mantissa - (BigInteger.One << 52));
+            }
+
+            if (negative)
+                resultBits |= long.MinValue; // the sign bit.
+            return BitConverter.Int64BitsToDouble(resultBits);
+        }
+
         
         public static BigFloat Convert(object y, IFormatProvider prov = null)
         {
@@ -889,9 +983,9 @@ namespace OpenTap
             if (t == typeof(BigFloat))
                 return this;
             if (t == typeof(double))
-                return (((double)Numerator) / ((double)Denominator));
+                return ToDouble();
             if (t == typeof(float))
-                return (float)((double)((double)Numerator) / ((double)Denominator));
+                return (float)ToDouble();
             if (t == typeof(decimal))
                 return ((decimal)Numerator) / ((decimal)Denominator);
             if (t == typeof(int))

--- a/Engine/BigFloat.cs
+++ b/Engine/BigFloat.cs
@@ -870,7 +870,7 @@ namespace OpenTap
         static int bitLength(BigInteger value)
         {
             if (value.IsZero) return 0;
-            var bytes = value.ToByteArray(); // little endian, two's complement.
+            var bytes = value.ToByteArray();
             int i = bytes.Length - 1;
             while (i > 0 && bytes[i] == 0)
                 i--;
@@ -884,13 +884,7 @@ namespace OpenTap
         static readonly BigInteger maxExactInteger = BigInteger.Pow(2, 53);
         static readonly BigInteger minExactInteger = -maxExactInteger;
 
-        /// <summary>
-        /// Converts the value to the nearest double, rounding half to even, exactly like double.Parse does.
-        /// Note this cannot generally be done as (double)Numerator / (double)Denominator, since BigInteger to
-        /// double conversions truncate instead of rounding to nearest (losing the last bit of precision for
-        /// values that need all 17 significant digits) and since large numerators/denominators overflow to
-        /// infinity (turning e.g. double.Epsilon into 0).
-        /// </summary>
+        /// <summary> Converts the value to the nearest double, rounding half to even, exactly like double.Parse does. </summary>
         public double ToDouble()
         {
             if (Denominator.IsZero)
@@ -901,8 +895,6 @@ namespace OpenTap
             if (Numerator >= minExactInteger && Numerator <= maxExactInteger &&
                 Denominator >= minExactInteger && Denominator <= maxExactInteger)
             {
-                // Both are represented exactly by a double and IEEE 754 division is correctly rounded,
-                // so the result is the nearest double. This covers everyday values such as 0.1 -> 1/10.
                 return (double)Numerator / (double)Denominator;
             }
             if (Numerator.IsZero) return 0.0;
@@ -914,43 +906,33 @@ namespace OpenTap
                 num = -num;
             if (den.Sign < 0)
             {
-                // Normalize() moves the sign to the numerator, but this is not guaranteed to have been called.
                 negative = !negative;
                 den = -den;
             }
 
-            // q = floor(num / den * 2^shift). Since a b-bit number is in [2^(b-1), 2^b), num/den is within
-            // a factor of two of 2^(bitLength(num) - bitLength(den)), so q has 54 or 55 significant bits:
-            // at least 53 for the mantissa of a double plus at least one extra bit to round by.
             int shift = 54 - (bitLength(num) - bitLength(den));
             var q = BigInteger.DivRem(shift > 0 ? num << shift : num, shift < 0 ? den << -shift : den, out var rem);
 
-            // the value is q * 2^-shift, and rem being non-zero means there is a non-zero remainder below that.
-            // Keep 53 bits for the mantissa and round by the dropped bits; keep fewer bits if the result is
-            // subnormal - the smallest subnormal double is 2^-1074.
             int drop = Math.Max(bitLength(q) - 53, shift - 1074);
             var dropped = q & ((BigInteger.One << drop) - 1);
             var half = BigInteger.One << (drop - 1);
             var mantissa = q >> drop;
             if (dropped > half || (dropped == half && (!rem.IsZero || !mantissa.IsEven)))
-                mantissa += 1; // round to nearest, ties to even.
+                mantissa += 1;
 
-            int exp = drop - shift; // the value is now mantissa * 2^exp.
+            int exp = drop - shift;
 
             long resultBits;
             if (mantissa.IsZero)
-                resultBits = 0; // rounded down to zero.
+                resultBits = 0;
             else if (exp == -1074)
             {
-                // Subnormal: the mantissa is the fraction bits directly. If rounding carried the mantissa
-                // into bit 52 (or 53) this conveniently gives the smallest normal value(s) instead.
                 resultBits = (long)mantissa;
             }
             else
             {
                 if (bitLength(mantissa) == 54)
                 {
-                    // rounding up carried into an extra bit.
                     mantissa >>= 1;
                     exp++;
                 }
@@ -961,7 +943,7 @@ namespace OpenTap
             }
 
             if (negative)
-                resultBits |= long.MinValue; // the sign bit.
+                resultBits |= long.MinValue;
             return BitConverter.Int64BitsToDouble(resultBits);
         }
 

--- a/Engine/BigFloat.cs
+++ b/Engine/BigFloat.cs
@@ -919,22 +919,16 @@ namespace OpenTap
                 den = -den;
             }
 
-            // Find q = floor(num / den * 2^shift) such that q has exactly 54 significant bits:
-            // 53 bits for the mantissa of a double plus one extra bit to round by.
+            // q = floor(num / den * 2^shift). Since a b-bit number is in [2^(b-1), 2^b), num/den is within
+            // a factor of two of 2^(bitLength(num) - bitLength(den)), so q has 54 or 55 significant bits:
+            // at least 53 for the mantissa of a double plus at least one extra bit to round by.
             int shift = 54 - (bitLength(num) - bitLength(den));
-            BigInteger q, rem;
-            while (true)
-            {
-                q = BigInteger.DivRem(shift > 0 ? num << shift : num, shift < 0 ? den << -shift : den, out rem);
-                int qBits = bitLength(q);
-                if (qBits == 54) break;
-                // the first estimate of shift is off by at most one bit, so this loops at most twice.
-                shift += 54 - qBits;
-            }
+            var q = BigInteger.DivRem(shift > 0 ? num << shift : num, shift < 0 ? den << -shift : den, out var rem);
 
             // the value is q * 2^-shift, and rem being non-zero means there is a non-zero remainder below that.
-            // Drop the extra bit, or more bits if the result is subnormal - the smallest subnormal double is 2^-1074.
-            int drop = Math.Max(1, shift - 1074);
+            // Keep 53 bits for the mantissa and round by the dropped bits; keep fewer bits if the result is
+            // subnormal - the smallest subnormal double is 2^-1074.
+            int drop = Math.Max(bitLength(q) - 53, shift - 1074);
             var dropped = q & ((BigInteger.One << drop) - 1);
             var half = BigInteger.One << (drop - 1);
             var mantissa = q >> drop;

--- a/Engine/BigFloat.cs
+++ b/Engine/BigFloat.cs
@@ -880,12 +880,16 @@ namespace OpenTap
             return bits;
         }
 
+        /// <summary> 2^53. Integers up to this are represented exactly by a double. </summary>
+        static readonly BigInteger maxExactInteger = BigInteger.Pow(2, 53);
+        static readonly BigInteger minExactInteger = -maxExactInteger;
+
         /// <summary>
         /// Converts the value to the nearest double, rounding half to even, exactly like double.Parse does.
-        /// Note this cannot be done as (double)Numerator / (double)Denominator, since BigInteger to double
-        /// conversions truncate instead of rounding to nearest (losing the last bit of precision for values
-        /// that need all 17 significant digits) and since large numerators/denominators overflow to infinity
-        /// (turning e.g. double.Epsilon into 0).
+        /// Note this cannot generally be done as (double)Numerator / (double)Denominator, since BigInteger to
+        /// double conversions truncate instead of rounding to nearest (losing the last bit of precision for
+        /// values that need all 17 significant digits) and since large numerators/denominators overflow to
+        /// infinity (turning e.g. double.Epsilon into 0).
         /// </summary>
         public double ToDouble()
         {
@@ -893,6 +897,13 @@ namespace OpenTap
             {
                 if (Numerator.IsZero) return double.NaN;
                 return Numerator.Sign > 0 ? double.PositiveInfinity : double.NegativeInfinity;
+            }
+            if (Numerator >= minExactInteger && Numerator <= maxExactInteger &&
+                Denominator >= minExactInteger && Denominator <= maxExactInteger)
+            {
+                // Both are represented exactly by a double and IEEE 754 division is correctly rounded,
+                // so the result is the nearest double. This covers everyday values such as 0.1 -> 1/10.
+                return (double)Numerator / (double)Denominator;
             }
             if (Numerator.IsZero) return 0.0;
 


### PR DESCRIPTION
Numeric collections are deserialized through NumberFormatter/BigFloat, and BigFloat converted to double as (double)Numerator / (double)Denominator. BigInteger to double conversions truncate instead of rounding to nearest, so values needing all 17 significant digits changed value, e.g. double.MaxValue became 1.7976931348623155E+308. Large numerators/denominators additionally overflowed to infinity, turning double.Epsilon into 0.

BigFloat.ToDouble now rounds to the nearest double (ties to even), exactly like double.Parse does, and handles subnormals, overflow and underflow.

Close #2433